### PR TITLE
Sivalue memory safety

### DIFF
--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -139,14 +139,14 @@ int AR_EXP_GetOperandType(AR_ExpNode *exp) {
  * e.g. MINUS(X) where X is a constant number will be reduced to
  * a single node with the value -X
  * PLUS(MINUS(A), B) will be reduced to a single constant: B-A. */
-int AR_EXP_ReduceToScalar(AR_ExpNode **root) {
+bool AR_EXP_ReduceToScalar(AR_ExpNode **root) {
 	if((*root)->type == AR_EXP_OPERAND) {
 		if((*root)->operand.type == AR_EXP_CONSTANT) {
 			// Root is already a constant
-			return 1;
+			return true;
 		}
 		// Root is variadic, no way to reduce.
-		return 0;
+		return false;
 	} else {
 		// root represents an operation.
 		assert((*root)->type == AR_EXP_OP);
@@ -162,17 +162,17 @@ int AR_EXP_ReduceToScalar(AR_ExpNode **root) {
 				}
 			}
 			// Can't reduce root as one of its children is not a constant.
-			if(!reduce_children) return 0;
+			if(!reduce_children) return false;
 
 			// All child nodes are constants, reduce.
 			SIValue v = AR_EXP_Evaluate(*root, NULL);
 			AR_EXP_Free(*root);
 			*root = AR_EXP_NewConstOperandNode(v);
-			return 1;
+			return true;
 		}
 
 		// Root is an aggregation function, can't reduce.
-		return 0;
+		return false;
 	}
 }
 

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -193,6 +193,11 @@ SIValue AR_EXP_Evaluate(AR_ExpNode *root, const Record r) {
 			}
 			/* Evaluate self. */
 			result = root->op.f(sub_trees, root->op.child_count);
