### PR TITLE
Fix function names for existence and aggregation checks

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -248,9 +248,15 @@ bool AST_ClauseContainsAggregation(const cypher_astnode_t *clause) {
 
 	void *value;
 	tm_len_t len;
-	char *funcName;
+	char *ptr;
+	char funcName[32];
 	TrieMapIterator *it = TrieMap_Iterate(referred_funcs, "", 0);
-	while(TrieMapIterator_Next(it, &funcName, &len, &value)) {
+	while(TrieMapIterator_Next(it, &ptr, &len, &value)) {
+		assert(len < 32);
+		// Copy the triemap key so that we can safely add a terinator character
+		memcpy(funcName, ptr, len);
+		funcName[len] = 0;
+
 		if(Agg_FuncExists(funcName)) {
 			aggregated = true;
 			break;

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -124,18 +124,22 @@ static AST_Validation _ValidateReferredFunctions(TrieMap *referred_functions, ch
 	AST_Validation res = AST_VALID;
 	void *value;
 	tm_len_t len;
-	char *funcName;
+	char *ptr;
+	char funcName[32];
 	TrieMapIterator *it = TrieMap_Iterate(referred_functions, "", 0);
 	*reason = NULL;
 
 	// TODO: return RAX.
-	while(TrieMapIterator_Next(it, &funcName, &len, &value)) {
-		funcName[len] = 0;
+	while(TrieMapIterator_Next(it, &ptr, &len, &value)) {
 		// No functions have a name longer than 32 characters
 		if(len >= 32) {
 			res = AST_INVALID;
 			break;
 		}
+
+		// Copy the triemap key so that we can safely add a terinator character
+		memcpy(funcName, ptr, len);
+		funcName[len] = 0;
 
 		if(AR_FuncExists(funcName)) continue;
 


### PR DESCRIPTION
Improper use of triemap keys was causing the aggregation check to work improperly.

Before this fix:
```
127.0.0.1:6379> GRAPH.EXPLAIN social "MATCH (a) RETURN a.name, tolower(a.name), COUNT(a)"
1) "Results"
2) "    Project"
3) "        All Node Scan | (a)"
```
(Since `tolower` is longer than `COUNT`, on the second iteration the pointer contains the bytes `COUNTer`.) 

After:
```
127.0.0.1:6379> GRAPH.EXPLAIN social "MATCH (a) RETURN a.name, tolower(a.name), COUNT(a)"
1) "Results"
2) "    Aggregate"
3) "        All Node Scan | (a)"
```