### PR TITLE
All ops NULL-set variables in their free routines

### DIFF
--- a/src/execution_plan/ops/op_apply.c
+++ b/src/execution_plan/ops/op_apply.c
@@ -93,12 +93,16 @@ OpResult ApplyReset(OpBase *opBase) {
 
 void ApplyFree(OpBase *opBase) {
 	Apply *op = (Apply *)opBase;
-	if(op->lhs_record) Record_Free(op->lhs_record);
+	if(op->lhs_record) {
+		Record_Free(op->lhs_record);
+		op->lhs_record = NULL;
+	}
 	if(op->rhs_records) {
 		uint len = array_len(op->rhs_records);
 		for(uint i = 0; i < len; i ++) {
 			Record_Free(op->rhs_records[i]);
 		}
 		array_free(op->rhs_records);
+		op->rhs_records = NULL;
 	}
 }

--- a/src/execution_plan/ops/op_cond_var_len_traverse.c
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.c
@@ -146,8 +146,24 @@ OpResult CondVarLenTraverseReset(OpBase *ctx) {
 
 void CondVarLenTraverseFree(OpBase *ctx) {
 	CondVarLenTraverse *op = (CondVarLenTraverse *)ctx;
-	array_free(op->edgeRelationTypes);
-	AlgebraicExpression_Free(op->ae);
-	if(op->r) Record_Free(op->r);
-	if(op->allPathsCtx) AllPathsCtx_Free(op->allPathsCtx);
+
+	if(op->edgeRelationTypes) {
+		array_free(op->edgeRelationTypes);
+		op->edgeRelationTypes = NULL;
+	}
+
+	if(op->ae) {
+		AlgebraicExpression_Free(op->ae);
+		op->ae = NULL;
+	}
+
+	if(op->r) {
+		Record_Free(op->r);
+		op->r = NULL;
+	}
+
+	if(op->allPathsCtx) {
+		AllPathsCtx_Free(op->allPathsCtx);
+		op->allPathsCtx = NULL;
+	}
 }

--- a/src/execution_plan/ops/op_create.c
+++ b/src/execution_plan/ops/op_create.c
@@ -344,10 +344,15 @@ void OpCreateFree(OpBase *ctx) {
 		op->edges_to_create = NULL;
 	}
 
-	array_free(op->created_nodes);
-	array_free(op->created_edges);
-	op->created_nodes = NULL;
-	op->created_edges = NULL;
+	if(op->created_nodes) {
+		array_free(op->created_nodes);
+		op->created_nodes = NULL;
+	}
+
+	if(op->created_edges) {
+		array_free(op->created_edges);
+		op->created_edges = NULL;
+	}
 
 	// Free all graph-committed properties associated with nodes
 	uint prop_count = array_len(op->node_properties);

--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -182,15 +182,19 @@ OpResult OpMergeReset(OpBase *ctx) {
 void OpMergeFree(OpBase *ctx) {
 	OpMerge *op = (OpMerge *)ctx;
 
-	uint node_count = array_len(op->nodes_to_merge);
-	for(uint i = 0; i < node_count; i ++) {
-		PropertyMap_Free(op->nodes_to_merge[i].properties);
+	if(op->nodes_to_merge) {
+		uint node_count = array_len(op->nodes_to_merge);
+		for(uint i = 0; i < node_count; i ++) {
+			PropertyMap_Free(op->nodes_to_merge[i].properties);
+		}
+		op->nodes_to_merge = NULL;
 	}
-	op->nodes_to_merge = NULL;
 
-	uint edge_count = array_len(op->edges_to_merge);
-	for(uint i = 0; i < edge_count; i ++) {
-		PropertyMap_Free(op->edges_to_merge[i].properties);
+	if(op->edges_to_merge) {
+		uint edge_count = array_len(op->edges_to_merge);
+		for(uint i = 0; i < edge_count; i ++) {
+			PropertyMap_Free(op->edges_to_merge[i].properties);
+		}
+		op->edges_to_merge = NULL;
 	}
-	op->edges_to_merge = NULL;
 }


### PR DESCRIPTION
Update OpFree routines to work safely with the PropagateFree logic.

This fixes (at minimum) a possible crash in variable-length traversals. The crash occurred in the query:
```
MATCH (a)-[*]->(b)<-[*]-(c) MATCH (b)-[*]->(d) SET a.test = false, b.test = true, c.test = b.name
```