### PR TITLE
fixed dummy record length

### DIFF
--- a/src/execution_plan/ops/op_project.c
+++ b/src/execution_plan/ops/op_project.c
@@ -96,7 +96,7 @@ Record ProjectConsume(OpBase *opBase) {
         // on the second call.
         if(op->singleResponse) return NULL;
         op->singleResponse = true;
-        r = Record_New(op->record_len);  // Fake empty record.
+        r = Record_New(AST_AliasCount(op->ast));  // Fake empty record.
     }
 
     Record projection = Record_New(op->record_len);


### PR DESCRIPTION
fixed dummy record length in project op, as the first operator in the execution plan, for considering the anonymous entities.