### PR TITLE
Bgsave

### DIFF
--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -11,7 +11,9 @@
 #include "../util/rmalloc.h"
 #include "../redismodule.h"
 
-extern pthread_key_t _tlsGCKey;    // Thread local storage graph context key.
+extern pthread_key_t _tlsGCKey;             // Thread local storage graph context key.
+extern pthread_mutex_t _module_mutex;       // Module-level lock
+extern GraphContext **graphs_in_keyspace;   // Global array tracking all extant GraphContexts
 
 //------------------------------------------------------------------------------
 // GraphContext API
@@ -48,6 +50,7 @@ GraphContext *GraphContext_New(RedisModuleCtx *ctx, const char *graphname,
 	// Set and close GraphContext key in Redis keyspace
 	RedisModule_ModuleTypeSetValue(key, GraphContextRedisModuleType, gc);
 
+	GraphContext_RegisterWithModule(gc);
 cleanup:
 	RedisModule_CloseKey(key);
 	RedisModule_FreeString(ctx, rs_name);
@@ -240,6 +243,30 @@ void GraphContext_DeleteNodeFromIndices(GraphContext *gc, Node *n) {
 }
 
 //------------------------------------------------------------------------------
+// Functions for globally tracking GraphContexts
+//------------------------------------------------------------------------------
+
+// Register a new GraphContext for module-level tracking
+void GraphContext_RegisterWithModule(GraphContext *gc) {
+	assert(pthread_mutex_lock(&_module_mutex) == 0);
+	graphs_in_keyspace = array_append(graphs_in_keyspace, gc);
+	assert(pthread_mutex_unlock(&_module_mutex) == 0);
+}
+
+// Delete a GraphContext reference from the global array
+void GraphContext_RemoveFromRegistry(GraphContext *gc) {
+	assert(pthread_mutex_lock(&_module_mutex) == 0);
+	uint graph_count = array_len(graphs_in_keyspace);
+	for(uint i = 0; i < graph_count; i ++) {
+		if(graphs_in_keyspace[i] == gc) {
+			graphs_in_keyspace = array_del_fast(graphs_in_keyspace, i);
+			break;
+		}
+	}
+	assert(pthread_mutex_unlock(&_module_mutex) == 0);
+}
+
+//------------------------------------------------------------------------------
 // Free routine
 //------------------------------------------------------------------------------
 
@@ -277,6 +304,9 @@ void GraphContext_Free(GraphContext *gc) {
 		}
 		array_free(gc->string_mapping);
 	}
+
+	// Remove GraphContext from global array of graphs
+	GraphContext_RemoveFromRegistry(gc);
 
 	rm_free(gc);
 }

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -12,8 +12,9 @@
 #include "../redismodule.h"
 
 extern pthread_key_t _tlsGCKey;             // Thread local storage graph context key.
-extern pthread_mutex_t _module_mutex;       // Module-level lock
-extern GraphContext **graphs_in_keyspace;   // Global array tracking all extant GraphContexts
+extern pthread_mutex_t _module_mutex;       // Module-level lock (defined in module.c)
+// Global array tracking all extant GraphContexts (defined in module.c)
+extern GraphContext **graphs_in_keyspace;
 
 //------------------------------------------------------------------------------
 // GraphContext API

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -78,6 +78,11 @@ int GraphContext_DeleteIndex(GraphContext *gc, const char *label, const char *fi
 // Remove a single node from all indices that refer to it
 void GraphContext_DeleteNodeFromIndices(GraphContext *gc, Node *n);
 
+// Add GraphContext to global array
+void GraphContext_RegisterWithModule(GraphContext *gc);
+// Remove GraphContext from global array
+void GraphContext_RemoveFromRegistry(GraphContext *gc);
+
 // Free the GraphContext and all associated graph data
 void GraphContext_Free(GraphContext *gc);
 

--- a/src/graph/serializers/graphcontext_type.c
+++ b/src/graph/serializers/graphcontext_type.c
@@ -26,6 +26,7 @@ void *GraphContextType_RdbLoad(RedisModuleIO *rdb, int encver) {
 		// Not forward compatible.
 		printf("Failed loading Graph, RedisGraph version (%d) is not forward compatible.\n",
 			   REDISGRAPH_MODULE_VERSION);
+		return NULL;
 	} else if(encver >= DECODER_SUPPORT_MIN_V && encver <= DECODER_SUPPORT_MAX_V) {
 		gc = RdbLoadGraphContext(rdb);
 	} else if(encver >= PREV_DECODER_SUPPORT_MIN_V && encver <= PREV_DECODER_SUPPORT_MAX_V) {
@@ -33,9 +34,10 @@ void *GraphContextType_RdbLoad(RedisModuleIO *rdb, int encver) {
 	} else {
 		printf("Failed loading Graph, RedisGraph version (%d) is not backward compatible with encoder version %d.\n",
 			   REDISGRAPH_MODULE_VERSION, encver);
+		return NULL;
 	}
 
-	// Add GraphContext to global array of Graphs
+	// Add GraphContext to global array of graphs.
 	GraphContext_RegisterWithModule(gc);
 
 	return gc;

--- a/src/graph/serializers/graphcontext_type.c
+++ b/src/graph/serializers/graphcontext_type.c
@@ -34,6 +34,10 @@ void *GraphContextType_RdbLoad(RedisModuleIO *rdb, int encver) {
 		printf("Failed loading Graph, RedisGraph version (%d) is not backward compatible with encoder version %d.\n",
 			   REDISGRAPH_MODULE_VERSION, encver);
 	}
+
+	// Add GraphContext to global array of Graphs
+	GraphContext_RegisterWithModule(gc);
+
 	return gc;
 }
 

--- a/src/module.c
+++ b/src/module.c
@@ -79,12 +79,13 @@ static void _PrepareModuleGlobals() {
 
 static void RG_ForkPrepare() {
 	/* At this point, a fork call has been issued. (We assume that this is because BGSave was called.)
-	 * Acquire the writer mutex of each graph to ensure that no locks are held, or else
+	 * Acquire the read-write lock of each graph to ensure that no graph is being modified, or else
 	 * the child process will deadlock when attempting to acquire that lock.
 	 * 1. If a writer thread is active, we'll wait until the writer finishes and releases the lock.
 	 * 2. Otherwise, no write in progress. Acquire the lock and release it immediately after forking. */
 
-	// Acquire the module-scoped lock; it will be released after forking.
+	/* Acquire the module-scoped lock to ensure that no graphs are created or deleted during the
+	 * lock acquisition process. It will be released after forking. */
 	assert(pthread_mutex_lock(&_module_mutex) == 0);
 
 	uint graph_count = array_len(graphs_in_keyspace);


### PR DESCRIPTION
This is a solution to the problem of `bgsave` commands hanging indefinitely if invoked while the graph's read-write lock is held (https://github.com/RedisGraph/RedisGraph/blob/master/src/graph/graph.h#L70).

Since bgsave operates on a forked process, if this lock is held when `bgsave` is called, the `bgsave` process will never be notified when that lock is released (this is thread data, not process data).

I don't love this solution. It gets the job done, but causes `bgsave` to block until it can acquire all locks, which contradicts the point of the call. It additionally seems very possible to me that enterprise environments fork for reasons other than bgsaves, which would cause a lot of unnecessary lock contention here.

As an alternative, I think the RDB save routines could detect if they're in a bgsave context, and if so, don't lock at all. This introduces a small-but-real possibility of data inconsistency in a given RDB snapshot, but sidesteps the problems with this approach. Thoughts?