### PR TITLE
Allocate space in fake record to accommodate aliases

### DIFF
--- a/src/execution_plan/ops/op_project.c
+++ b/src/execution_plan/ops/op_project.c
@@ -96,7 +96,7 @@ Record ProjectConsume(OpBase *opBase) {
         // on the second call.
         if(op->singleResponse) return NULL;
         op->singleResponse = true;
-        r = Record_New(0);  // Fake empty record.
+        r = Record_New(op->record_len);  // Fake empty record.
     }
 
     Record projection = Record_New(op->record_len);


### PR DESCRIPTION
This is the only fix I found necessary after testing #518 by @DvirDukhan under Valgrind.

If aliases are provided, the fake record must be large enough to have them written back. This resolves memory errors in expressions like `RETURN 1+2 AS three` or the query
`MATCH (n:actor) RETURN count(n) as actors_count`
Which utilizes the count optimization to replace scans.