### PR TITLE
Enable AOF

### DIFF
--- a/src/commands/cmd_bulk_insert.c
+++ b/src/commands/cmd_bulk_insert.c
@@ -71,7 +71,7 @@ void _MGraph_BulkInsert(void *args) {
         assert(gc);
     } else {
         // Query did not start with a "BEGIN" token
-        gc = GraphContext_Retrieve(ctx, graphname);
+        gc = GraphContext_Retrieve(ctx, graphname, false);
         if (gc == NULL) {
             RedisModule_ReplyWithError(ctx, "Bulk insert query did not include a BEGIN token and graph was not found.");
             goto cleanup;

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -79,7 +79,7 @@ int MGraph_Explain(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
     // Retrieve the GraphContext and acquire a read lock.
     if(graphname) {
-        gc = GraphContext_Retrieve(ctx, graphname);
+        gc = GraphContext_Retrieve(ctx, graphname, true);
         if(!gc) {
             RedisModule_ReplyWithError(ctx, "key doesn't contains a graph object.");
             goto cleanup;

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -72,7 +72,7 @@ void _MGraph_Query(void *args) {
 
     // Try to access the GraphContext
     CommandCtx_ThreadSafeContextLock(qctx);
-    GraphContext *gc = GraphContext_Retrieve(ctx, qctx->graphName);
+    GraphContext *gc = GraphContext_Retrieve(ctx, qctx->graphName, readonly);
     if(!gc) {
         if(!ast[0]->createNode && !ast[0]->mergeNode) {
             CommandCtx_ThreadSafeContextUnlock(qctx);
@@ -168,6 +168,8 @@ int MGraph_Query(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
      * run on Redis main thread, others can run on different threads. */
     CommandCtx *context;
     int flags = RedisModule_GetContextFlags(ctx);
+    // TODO: uncomment once REDISMODULE_CTX_FLAGS_LOADING is introduced to redis.
+    // if (flags & (REDISMODULE_CTX_FLAGS_MULTI | REDISMODULE_CTX_FLAGS_LUA | REDISMODULE_CTX_FLAGS_LOADING)) {
     if (flags & (REDISMODULE_CTX_FLAGS_MULTI | REDISMODULE_CTX_FLAGS_LUA)) {
       // Run query on Redis main thread.
       context = CommandCtx_New(ctx, NULL, ast, argv[1], argv, argc);

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -29,8 +29,8 @@ typedef struct {
 /* GraphContext API */
 GraphContext* GraphContext_New(RedisModuleCtx *ctx, const char *graphname,
                                size_t node_cap, size_t edge_cap);
-GraphContext* GraphContext_Retrieve(RedisModuleCtx *ctx, const char *graphname);
-
+// Retrives graphcontext object from key.
+GraphContext* GraphContext_Retrieve(RedisModuleCtx *ctx, const char *graphname, bool readonly);
 // Retrives graph context from thread local storage.
 GraphContext* GraphContext_GetFromTLS();
 


### PR DESCRIPTION
Opening a graph key with WRITE flag when a query has the potential to modify the underline graph
As a result the query will be added to AOF.

When loading AOF, Redis replies each query using a fake client, in this case the replied query can't be executed on a dedicated thread, but must run on Redis main thread, to figure out if the command was sent as part of AOF load we need this [PR](https://github.com/antirez/redis/pull/6161) to be merged and hopefully back-ported.