### PR TITLE
moved strip to circle flow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,9 @@ jobs:
       
       - run:
           name: Persist Artifacts
-          command: >-
-            mkdir -p /workspace/build && cp src/$MODULE_ARTIFACT /workspace/ &&
+          command: |
+            strip src/$MODULE_ARTIFACT
+            mkdir -p /workspace/build && cp src/$MODULE_ARTIFACT /workspace
             cp ramp.yml /workspace/
       
       - persist_to_workspace:

--- a/src/Makefile
+++ b/src/Makefile
@@ -143,12 +143,6 @@ parser:
 # Build the module...
 redisgraph.so: $(MODULE)
 	$(REDISGRAPH_CC) -o $@ $(CC_OBJECTS) $(LIBS) $(SHOBJ_LDFLAGS) -lc -lm
-ifneq ($(DEBUG),1)
-ifeq ($(uname_S),Linux)
-	@echo stripping symbols from module file
-	@strip $@
-endif
-endif
 
 clean:
 	@find . -name '*.[oad]' -type f -delete


### PR DESCRIPTION
this PR restore the original makefile and executes the `strip` function at the circleCI build