### PR TITLE
Fix Record ID of edges held in ExpandInto op

### DIFF
--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -769,7 +769,6 @@ static ExecutionPlanSegment *_NewExecutionPlanSegment(RedisModuleCtx *ctx, Graph
 		for(int i = 0; i < Vector_Size(sub_trees); i++) {
 			FT_FilterNode *tree;
 			Vector_Get(sub_trees, i, &tree);
-
 			rax *references = FilterTree_CollectModified(tree);
 
 			if(raxSize(references) > 0) {

--- a/src/execution_plan/ops/op_expand_into.h
+++ b/src/execution_plan/ops/op_expand_into.h
@@ -14,7 +14,6 @@
 
 typedef struct {
 	OpBase op;
-	AST *ast;
 	Graph *graph;
 	AlgebraicExpression *ae;
 	GrB_Matrix F;               // Filter matrix.
@@ -32,7 +31,7 @@ typedef struct {
 	Record r;                   // Current selected record.
 } OpExpandInto;
 
-OpBase *NewExpandIntoOp(AlgebraicExpression *ae, RecordMap *record_map, uint records_cap);
+OpBase *NewExpandIntoOp(Graph *g, RecordMap *record_map, AlgebraicExpression *ae, uint records_cap);
 OpResult ExpandIntoInit(OpBase *opBase);
 Record ExpandIntoConsume(OpBase *opBase);
 OpResult ExpandIntoReset(OpBase *ctx);

--- a/src/execution_plan/optimizations/reduce_traversal.c
+++ b/src/execution_plan/optimizations/reduce_traversal.c
@@ -86,7 +86,8 @@ void reduceTraversal(ExecutionPlan *plan) {
 		 * perform expand into instaed of traverse. */
 		if(op->type == OPType_CONDITIONAL_TRAVERSE) {
 			CondTraverse *traverse = (CondTraverse *)op;
-			OpBase *expand_into = NewExpandIntoOp(traverse->ae, op->record_map, traverse->recordsCap);
+			OpBase *expand_into = NewExpandIntoOp(traverse->graph, op->record_map, traverse->ae,
+												  traverse->recordsCap);
 
 			// Set traverse algebraic_expression to NULL to avoid early free.
 			traverse->ae = NULL;

--- a/src/filter_tree/filter_tree.c
+++ b/src/filter_tree/filter_tree.c
@@ -357,14 +357,14 @@ void _FilterTree_Print(const FT_FilterNode *root, int ident) {
 	case FT_N_EXP:
 		AR_EXP_ToString(root->exp.exp, &exp);
 		printf("%s\n",  exp);
-		free(exp);
+		rm_free(exp);
 		break;
 	case FT_N_PRED:
 		AR_EXP_ToString(root->pred.lhs, &left);
 		AR_EXP_ToString(root->pred.rhs, &right);
 		printf("%s %d %s\n",  left, root->pred.op, right);
-		free(left);
-		free(right);
+		rm_free(left);
+		rm_free(right);
 		break;
 	case FT_N_COND:
 		printf("%d\n", root->cond.op);


### PR DESCRIPTION
Resolves #605 

Most of the changes in this PR just make `NewExpandIntoOp` more similar to `NewCondTraverseOp`.

The only important line is `op_expand_into.c:109`, which corrects a mis-assignment of the Record ID of ExpandInto's contained edge. The new logic is the same logic as seen in `NewCondTraverseOp`.