+			/* Free any SIValues that were allocated while evaluating this tree. */
+			for(int child_idx = 0; child_idx < root->op.child_count; child_idx++) {
+				SIValue_Free(&sub_trees[child_idx]);
+			}
+
 		}
 	} else {
 		/* Deal with a constant node. */

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -215,8 +215,8 @@ SIValue AR_EXP_Evaluate(AR_ExpNode *root, const Record r) {
 				if(property == PROPERTY_NOTFOUND) {
 					result = SI_NullVal();
 				} else {
-					// The value belongs to a graph property and is shared with the caller.
-					result = SI_ShareValue(*property);
+					// The value belongs to a graph property, and can be accessed safely during the query lifetime.
+					result = SI_ConstValue(*property);
 				}
 			} else {
 				// Alias doesn't necessarily refers to a graph entity,

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -135,6 +135,47 @@ int AR_EXP_GetOperandType(AR_ExpNode *exp) {
 	return -1;
 }
 
+/* Compact tree by evaluating constant expressions
+ * e.g. MINUS(X) where X is a constant number will be reduced to
+ * a single node with the value -X
+ * PLUS(MINUS(A), B) will be reduced to a single constant: B-A. */
+int AR_EXP_ReduceToScalar(AR_ExpNode **root) {
+	if((*root)->type == AR_EXP_OPERAND) {
+		if((*root)->operand.type == AR_EXP_CONSTANT) {
+			// Root is already a constant
+			return 1;
+		}
+		// Root is variadic, no way to reduce.
+		return 0;
+	} else {
+		// root represents an operation.
+		assert((*root)->type == AR_EXP_OP);
+
+		if((*root)->op.type == AR_OP_FUNC) {
+			/* See if we're able to reduce each child of root
+			 * if so we'll be able to reduce root. */
+			bool reduce_children = true;
+			for(int i = 0; i < (*root)->op.child_count; i++) {
+				if(!AR_EXP_ReduceToScalar((*root)->op.children + i)) {
+					reduce_children = false;
+					break;
+				}
+			}
+			// Can't reduce root as one of its children is not a constant.
+			if(!reduce_children) return 0;
+
+			// All child nodes are constants, reduce.
+			SIValue v = AR_EXP_Evaluate(*root, NULL);
+			AR_EXP_Free(*root);
+			*root = AR_EXP_NewConstOperandNode(v);
+			return 1;
+		}
+
+		// Root is an aggregation function, can't reduce.
+		return 0;
+	}
+}
+
 SIValue AR_EXP_Evaluate(AR_ExpNode *root, const Record r) {
 	SIValue result;
 	if(root->type == AR_EXP_OP) {

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -183,7 +183,7 @@ SIValue AR_EXP_Evaluate(AR_ExpNode *root, const Record r) {
 		 * TODO: verify above statement. */
 		if(root->op.type == AR_OP_AGGREGATE) {
 			AggCtx *agg = root->op.agg_func;
-			result = agg->result;
+			result = SI_ShareValue(agg->result);
 		} else {
 			/* Evaluate each child before evaluating current node. */
 			SIValue sub_trees[root->op.child_count];
@@ -196,7 +196,7 @@ SIValue AR_EXP_Evaluate(AR_ExpNode *root, const Record r) {
 	} else {
 		/* Deal with a constant node. */
 		if(root->operand.type == AR_EXP_CONSTANT) {
-			result = root->operand.constant;
+			result = SI_ShareValue(root->operand.constant);
 		} else {
 			// Fetch entity property value.
 			if(root->operand.variadic.entity_prop != NULL) {
@@ -211,7 +211,7 @@ SIValue AR_EXP_Evaluate(AR_ExpNode *root, const Record r) {
 				}
 				SIValue *property = GraphEntity_GetProperty(ge, root->operand.variadic.entity_prop_idx);
 				if(property == PROPERTY_NOTFOUND) result = SI_NullVal();
-				else result = SI_ShallowCopy(*property);
+				else result = SI_ShareValue(*property);
 			} else {
 				// Alias doesn't necessarily refers to a graph entity,
 				// it could also be a constant.

--- a/src/arithmetic/arithmetic_expression.h
+++ b/src/arithmetic/arithmetic_expression.h
@@ -96,6 +96,9 @@ AR_ExpNode *AR_EXP_NewConstOperandNode(SIValue constant);
 /* Return AR_OperandNodeType for operands and -1 for operations. */
 int AR_EXP_GetOperandType(AR_ExpNode *exp);
 
+/* Compact tree by evaluating all contained functions that can be resolved right now. */
+int AR_EXP_ReduceToScalar(AR_ExpNode **root);
+
 /* Evaluate arithmetic expression tree. */
 SIValue AR_EXP_Evaluate(AR_ExpNode *root, const Record r);
 

--- a/src/arithmetic/arithmetic_expression.h
+++ b/src/arithmetic/arithmetic_expression.h
@@ -97,7 +97,7 @@ AR_ExpNode *AR_EXP_NewConstOperandNode(SIValue constant);
 int AR_EXP_GetOperandType(AR_ExpNode *exp);
 
 /* Compact tree by evaluating all contained functions that can be resolved right now. */
-int AR_EXP_ReduceToScalar(AR_ExpNode **root);
+bool AR_EXP_ReduceToScalar(AR_ExpNode **root);
 
 /* Evaluate arithmetic expression tree. */
 SIValue AR_EXP_Evaluate(AR_ExpNode *root, const Record r);

--- a/src/ast/ast_build_ar_exp.c
+++ b/src/ast/ast_build_ar_exp.c
@@ -147,7 +147,6 @@ static AR_ExpNode *_AR_EXP_FromUnaryOpExpression(RecordMap *record_map,
 	if(operator == CYPHER_OP_UNARY_MINUS) {
 		// This expression can be something like -3 or -a.val
 		// TODO In the former case, we can construct a much simpler tree than this.
-		AR_ExpNode *ar_exp = AR_EXP_FromExpression(record_map, arg);
 		AR_ExpNode *op = AR_EXP_NewOpNodeFromAST(OP_MULT, 2);
 		op->op.children[0] = AR_EXP_NewConstOperandNode(SI_LongVal(-1));
 		op->op.children[1] = AR_EXP_FromExpression(record_map, arg);

--- a/src/ast/ast_build_ar_exp.c
+++ b/src/ast/ast_build_ar_exp.c
@@ -149,7 +149,7 @@ static AR_ExpNode *_AR_EXP_FromUnaryOpExpression(RecordMap *record_map,
 	const cypher_operator_t *operator = cypher_ast_unary_operator_get_operator(expr);
 	if(operator == CYPHER_OP_UNARY_MINUS) {
 		// This expression can be something like -3 or -a.val
-		// TODO In the former case, we can construct a much simpler tree than this.
+		// In the former case, we'll reduce the tree to a constant after building it fully.
 		AR_ExpNode *op = AR_EXP_NewOpNodeFromAST(OP_MULT, 2);
 		op->op.children[0] = AR_EXP_NewConstOperandNode(SI_LongVal(-1));
 		op->op.children[1] = _AR_EXP_FromExpression(record_map, arg);

--- a/src/ast/ast_build_ar_exp.c
+++ b/src/ast/ast_build_ar_exp.c
@@ -248,7 +248,7 @@ static AR_ExpNode *_AR_EXP_FromCaseExpression(RecordMap *record_map, const cyphe
 	return op;
 }
 
-AR_ExpNode *AR_EXP_FromExpression(RecordMap *record_map, const cypher_astnode_t *expr) {
+AR_ExpNode *_AR_EXP_FromExpression(RecordMap *record_map, const cypher_astnode_t *expr) {
 	const cypher_astnode_type_t type = cypher_astnode_type(expr);
 
 	/* Function invocations */
@@ -302,4 +302,10 @@ AR_ExpNode *AR_EXP_FromExpression(RecordMap *record_map, const cypher_astnode_t 
 
 	assert(false);
 	return NULL;
+}
+
+AR_ExpNode *AR_EXP_FromExpression(RecordMap *record_map, const cypher_astnode_t *expr) {
+	AR_ExpNode *root = _AR_EXP_FromExpression(record_map, expr);
+	AR_EXP_ReduceToScalar(&root);
+	return root;
 }

--- a/src/execution_plan/ops/op_aggregate.c
+++ b/src/execution_plan/ops/op_aggregate.c
@@ -213,6 +213,8 @@ static Record _handoff(OpAggregate *op) {
 		} else {
 			// Non-aggregated expression.
 			res = group->keys[keyIdx++];
+			// Key values are shared with the Record, as they'll be freed with the group cache.
+			res = SI_ShareValue(res);
 			Record_Add(r, i, res);
 		}
 	}
@@ -228,6 +230,8 @@ static Record _handoff(OpAggregate *op) {
 		} else {
 			// Non-aggregated expression.
 			res = group->keys[keyIdx++];
+			// Key values are shared with the Record, as they'll be freed with the group cache.
+			res = SI_ShareValue(res);
 			Record_AddScalar(r, exp_count + i, res);
 		}
 	}

--- a/src/execution_plan/ops/op_project.c
+++ b/src/execution_plan/ops/op_project.c
@@ -79,6 +79,8 @@ Record ProjectConsume(OpBase *opBase) {
 	int rec_idx = 0;
 	for(unsigned short i = 0; i < op->exp_count; i++) {
 		SIValue v = AR_EXP_Evaluate(op->exps[i], r);
+		// Persisting a value is only necessary here if it belongs to the Record 'r'; can be improved.
+		SIValue_Persist(&v);
 		Record_Add(projection, rec_idx, v);
 		rec_idx++;
 	}
@@ -86,6 +88,8 @@ Record ProjectConsume(OpBase *opBase) {
 	// Project Order expressions.
 	for(unsigned short i = 0; i < op->order_exp_count; i++) {
 		SIValue v = AR_EXP_Evaluate(op->order_exps[i], r);
+		// Persisting a value is only necessary here if it belongs to the Record 'r'; can be improved.
+		SIValue_Persist(&v);
 		Record_Add(projection, rec_idx, v);
 		rec_idx++;
 	}

--- a/src/execution_plan/ops/op_project.c
+++ b/src/execution_plan/ops/op_project.c
@@ -79,8 +79,11 @@ Record ProjectConsume(OpBase *opBase) {
 	int rec_idx = 0;
 	for(unsigned short i = 0; i < op->exp_count; i++) {
 		SIValue v = AR_EXP_Evaluate(op->exps[i], r);
-		// Persisting a value is only necessary here if it belongs to the Record 'r'; can be improved.
-		SIValue_Persist(&v);
+		/* Persisting a value is only necessary here if 'v' refers to a scalar held in Record 'r'.
+		 * The RETURN projection here requires persistence:
+		 * MATCH (a) WITH toUpper(a.name) AS e RETURN e
+		 * TODO This is a rare case; the logic of when to persist can be improved.  */
+		if(!(v.type & SI_GRAPHENTITY)) SIValue_Persist(&v);
 		Record_Add(projection, rec_idx, v);
 		rec_idx++;
 	}
@@ -88,8 +91,8 @@ Record ProjectConsume(OpBase *opBase) {
 	// Project Order expressions.
 	for(unsigned short i = 0; i < op->order_exp_count; i++) {
 		SIValue v = AR_EXP_Evaluate(op->order_exps[i], r);
-		// Persisting a value is only necessary here if it belongs to the Record 'r'; can be improved.
-		SIValue_Persist(&v);
+		// TODO persisting here can be improved as described above.
+		if(!(v.type & SI_GRAPHENTITY)) SIValue_Persist(&v);
 		Record_Add(projection, rec_idx, v);
 		rec_idx++;
 	}

--- a/src/execution_plan/ops/op_project.c
+++ b/src/execution_plan/ops/op_project.c
@@ -80,6 +80,7 @@ Record ProjectConsume(OpBase *opBase) {
 	for(unsigned short i = 0; i < op->exp_count; i++) {
 		SIValue v = AR_EXP_Evaluate(op->exps[i], r);
 		/* Persisting a value is only necessary here if 'v' refers to a scalar held in Record 'r'.
+		 * Graph entities don't need to be persisted here as Record_Add will copy them internally.
 		 * The RETURN projection here requires persistence:
 		 * MATCH (a) WITH toUpper(a.name) AS e RETURN e
 		 * TODO This is a rare case; the logic of when to persist can be improved.  */

--- a/src/execution_plan/record.c
+++ b/src/execution_plan/record.c
@@ -127,7 +127,7 @@ void Record_Add(Record r, int idx, SIValue v) {
 }
 
 void Record_AddScalar(Record r, int idx, SIValue v) {
-	r[idx].value.s = SI_ShareValue(v);
+	r[idx].value.s = v;
 	r[idx].type = REC_TYPE_SCALAR;
 }
 

--- a/src/execution_plan/record.c
+++ b/src/execution_plan/record.c
@@ -12,11 +12,10 @@
 #define RECORD_HEADER(r) (r-1)
 #define RECORD_HEADER_ENTRY(r) *(RECORD_HEADER((r)))
 
-static inline void _Record_ShareEntry(Record *a, const Entry e, uint idx) {
-	(*a)[idx] = e;
-	if(e.type == REC_TYPE_SCALAR && e.value.s.allocation == M_SELF) {
-		(*a)[idx].value.s.allocation = M_VOLATILE;
-	}
+static inline void _Record_ShareEntry(Record a, const Entry e, uint idx) {
+	a[idx] = e;
+	// If the entry is a scalar, make sure both Records don't believe they own the allocation.
+	if(e.type == REC_TYPE_SCALAR) a[idx].value.s = SI_VolatileValue(e.value.s);
 }
 
 Record Record_New(int entries) {
@@ -56,7 +55,7 @@ Record Record_Clone(const Record r) {
 	int recordLength = Record_length(r);
 	Record clone = Record_New(recordLength);
 	for(uint i = 0; i < recordLength; i++) {
-		_Record_ShareEntry(&clone, r[i], i);
+		_Record_ShareEntry(clone, r[i], i);
 	}
 	return clone;
 }
@@ -68,7 +67,7 @@ void Record_Merge(Record *a, const Record b) {
 
 	for(int i = 0; i < bLength; i++) {
 		if(b[i].type != REC_TYPE_UNKNOWN) {
-			_Record_ShareEntry(a, b[i], i);
+			_Record_ShareEntry(*a, b[i], i);
 		}
 	}
 }

--- a/src/execution_plan/record.c
+++ b/src/execution_plan/record.c
@@ -127,7 +127,7 @@ void Record_Add(Record r, int idx, SIValue v) {
 }
 
 void Record_AddScalar(Record r, int idx, SIValue v) {
-	r[idx].value.s = v;
+	r[idx].value.s = SI_ShareValue(v);
 	r[idx].type = REC_TYPE_SCALAR;
 }
 

--- a/src/execution_plan/record.c
+++ b/src/execution_plan/record.c
@@ -15,7 +15,7 @@
 static inline void _Record_ShareEntry(Record a, const Entry e, uint idx) {
 	a[idx] = e;
 	// If the entry is a scalar, make sure both Records don't believe they own the allocation.
-	if(e.type == REC_TYPE_SCALAR) a[idx].value.s = SI_VolatileValue(e.value.s);
+	if(e.type == REC_TYPE_SCALAR) SIValue_MakeVolatile(&a[idx].value.s);
 }
 
 Record Record_New(int entries) {

--- a/src/execution_plan/record.h
+++ b/src/execution_plan/record.h
@@ -36,13 +36,13 @@ Record Record_New(int entries);
 // Extands record to given length.
 void Record_Extend(Record *r, int len);
 
-// Clones record.
+// Clones record, sharing any nested references with the original.
 Record Record_Clone(const Record r);
 
 // Extends record to accommodate 'len' entries.
 void Record_Extend(Record *r, int len);
 
-// Merge record b into a.
+// Merge record b into a, sharing any nested references in b with a.
 void Record_Merge(Record *a, const Record b);
 
 // Returns number of entries record can hold.

--- a/src/graph/entities/graph_entity.c
+++ b/src/graph/entities/graph_entity.c
@@ -53,7 +53,7 @@ SIValue *GraphEntity_AddProperty(GraphEntity *e, Attribute_ID attr_id, SIValue v
 
 	int prop_idx = e->entity->prop_count;
 	e->entity->properties[prop_idx].id = attr_id;
-	e->entity->properties[prop_idx].value = SI_Clone(value);
+	e->entity->properties[prop_idx].value = SI_CloneValue(value);
 	e->entity->prop_count++;
 
 	return &(e->entity->properties[prop_idx].value);
@@ -84,7 +84,7 @@ void GraphEntity_SetProperty(const GraphEntity *e, Attribute_ID attr_id, SIValue
 	SIValue *prop = GraphEntity_GetProperty(e, attr_id);
 	assert(prop != PROPERTY_NOTFOUND);
 	SIValue_Free(prop);
-	*prop = SI_Clone(value);
+	*prop = SI_CloneValue(value);
 }
 
 void FreeEntity(Entity *e) {

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -40,7 +40,7 @@ int compareNumerics(SIValue *a, SIValue *b) {
  * so that it becomes outdated but not broken by updates to the property. */
 SIValue *cloneKey(SIValue *property) {
 	SIValue *clone = rm_malloc(sizeof(SIValue));
-	*clone = SI_Clone(*property);
+	*clone = SI_CloneValue(*property);
 	return clone;
 }
 

--- a/src/value.c
+++ b/src/value.c
@@ -124,13 +124,11 @@ SIValue SI_ConstValue(const SIValue v) {
 	return dup;
 }
 
-/* Make an SIValue that shares the original's allocations but, if the original
- * owns the allocations, has no guarantee regarding the scope.
+/* Update an SIValue marked as owning its internal allocations so that it instead is sharing them,
+ * with no responsibility for freeing or guarantee regarding scope.
  * This is used in cases like performing shallow copies of scalars in Record entries. */
-SIValue SI_VolatileValue(const SIValue v) {
-	SIValue dup = v;
-	if(v.allocation == M_SELF) dup.allocation = M_VOLATILE;
-	return dup;
+void SIValue_MakeVolatile(SIValue *v) {
+	if(v->allocation == M_SELF) v->allocation = M_VOLATILE;
 }
 
 /* Ensure that any allocation held by the given SIValue is guaranteed to not go out

--- a/src/value.c
+++ b/src/value.c
@@ -76,26 +76,82 @@ SIValue SI_TransferStringVal(char *s) {
 	};
 }
 
-SIValue SI_Clone(SIValue v) {
-	if(v.type == T_STRING) {
-		// Allocate a new copy of the input's string value
-		return SI_DuplicateStringVal(v.stringval);
-	}
-	SIValue dup;
-	memcpy(&dup, &v, sizeof(SIValue));
+/* Make an SIValue that reuses the original's allocations, if any.
+ * The returned value is not responsible for freeing any allocations,
+ * and is not guaranteed that these allocations will remain in scope. */
+SIValue SI_ShareValue(const SIValue v) {
+	SIValue dup = v;
+	// If the original value owns an allocation, mark that the duplicate shares it.
+	if(v.allocation == M_SELF) dup.allocation = M_VOLATILE;
 	return dup;
 }
 
-SIValue SI_ShallowCopy(SIValue v) {
-	SIValue dup = v;
-	// If the original value owns an allocation, mark that the duplicate shares it
-	if(v.allocation == M_SELF) dup.allocation = M_CONST;
-	return dup;
+
+/* Make an SIValue that creates its own copies of the original's allocations, if any.
+ * This is not a deep clone: if the inner value holds its own references,
+ * such as the Entity pointer to the properties of a Node or Edge, those are unmodified. */
+SIValue SI_CloneValue(const SIValue v) {
+	if(v.allocation == M_NONE) return v; // Stack value; no allocation necessary.
+
+	if(v.type & SI_STRING) {
+		// Allocate a new copy of the input's string value.
+		return SI_DuplicateStringVal(v.stringval);
+	}
+
+	// Copy the memory region for Node and Edge values. This does not modify the
+	// inner Entity pointer to the value's properties.
+	// TODO None of this logic should be accessible right now
+	SIValue clone;
+	clone.type = v.type;
+	clone.allocation = M_SELF;
+
+	size_t size;
+	if(v.type == T_NODE) {
+		size = sizeof(Node);
+	} else if(v.type == T_EDGE) {
+		size = sizeof(Edge);
+	} else {
+		assert(false && "Encountered heap-allocated SIValue of unhandled type");
+	}
+	clone.ptrval = rm_malloc(size);
+	memcpy(clone.ptrval, v.ptrval, size);
+	return clone;
+}
+
+/* Ensure that any allocation held by the given SIValue is guaranteed to not go out
+ * of scope during the lifetime of this query by copying references to volatile memory.
+ * Heap allocations that are not scoped to the input SIValue, such as strings from the AST
+ * or a GraphEntity property, are not modified. */
+void SIValue_Persist(SIValue *v) {
+	// Do nothing for non-volatile values.
+	if(v->allocation != M_VOLATILE) return;
+
+	// Copy volatile string values.
+	if(v->type == T_STRING) {
+		*v = SI_DuplicateStringVal(v->stringval);
+		return;
+	}
+
+	// Copy the memory region for Node and Edge values. This does not modify the
+	// inner Entity pointer to the value's properties.
+	size_t size;
+	if(v->type == T_NODE) {
+		size = sizeof(Node);
+	} else if(v->type == T_EDGE) {
+		size = sizeof(Edge);
+	} else {
+		assert(false && "Encountered heap-allocated SIValue of unhandled type");
+	}
+	void *clone = rm_malloc(size);
+	clone = memcpy(clone, v->ptrval, size);
+	v->ptrval = clone;
+	v->allocation = M_SELF;
 }
 
 inline int SIValue_IsNull(SIValue v) {
 	return v.type == T_NULL;
 }
+
 inline int SIValue_IsNullPtr(SIValue *v) {
 	return v == NULL || v->type == T_NULL;
 }
@@ -281,38 +337,20 @@ int SIValue_Order(const SIValue a, const SIValue b) {
 	return 0;
 }
 
-void SIValue_Persist(SIValue *v) {
-	if(v->allocation == M_VOLATILE) {
-		size_t size;
-		if(v->type == T_NODE) {
-			size = sizeof(Node);
-		} else if(v->type == T_EDGE) {
-			size = sizeof(Edge);
-		} else {
-			return;
-		}
-		void *clone = rm_malloc(size);
-		clone = memcpy(clone, v->ptrval, size);
-		v->ptrval = clone;
-		v->allocation = M_SELF;
-	}
-}
-
 void SIValue_Free(SIValue *v) {
 	// The free routine only performs work if it owns a heap allocation.
-	if(v->allocation == M_SELF) {
-		switch(v->type) {
-		case T_STRING:
-			rm_free(v->stringval);
-			v->stringval = NULL;
-			return;
-		case T_NODE:
-		case T_EDGE:
-			rm_free(v->ptrval);
-			return;
-		default:
-			return;
-		}
+	if(v->allocation != M_SELF) return;
+
+	switch(v->type) {
+	case T_STRING:
+		rm_free(v->stringval);
+		v->stringval = NULL;
+		return;
+	case T_NODE:
+	case T_EDGE:
+		rm_free(v->ptrval);
+		return;
+	default:
+		return;
 	}
 }
-

--- a/src/value.c
+++ b/src/value.c
@@ -124,6 +124,15 @@ SIValue SI_ConstValue(const SIValue v) {
 	return dup;
 }
 
+/* Make an SIValue that shares the original's allocations but, if the original
+ * owns the allocations, has no guarantee regarding the scope.
+ * This is used in cases like performing shallow copies of scalars in Record entries. */
+SIValue SI_VolatileValue(const SIValue v) {
+	SIValue dup = v;
+	if(v.allocation == M_SELF) dup.allocation = M_VOLATILE;
+	return dup;
+}
+
 /* Ensure that any allocation held by the given SIValue is guaranteed to not go out
  * of scope during the lifetime of this query by copying references to volatile memory.
  * Heap allocations that are not scoped to the input SIValue, such as strings from the AST

--- a/src/value.h
+++ b/src/value.h
@@ -92,8 +92,8 @@ SIValue SI_CloneValue(const SIValue v);
 // SI_ConstValue creates an SIValue that shares the original's allocations, but does not need to persist them.
 SIValue SI_ConstValue(const SIValue v);
 
-// SI_VolatileValue creates an SIValue that shares the original's allocations and can make no assumptions regarding their scope.
-SIValue SI_VolatileValue(const SIValue v);
+// SIValue_MakeVolatile updates an SIValue to mark that its allocations are shared rather than self-owned.
+void SIValue_MakeVolatile(SIValue *v);
 
 // SIValue_Persist updates an SIValue to duplicate any allocations that may go out of scope in the lifetime of this query.
 void SIValue_Persist(SIValue *v);

--- a/src/value.h
+++ b/src/value.h
@@ -92,6 +92,9 @@ SIValue SI_CloneValue(const SIValue v);
 // SI_ConstValue creates an SIValue that shares the original's allocations, but does not need to persist them.
 SIValue SI_ConstValue(const SIValue v);
 
+// SI_VolatileValue creates an SIValue that shares the original's allocations and can make no assumptions regarding their scope.
+SIValue SI_VolatileValue(const SIValue v);
+
 // SIValue_Persist updates an SIValue to duplicate any allocations that may go out of scope in the lifetime of this query.
 void SIValue_Persist(SIValue *v);
 

--- a/src/value.h
+++ b/src/value.h
@@ -84,8 +84,10 @@ SIValue SI_TransferStringVal(char *s);  // Don't duplicate input string, but ass
 /* Functions for copying and guaranteeing memory safety for SIValues. */
 // SI_ShareValue creates an SIValue that shares all of the original's allocations.
 SIValue SI_ShareValue(const SIValue v);
+
 // SI_CloneValue creates an SIValue that duplicates all of the original's allocations.
 SIValue SI_CloneValue(const SIValue v);
+
 // SIValue_Persist updates an SIValue to duplicate any allocations that may go out of scope in the lifetime of this query.
 void SIValue_Persist(SIValue *v);
 

--- a/src/value.h
+++ b/src/value.h
@@ -41,6 +41,7 @@ typedef enum {
 
 #define SI_NUMERIC (T_INT64 | T_DOUBLE)
 #define SI_STRING (T_STRING | T_CONSTSTRING)
+#define SI_GRAPHENTITY (T_NODE | T_EDGE)
 #define SI_TYPE(value) (value).type
 
 /* Retrieve the numeric associated with an SIValue without explicitly
@@ -87,6 +88,9 @@ SIValue SI_ShareValue(const SIValue v);
 
 // SI_CloneValue creates an SIValue that duplicates all of the original's allocations.
 SIValue SI_CloneValue(const SIValue v);
+
+// SI_ConstValue creates an SIValue that shares the original's allocations, but does not need to persist them.
+SIValue SI_ConstValue(const SIValue v);
 
 // SIValue_Persist updates an SIValue to duplicate any allocations that may go out of scope in the lifetime of this query.
 void SIValue_Persist(SIValue *v);

--- a/src/value.h
+++ b/src/value.h
@@ -81,9 +81,13 @@ SIValue SI_DuplicateStringVal(const char *s); // Duplicate and ultimately free t
 SIValue SI_ConstStringVal(char *s); // Neither duplicate nor assume ownership of input string
 SIValue SI_TransferStringVal(char *s);  // Don't duplicate input string, but assume ownership
 
-/* Functions to copy an SIValue. */
-SIValue SI_Clone(SIValue v);    // If input is a string type, duplicate and assume ownership
-SIValue SI_ShallowCopy(SIValue v);  // Don't duplicate any inputs
+/* Functions for copying and guaranteeing memory safety for SIValues. */
+// SI_ShareValue creates an SIValue that shares all of the original's allocations.
+SIValue SI_ShareValue(const SIValue v);
+// SI_CloneValue creates an SIValue that duplicates all of the original's allocations.
+SIValue SI_CloneValue(const SIValue v);
+// SIValue_Persist updates an SIValue to duplicate any allocations that may go out of scope in the lifetime of this query.
+void SIValue_Persist(SIValue *v);
 
 int SIValue_IsNull(SIValue v);
 int SIValue_IsNullPtr(SIValue *v);
@@ -122,10 +126,6 @@ int SIValue_Compare(const SIValue a, const SIValue b);
  * to Cypher's comparability property if applicable, and its orderability property if not.
  * Under Cypher's orderability, where string < boolean < numeric < NULL. */
 int SIValue_Order(const SIValue a, const SIValue b);
-
-/* If an SIValue holds a pointer to a volatile memory region, copy that memory
- * so that it is held by the SIValue. */
-void SIValue_Persist(SIValue *v);
 
 /* Free an SIValue's internal property if that property is a heap allocation owned
  * by this object. */

--- a/tests/unit/test_arithmetic_expression.cpp
+++ b/tests/unit/test_arithmetic_expression.cpp
@@ -132,22 +132,22 @@ TEST_F(ArithmeticTest, ExpressionTest)
     query = "RETURN 'a' + 'b'";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_TRUE(strcmp(result.stringval, "ab") == 0);
+    AR_EXP_Free(arExp);
 
     /* 1 + 2 + 'a' + 2 + 1 */
     query = "RETURN 1 + 2 + 'a' + 2 + 1";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_TRUE(strcmp(result.stringval, "3a21") == 0);
+    AR_EXP_Free(arExp);
 
     /* 2 * 2 + 'a' + 3 * 3 */
     query = "RETURN 2 * 2 + 'a' + 3 * 3";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_TRUE(strcmp(result.stringval, "4a9") == 0);
+    AR_EXP_Free(arExp);
 }
 
 TEST_F(ArithmeticTest, NullArithmetic)
@@ -447,24 +447,24 @@ TEST_F(ArithmeticTest, ReverseTest)
     query = "RETURN REVERSE('muchacho')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "ohcahcum";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* REVERSE("") */
     query = "RETURN REVERSE('')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* REVERSE() */
     query = "RETURN REVERSE(NULL)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_EQ(result.type, T_NULL);
+    AR_EXP_Free(arExp);
 }
 
 TEST_F(ArithmeticTest, LeftTest)
@@ -479,24 +479,24 @@ TEST_F(ArithmeticTest, LeftTest)
     query = "RETURN LEFT('muchacho', 4)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "much";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* LEFT("muchacho", 100) */
     query = "RETURN LEFT('muchacho', 100)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* LEFT(NULL, 100) */
     query = "RETURN LEFT(NULL, 100)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_EQ(result.type, T_NULL);
+    AR_EXP_Free(arExp);
 }
 
 TEST_F(ArithmeticTest, RightTest)
@@ -511,24 +511,24 @@ TEST_F(ArithmeticTest, RightTest)
     query = "RETURN RIGHT('muchacho', 4)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "acho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* RIGHT("muchacho", 100) */
     query = "RETURN RIGHT('muchacho', 100)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* RIGHT(NULL, 100) */
     query = "RETURN RIGHT(NULL, 100)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_EQ(result.type, T_NULL);
+    AR_EXP_Free(arExp);
 }
 
 TEST_F(ArithmeticTest, LTrimTest)
@@ -543,40 +543,40 @@ TEST_F(ArithmeticTest, LTrimTest)
     query = "RETURN lTrim('   muchacho')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* lTrim("muchacho   ") */
     query = "RETURN lTrim('muchacho   ')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho   ";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* lTrim("   much   acho   ") */
     query = "RETURN lTrim('   much   acho   ')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "much   acho   ";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* lTrim("muchacho") */
     query = "RETURN lTrim('muchacho')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* lTrim() */
     query = "RETURN lTrim(NULL)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_EQ(result.type, T_NULL);
+    AR_EXP_Free(arExp);
 }
 
 TEST_F(ArithmeticTest, RTrimTest)
@@ -591,40 +591,40 @@ TEST_F(ArithmeticTest, RTrimTest)
     query = "RETURN rTrim('   muchacho')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "   muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* rTrim("muchacho   ") */
     query = "RETURN rTrim('muchacho   ')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* rTrim("   much   acho   ") */
     query = "RETURN rTrim('   much   acho   ')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "   much   acho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* rTrim("muchacho") */
     query = "RETURN rTrim('muchacho')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* rTrim() */
     query = "RETURN rTrim(NULL)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_EQ(result.type, T_NULL);
+    AR_EXP_Free(arExp);
 }
 
 TEST_F(ArithmeticTest, TrimTest)
@@ -639,40 +639,40 @@ TEST_F(ArithmeticTest, TrimTest)
     query = "RETURN trim('   muchacho')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* trim("muchacho   ") */
     query = "RETURN trim('muchacho   ')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* trim("   much   acho   ") */
     query = "RETURN trim('   much   acho   ')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "much   acho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* trim("muchacho") */
     query = "RETURN trim('muchacho')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* trim() */
     query = "RETURN trim(NULL)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_EQ(result.type, T_NULL);
+    AR_EXP_Free(arExp);
 }
 
 TEST_F(ArithmeticTest, SubstringTest)
@@ -687,24 +687,24 @@ TEST_F(ArithmeticTest, SubstringTest)
     query = "RETURN SUBSTRING('muchacho', 0, 4)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "much";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* SUBSTRING("muchacho", 3, 20) */
     query = "RETURN SUBSTRING('muchacho', 3, 20)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "hacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* SUBSTRING(NULL, 3, 20) */
     query = "RETURN SUBSTRING(NULL, 3, 20)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_EQ(result.type, T_NULL);
+    AR_EXP_Free(arExp);
 }
 
 TEST_F(ArithmeticTest, ToLowerTest)
@@ -719,24 +719,24 @@ TEST_F(ArithmeticTest, ToLowerTest)
     query = "RETURN toLower('MuChAcHo')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* toLower("mUcHaChO") */
     query = "RETURN toLower('mUcHaChO')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* toLower("mUcHaChO") */
     query = "RETURN toLower(NULL)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_EQ(result.type, T_NULL);
+    AR_EXP_Free(arExp);
 }
 
 TEST_F(ArithmeticTest, ToUpperTest)
@@ -751,24 +751,24 @@ TEST_F(ArithmeticTest, ToUpperTest)
     query = "RETURN toUpper('MuChAcHo')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "MUCHACHO";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* toUpper("mUcHaChO") */
     query = "RETURN toUpper('mUcHaChO')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "MUCHACHO";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* toUpper("mUcHaChO") */
     query = "RETURN toUpper(NULL)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_EQ(result.type, T_NULL);
+    AR_EXP_Free(arExp);
 }
 
 TEST_F(ArithmeticTest, ToStringTest)
@@ -783,24 +783,24 @@ TEST_F(ArithmeticTest, ToStringTest)
     query = "RETURN toString('muchacho')";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "muchacho";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* toString("3.14") */
     query = "RETURN toString(3.14)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     expected = "3.140000";
     ASSERT_STREQ(result.stringval, expected);
+    AR_EXP_Free(arExp);
 
     /* toString() */
     query = "RETURN toString(NULL)";
     arExp = _exp_from_query(query);
     result = AR_EXP_Evaluate(arExp, r);
-    AR_EXP_Free(arExp);
     ASSERT_EQ(result.type, T_NULL);
+    AR_EXP_Free(arExp);
 }
 
 TEST_F(ArithmeticTest, ExistsTest)


### PR DESCRIPTION
This PR demonstrates the interface and treatment of memory ownership that I hope to adopt with respect to SIValues. It attempts to minimize redundant copying while making it clear at all points whether an access is potentially unsafe.

There are currently no memory errors in running the test suite and TCK with this approach (with malloc or jemalloc), but I suspect that there are some unplugged leaks on this branch that I'll continue to investigate.

Please comment or add questions as thoroughly as you would like! It's important for us all to agree with the approach we take to resolve this issue.