### PR TITLE
Add flow test illustrating issues with repeated entities in patterns

### DIFF
--- a/src/arithmetic/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression.c
@@ -34,6 +34,8 @@ AlgebraicExpression *_AE_MUL(size_t operand_cap) {
     return ae;
 }
 
+// TODO This function incorrectly returns true when a node is repeatedly referenced,
+// as with (a)-[]->(a)
 int _intermidate_node(const Node *n) {
     /* ->()<- 
      * <-()->
@@ -242,6 +244,8 @@ AlgebraicExpression **_AlgebraicExpression_Intermidate_Expressions(AlgebraicExpr
         }
 
         /* If intermidate node is referenced, create a new algebraic expression. */
+        // TODO This will falsely trigger in the given cases, but that does not seem
+        // to impact the results of these particular queries.
         if(_intermidate_node(dest) && _referred_node(dest, ref_entities)) {
             // Finalize current expression.
             iexp->dest_node = dest;
@@ -254,7 +258,7 @@ AlgebraicExpression **_AlgebraicExpression_Intermidate_Expressions(AlgebraicExpr
             expressions[expIdx++] = iexp;
         }
     }
-    
+
     *exp_count = expIdx;
     TrieMap_Free(ref_entities, TrieMap_NOP_CB);
     return expressions;

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -108,6 +108,8 @@ OpResult CondTraverseConsume(OpBase *opBase, Record *r) {
     char *destNodeAlias = op->algebraic_results->dest_node->alias;
     Record_AddEntry(r, destNodeAlias, SI_PtrVal(destNode));
 
+    // TODO If edge were set here, the failing fixed-length test would be resolved.
+    // The changes I've thought to make to introduce that, however, have caused other issues.
     if(op->algebraic_expression->edge != NULL) {
         // We're guarantee to have at least one edge.
         Node *srcNode = Record_GetNode(*r, op->algebraic_expression->src_node->alias);

--- a/tests/flow/test_traversals.py
+++ b/tests/flow/test_traversals.py
@@ -1,0 +1,108 @@
+import os
+import sys
+import unittest
+from redisgraph import Graph, Node, Edge
+
+# import redis
+from .disposableredis import DisposableRedis
+
+from base import FlowTestsBase
+
+redis_graph = None
+
+nodevals = ['a', 'b', 'c']
+edge_connections = [[0, 1], [1, 2], [1, 0]]
+
+def redis():
+    return DisposableRedis(loadmodule=os.path.dirname(os.path.abspath(__file__)) + '/../../src/redisgraph.so')
+
+class GraphTraversalsFlowTest(FlowTestsBase):
+    @classmethod
+    def setUpClass(cls):
+        print "GraphTraversalsFlowTest"
+        global redis_graph
+        cls.r = redis()
+        cls.r.start()
+        redis_con = cls.r.client()
+        redis_graph = Graph("G", redis_con)
+
+        cls.populate_graph()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.r.stop()
+        # pass
+
+    @classmethod
+    def populate_graph(cls):
+        global redis_graph
+
+        # Create graph with 3 edges and one 2-hop cycle
+        # (Values are the properties on each entity)
+        # (a)-[0]->(b)-[1]->(c)
+        # (b)-[2]->(a)
+        nodes = {}
+         # Create entities
+        for idx, n in enumerate(nodevals):
+            node = Node(label="nodeval", properties={"val": n})
+            redis_graph.add_node(node)
+            nodes[idx] = node
+
+        for idx, e in enumerate(edge_connections):
+            edge = Edge(nodes[e[0]], "connects", nodes[e[1]], {"edgeprop": idx})
+            redis_graph.add_edge(edge)
+
+        redis_graph.commit()
+
+    # Verify that node properties match expectations
+    def test_node_properties(self):
+        query = """MATCH(a) return a ORDER BY a.val"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(nodevals)))
+        for idx, result in enumerate(actual_result.result_set[1:]):
+            assert result[0] == nodevals[idx]
+
+    # Verify that edge properties match expectations
+    def test_edge_properties(self):
+        query = """MATCH()-[b]->() return b ORDER BY b.edgeprop"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(edge_connections)))
+        for idx, result in enumerate(actual_result.result_set[1:]):
+            assert (int(float(result[0])) == idx)
+
+    # Verify that the appropriate nodes are connected
+    def test_single_hop(self):
+        query = """MATCH(a)-[]->(b) return a, b ORDER BY a.val, b.val"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(edge_connections)))
+        assert (actual_result.result_set[1:]) == [['a', 'b'], ['b', 'a'], ['b', 'c']]
+
+    # Verify that the appropriate nodes are connected with all labels specified
+    def test_single_labeled_hop(self):
+        query = """MATCH(a:nodeval)-[:connects]->(b:nodeval) return a, b ORDER BY a.val, b.val"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == (len(edge_connections)))
+        assert (actual_result.result_set[1:]) == [['a', 'b'], ['b', 'a'], ['b', 'c']]
+
+    # Verify that no node is connected to itself with all labels specified
+    def test_single_labeled_hop_loop_detection(self):
+        query = """MATCH(a:nodeval)-[b:connects]->(a:nodeval) return a,b"""
+        actual_result = redis_graph.query(query)
+        assert (len(actual_result.result_set)-1 == 0)
+
+    # Verify that no node is directly connected to itself
+    def test_single_hop_loop_detection(self):
+        query = """MATCH(a)-[]->(a) return a"""
+        actual_result = redis_graph.query(query)
+        print actual_result.result_set
+        assert (len(actual_result.result_set)-1 == 0)
+
+    # Verify that two nodes are connected to themselves through a variable-length traversal
+    def test_single_labeled_hop_loop_detection(self):
+        query = """MATCH(a)-[*]->(a) return a ORDER BY a.val"""
+        actual_result = redis_graph.query(query)
+        print actual_result.result_set
+        assert (actual_result.result_set[1:]) == [['a'], ['b']]
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When an entity is referenced multiple times within a pattern, conditional traversals (normal and variable-length) return invalid results. I have added some simple tests, the final two of which are failing although they would not if this bug did not exist.

@swilly22 Can you look into this? I couldn't find a good solution, and you have a much better grasp of this area than I.