### PR TITLE
Include C++ unit tests in autoformatter

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -16,7 +16,6 @@
 --exclude=demo
 --exclude=deps
 --exclude=docs
---exclude=tests
 --exclude=src/util
 --exclude=src/redismodule.h
 --exclude=src/redisearch_api.h

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,4 @@ test:
 	@$(MAKE) -C ./src test
 
 format:
-	astyle -Q --options=.astylerc -R --ignore-exclude-errors "./*.c,*.h"
+	astyle -Q --options=.astylerc -R --ignore-exclude-errors "./*.c,*.h,*.cpp"

--- a/src/arithmetic/arithmetic_expression.h
+++ b/src/arithmetic/arithmetic_expression.h
@@ -88,7 +88,8 @@ typedef struct AR_ExpNode AR_ExpNode;
 AR_ExpNode *AR_EXP_NewOpNode(const char *func_name, uint child_count);
 
 /* Creates a new Arithmetic expression variable operand node */
-AR_ExpNode *AR_EXP_NewVariableOperandNode(RecordMap *record_map, const char *alias, const char *prop);
+AR_ExpNode *AR_EXP_NewVariableOperandNode(RecordMap *record_map, const char *alias,
+										  const char *prop);
 
 /* Creates a new Arithmetic expression constant operand node */
 AR_ExpNode *AR_EXP_NewConstOperandNode(SIValue constant);

--- a/src/arithmetic/funcs.h
+++ b/src/arithmetic/funcs.h
@@ -99,7 +99,7 @@ SIValue AR_NE(SIValue *argv, int argc);
 SIValue AR_TIMESTAMP(SIValue *argv, int argc);
 
 /* Conditional flow functions */
-/* Case When 
+/* Case When
  * Case Value [When Option i Then Result i] Else Default end */
 SIValue AR_CASEWHEN(SIValue *argv, int argc);
 

--- a/src/ast/ast_shared.h
+++ b/src/ast/ast_shared.h
@@ -31,9 +31,9 @@ typedef enum {
 	OP_DIV,
 	OP_MOD,
 	OP_POW,
-    OP_CONTAINS,
-    OP_STARTSWITH,
-    OP_ENDSWITH
+	OP_CONTAINS,
+	OP_STARTSWITH,
+	OP_ENDSWITH
 } AST_Operator;
 
 typedef struct {

--- a/src/execution_plan/ops/op_index_scan.h
+++ b/src/execution_plan/ops/op_index_scan.h
@@ -13,12 +13,12 @@
 #include "../../../deps/RediSearch/src/redisearch_api.h"
 
 typedef struct {
-    OpBase op;
-    QGNode *n;
-    Graph *g;
-    RSIndex *idx;
-    uint nodeRecIdx;
-    RSResultsIterator *iter;
+	OpBase op;
+	QGNode *n;
+	Graph *g;
+	RSIndex *idx;
+	uint nodeRecIdx;
+	RSResultsIterator *iter;
 } IndexScan;
 
 /* Creates a new IndexScan operation */

--- a/src/filter_tree/filter_tree.h
+++ b/src/filter_tree/filter_tree.h
@@ -19,7 +19,7 @@
 /* Nodes within the filter tree are one of two types
  * Either a predicate node or a condition node. */
 typedef enum {
-    FT_N_EXP,   // Expression node.
+	FT_N_EXP,   // Expression node.
 	FT_N_PRED,  // Predicate node.
 	FT_N_COND,  // Conditional node.
 } FT_FilterNodeType;
@@ -27,14 +27,14 @@ typedef enum {
 struct FT_FilterNode;
 
 /* The FT_ExpressionNode represent a leaf node within the filter tree
- * it holds a single boolean arithmetic expression to evaluate 
+ * it holds a single boolean arithmetic expression to evaluate
  * e.g. `WHERE false` in which case `false` is the expression. */
 typedef struct {
-    AR_ExpNode *exp;    /* Boolean expression to evaluate. */
+	AR_ExpNode *exp;    /* Boolean expression to evaluate. */
 } FT_ExpressionNode;
 
-/* The FT_PredicateNode represents a leaf node within the filter tree 
- * it holds an operator: [<. <=, =, >, >=] 
+/* The FT_PredicateNode represents a leaf node within the filter tree
+ * it holds an operator: [<. <=, =, >, >=]
  * a left and right hand-side arithmetic expressions
  * which are evaluated and compared to one another using the operator. */
 typedef struct {
@@ -43,8 +43,8 @@ typedef struct {
 	AST_Operator op;	/* Can validly be an operation (<, <=, =, =>, >, <>, maybe NOT). */
 } FT_PredicateNode;
 
-/* The FT_ConditionNode is a top level node in the filter tree 
- * it holds a conditional operator: [OR, AND] 
+/* The FT_ConditionNode is a top level node in the filter tree
+ * it holds a conditional operator: [OR, AND]
  * a left and right hand-side filter nodes which can be further extended */
 typedef struct {
 	struct FT_FilterNode *left;
@@ -55,7 +55,7 @@ typedef struct {
 /* All nodes within the filter tree are of type FT_FilterNode. */
 struct FT_FilterNode {
 	union {
-        FT_ExpressionNode exp;
+		FT_ExpressionNode exp;
 		FT_PredicateNode pred;
 		FT_ConditionNode cond;
 	};
@@ -91,7 +91,7 @@ rax *FilterTree_CollectModified(const FT_FilterNode *root);
 
 /* Extract every attribute mentioned in the tree
  * without duplications. */
-rax* FilterTree_CollectAttributes(const FT_FilterNode *root);
+rax *FilterTree_CollectAttributes(const FT_FilterNode *root);
 
 /* Checks to see if tree contains given operation. */
 bool FilterTree_containsOp(const FT_FilterNode *root, AST_Operator op);

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -67,11 +67,14 @@ Attribute_ID GraphContext_GetAttributeID(const GraphContext *gc, const char *str
 /* Index API */
 bool GraphContext_HasIndices(GraphContext *gc);
 // Attempt to retrieve an index on the given label and attribute
-Index* GraphContext_GetIndex(const GraphContext *gc, const char *label, const char *field, IndexType type);
+Index *GraphContext_GetIndex(const GraphContext *gc, const char *label, const char *field,
+							 IndexType type);
 // Create an index for the given label and attribute
-int GraphContext_AddIndex(Index **idx, GraphContext *gc, const char *label, const char *field, IndexType type);
+int GraphContext_AddIndex(Index **idx, GraphContext *gc, const char *label, const char *field,
+						  IndexType type);
 // Remove and free an index
-int GraphContext_DeleteIndex(GraphContext *gc, const char *label, const char *field, IndexType type);
+int GraphContext_DeleteIndex(GraphContext *gc, const char *label, const char *field,
+							 IndexType type);
 // Remove a single node from all indices that refer to it
 void GraphContext_DeleteNodeFromIndices(GraphContext *gc, Node *n);
 

--- a/src/graph/serializers/decoders/decode_graph.c
+++ b/src/graph/serializers/decoders/decode_graph.c
@@ -9,128 +9,128 @@
 #include "../../graph.h"
 
 SIValue _RdbLoadSIValue(RedisModuleIO *rdb) {
-    /* Format:
-     * SIType
-     * Value */
-    SIType t = RedisModule_LoadUnsigned(rdb);
-    switch (t) {
-        case T_INT64:
-            return SI_LongVal(RedisModule_LoadSigned(rdb));
-        case T_DOUBLE:
-            return SI_DoubleVal(RedisModule_LoadDouble(rdb));
-        case T_STRING:
-        case T_CONSTSTRING:
-            // Transfer ownership of the heap-allocated string to the
-            // newly-created SIValue
-            return SI_TransferStringVal(RedisModule_LoadStringBuffer(rdb, NULL));
-        case T_BOOL:
-            return SI_BoolVal(RedisModule_LoadSigned(rdb));
-        case T_NULL:
-        default: // currently impossible
-            return SI_NullVal();
-    }
+	/* Format:
+	 * SIType
+	 * Value */
+	SIType t = RedisModule_LoadUnsigned(rdb);
+	switch(t) {
+	case T_INT64:
+		return SI_LongVal(RedisModule_LoadSigned(rdb));
+	case T_DOUBLE:
+		return SI_DoubleVal(RedisModule_LoadDouble(rdb));
+	case T_STRING:
+	case T_CONSTSTRING:
+		// Transfer ownership of the heap-allocated string to the
+		// newly-created SIValue
+		return SI_TransferStringVal(RedisModule_LoadStringBuffer(rdb, NULL));
+	case T_BOOL:
+		return SI_BoolVal(RedisModule_LoadSigned(rdb));
+	case T_NULL:
+	default: // currently impossible
+		return SI_NullVal();
+	}
 }
 
 void _RdbLoadEntity(RedisModuleIO *rdb, GraphContext *gc, GraphEntity *e) {
-    /* Format:
-     * #properties N
-     * (name, value type, value) X N
-    */
-    uint64_t propCount = RedisModule_LoadUnsigned(rdb);
-    if(!propCount) return;
+	/* Format:
+	 * #properties N
+	 * (name, value type, value) X N
+	*/
+	uint64_t propCount = RedisModule_LoadUnsigned(rdb);
+	if(!propCount) return;
 
-    for(int i = 0; i < propCount; i++) {
-        char *attr_name = RedisModule_LoadStringBuffer(rdb, NULL);
-        SIValue attr_value = _RdbLoadSIValue(rdb);
-        Attribute_ID attr_id = GraphContext_GetAttributeID(gc, attr_name);
-        assert(attr_id != ATTRIBUTE_NOTFOUND);
-        GraphEntity_AddProperty(e, attr_id, attr_value);
-        RedisModule_Free(attr_name);
-    }
+	for(int i = 0; i < propCount; i++) {
+		char *attr_name = RedisModule_LoadStringBuffer(rdb, NULL);
+		SIValue attr_value = _RdbLoadSIValue(rdb);
+		Attribute_ID attr_id = GraphContext_GetAttributeID(gc, attr_name);
+		assert(attr_id != ATTRIBUTE_NOTFOUND);
+		GraphEntity_AddProperty(e, attr_id, attr_value);
+		RedisModule_Free(attr_name);
+	}
 }
 
 void _RdbLoadNodes(RedisModuleIO *rdb, GraphContext *gc) {
-    /* Format:
-     * #nodes
-     *      #labels M
-     *      (labels) X M
-     *      #properties N
-     *      (name, value type, value) X N
-    */
+	/* Format:
+	 * #nodes
+	 *      #labels M
+	 *      (labels) X M
+	 *      #properties N
+	 *      (name, value type, value) X N
+	*/
 
-    uint64_t nodeCount = RedisModule_LoadUnsigned(rdb);
-    if(nodeCount == 0) return;
+	uint64_t nodeCount = RedisModule_LoadUnsigned(rdb);
+	if(nodeCount == 0) return;
 
-    Graph_AllocateNodes(gc->g, nodeCount);
-    for(uint64_t i = 0; i < nodeCount; i++) {
-        Node n;
+	Graph_AllocateNodes(gc->g, nodeCount);
+	for(uint64_t i = 0; i < nodeCount; i++) {
+		Node n;
 
-        // Extend this logic when multi-label support is added.
-        // #labels M
-        uint64_t nodeLabelCount = RedisModule_LoadUnsigned(rdb);
+		// Extend this logic when multi-label support is added.
+		// #labels M
+		uint64_t nodeLabelCount = RedisModule_LoadUnsigned(rdb);
 
-        // * (labels) x M
-        // M will currently always be 0 or 1
-        uint64_t l = (nodeLabelCount) ? RedisModule_LoadUnsigned(rdb) : GRAPH_NO_LABEL;
-        Graph_CreateNode(gc->g, l, &n);
+		// * (labels) x M
+		// M will currently always be 0 or 1
+		uint64_t l = (nodeLabelCount) ? RedisModule_LoadUnsigned(rdb) : GRAPH_NO_LABEL;
+		Graph_CreateNode(gc->g, l, &n);
 
-        _RdbLoadEntity(rdb, gc, (GraphEntity*)&n);
-    }
+		_RdbLoadEntity(rdb, gc, (GraphEntity *)&n);
+	}
 }
 
 void _RdbLoadEdges(RedisModuleIO *rdb, GraphContext *gc) {
-    /* Format:
-     * #edges (N)
-     * {
-     *  source node ID
-     *  destination node ID
-     *  relation type
-     * } X N
-     * edge properties X N */
+	/* Format:
+	 * #edges (N)
+	 * {
+	 *  source node ID
+	 *  destination node ID
+	 *  relation type
+	 * } X N
+	 * edge properties X N */
 
-    uint64_t edgeCount = RedisModule_LoadUnsigned(rdb);
-    if(edgeCount == 0) return;
+	uint64_t edgeCount = RedisModule_LoadUnsigned(rdb);
+	if(edgeCount == 0) return;
 
-    Graph_AllocateEdges(gc->g, edgeCount);
-    // Construct connections.
-    for(int i = 0; i < edgeCount; i++) {
-        Edge e;
-        NodeID srcId = RedisModule_LoadUnsigned(rdb);
-        NodeID destId = RedisModule_LoadUnsigned(rdb);
-        uint64_t relation = RedisModule_LoadUnsigned(rdb);
-        assert(Graph_ConnectNodes(gc->g, srcId, destId, relation, &e));
-        _RdbLoadEntity(rdb, gc, (GraphEntity*)&e);
-    }
+	Graph_AllocateEdges(gc->g, edgeCount);
+	// Construct connections.
+	for(int i = 0; i < edgeCount; i++) {
+		Edge e;
+		NodeID srcId = RedisModule_LoadUnsigned(rdb);
+		NodeID destId = RedisModule_LoadUnsigned(rdb);
+		uint64_t relation = RedisModule_LoadUnsigned(rdb);
+		assert(Graph_ConnectNodes(gc->g, srcId, destId, relation, &e));
+		_RdbLoadEntity(rdb, gc, (GraphEntity *)&e);
+	}
 }
 
 void RdbLoadGraph(RedisModuleIO *rdb, GraphContext *gc) {
-    /* Format:
-     * #nodes
-     *      #labels M
-     *      (labels) X M
-     *      #properties N
-     *      (name, value type, value) X N
-     *
-     * #edges
-     *      relation type
-     *      source node ID
-     *      destination node ID
-     *      #properties N
-     *      (name, value type, value) X N
-     */
+	/* Format:
+	 * #nodes
+	 *      #labels M
+	 *      (labels) X M
+	 *      #properties N
+	 *      (name, value type, value) X N
+	 *
+	 * #edges
+	 *      relation type
+	 *      source node ID
+	 *      destination node ID
+	 *      #properties N
+	 *      (name, value type, value) X N
+	 */
 
-    // While loading the graph, minimize matrix realloc and synchronization calls.
-    Graph_SetMatrixPolicy(gc->g, RESIZE_TO_CAPACITY);
+	// While loading the graph, minimize matrix realloc and synchronization calls.
+	Graph_SetMatrixPolicy(gc->g, RESIZE_TO_CAPACITY);
 
-    // Load nodes.
-    _RdbLoadNodes(rdb, gc);
+	// Load nodes.
+	_RdbLoadNodes(rdb, gc);
 
-    // Load edges.
-    _RdbLoadEdges(rdb, gc);
+	// Load edges.
+	_RdbLoadEdges(rdb, gc);
 
-    // Revert to default synchronization behavior
-    Graph_SetMatrixPolicy(gc->g, SYNC_AND_MINIMIZE_SPACE);
+	// Revert to default synchronization behavior
+	Graph_SetMatrixPolicy(gc->g, SYNC_AND_MINIMIZE_SPACE);
 
-    // Resize and flush all pending changes to matrices.
-    Graph_ApplyAllPending(gc->g);
+	// Resize and flush all pending changes to matrices.
+	Graph_ApplyAllPending(gc->g);
 }

--- a/src/graph/serializers/decoders/decode_graphcontext.h
+++ b/src/graph/serializers/decoders/decode_graphcontext.h
@@ -9,4 +9,4 @@
 #include "../../graphcontext.h"
 #include "../../../redismodule.h"
 
-GraphContext* RdbLoadGraphContext(RedisModuleIO *rdb);
+GraphContext *RdbLoadGraphContext(RedisModuleIO *rdb);

--- a/src/graph/serializers/decoders/decode_schema.h
+++ b/src/graph/serializers/decoders/decode_schema.h
@@ -10,4 +10,4 @@
 #include "../../../redismodule.h"
 #include "../../../schema/schema.h"
 
-Schema* RdbLoadSchema(RedisModuleIO *rdb, SchemaType type);
+Schema *RdbLoadSchema(RedisModuleIO *rdb, SchemaType type);

--- a/src/graph/serializers/decoders/prev/prev_decode_graphcontext.h
+++ b/src/graph/serializers/decoders/prev/prev_decode_graphcontext.h
@@ -9,4 +9,4 @@
 #include "../../../graphcontext.h"
 #include "../../../../redismodule.h"
 
-GraphContext* PrevRdbLoadGraphContext(RedisModuleIO *rdb);
+GraphContext *PrevRdbLoadGraphContext(RedisModuleIO *rdb);

--- a/src/graph/serializers/encoder/encode_graphcontext.c
+++ b/src/graph/serializers/encoder/encode_graphcontext.c
@@ -9,65 +9,65 @@
 #include "encode_schema.h"
 
 static void _RdbSaveAttributeKeys(RedisModuleIO *rdb, GraphContext *gc) {
-    /* Format:
-     * #attribute keys
-     * attribute keys
-    */
+	/* Format:
+	 * #attribute keys
+	 * attribute keys
+	*/
 
-    uint count = GraphContext_AttributeCount(gc);
-    RedisModule_SaveUnsigned(rdb, count);
-    for (uint i = 0; i < count; i ++) {
-        char *key = gc->string_mapping[i];
-        RedisModule_SaveStringBuffer(rdb, key, strlen(key) + 1);
-    }
+	uint count = GraphContext_AttributeCount(gc);
+	RedisModule_SaveUnsigned(rdb, count);
+	for(uint i = 0; i < count; i ++) {
+		char *key = gc->string_mapping[i];
+		RedisModule_SaveStringBuffer(rdb, key, strlen(key) + 1);
+	}
 }
 
 void RdbSaveGraphContext(RedisModuleIO *rdb, void *value) {
-    /* Format:
-     * graph name
-     * attribute keys (unified schema)
-     * #node schemas
-     * node schema X #node schemas
-     * #relation schemas
-     * unified relation schema
-     * relation schema X #relation schemas
-     * graph object
-    */
+	/* Format:
+	 * graph name
+	 * attribute keys (unified schema)
+	 * #node schemas
+	 * node schema X #node schemas
+	 * #relation schemas
+	 * unified relation schema
+	 * relation schema X #relation schemas
+	 * graph object
+	*/
 
-    GraphContext *gc = value;
+	GraphContext *gc = value;
 
-    // Lock.
-    Graph_AcquireReadLock(gc->g);
+	// Lock.
+	Graph_AcquireReadLock(gc->g);
 
-    // Graph name.
-    RedisModule_SaveStringBuffer(rdb, gc->graph_name, strlen(gc->graph_name) + 1);
+	// Graph name.
+	RedisModule_SaveStringBuffer(rdb, gc->graph_name, strlen(gc->graph_name) + 1);
 
-    // Serialize all attribute keys
-    _RdbSaveAttributeKeys(rdb, gc);
+	// Serialize all attribute keys
+	_RdbSaveAttributeKeys(rdb, gc);
 
-    // #Node schemas.
-    unsigned short schema_count = GraphContext_SchemaCount(gc, SCHEMA_NODE);
-    RedisModule_SaveUnsigned(rdb, schema_count);
+	// #Node schemas.
+	unsigned short schema_count = GraphContext_SchemaCount(gc, SCHEMA_NODE);
+	RedisModule_SaveUnsigned(rdb, schema_count);
 
-    // Name of label X #node schemas.
-    for(int i = 0; i < schema_count; i++) {
-        Schema *s = gc->node_schemas[i];
-        RdbSaveSchema(rdb, s);
-    }
+	// Name of label X #node schemas.
+	for(int i = 0; i < schema_count; i++) {
+		Schema *s = gc->node_schemas[i];
+		RdbSaveSchema(rdb, s);
+	}
 
-    // #Relation schemas.
-    unsigned short relation_count = GraphContext_SchemaCount(gc, SCHEMA_EDGE);
-    RedisModule_SaveUnsigned(rdb, relation_count);
+	// #Relation schemas.
+	unsigned short relation_count = GraphContext_SchemaCount(gc, SCHEMA_EDGE);
+	RedisModule_SaveUnsigned(rdb, relation_count);
 
-    // Name of label X #relation schemas.
-    for(unsigned short i = 0; i < relation_count; i++) {
-        Schema *s = gc->relation_schemas[i];
-        RdbSaveSchema(rdb, s);
-    }
+	// Name of label X #relation schemas.
+	for(unsigned short i = 0; i < relation_count; i++) {
+		Schema *s = gc->relation_schemas[i];
+		RdbSaveSchema(rdb, s);
+	}
 
-    // Serialize graph object
-    RdbSaveGraph(rdb, gc);
+	// Serialize graph object
+	RdbSaveGraph(rdb, gc);
 
-    // Unlock.
-    Graph_ReleaseLock(gc->g);
+	// Unlock.
+	Graph_ReleaseLock(gc->g);
 }

--- a/src/procedures/proc_ctx.h
+++ b/src/procedures/proc_ctx.h
@@ -30,7 +30,7 @@ typedef struct ProcedureCtx *(*ProcGenerator)();
 // Procedure step function.
 typedef SIValue *(*ProcStep)(struct ProcedureCtx *ctx);
 // Procedure function pointer.
-typedef ProcedureResult (*ProcInvoke)(struct ProcedureCtx *ctx, const char **args);
+typedef ProcedureResult(*ProcInvoke)(struct ProcedureCtx *ctx, const char **args);
 // Procedure free resources.
 typedef ProcedureResult(*ProcFree)(struct ProcedureCtx *ctx);
 

--- a/src/procedures/proc_fulltext_drop_index.h
+++ b/src/procedures/proc_fulltext_drop_index.h
@@ -8,4 +8,4 @@
 
 #include "proc_ctx.h"
 
-ProcedureCtx* Proc_FulltextDropIdxGen();
+ProcedureCtx *Proc_FulltextDropIdxGen();

--- a/src/procedures/procedure.h
+++ b/src/procedures/procedure.h
@@ -36,7 +36,7 @@ uint Procedure_Argc(const ProcedureCtx *proc);
 uint Procedure_OutputCount(const ProcedureCtx *proc);
 
 /* Retrieves procedure ith output */
-const char* Procedure_GetOutput(const ProcedureCtx *proc, uint output_idx);
+const char *Procedure_GetOutput(const ProcedureCtx *proc, uint output_idx);
 
 /* Returns true if given output can be yield by procedure */
 bool Procedure_ContainsOutput(const ProcedureCtx *proc, const char *output);

--- a/src/schema/schema.h
+++ b/src/schema/schema.h
@@ -13,22 +13,22 @@
 #include "../../deps/RediSearch/src/redisearch_api.h"
 
 typedef enum {
-  SCHEMA_NODE,
-  SCHEMA_EDGE,
+	SCHEMA_NODE,
+	SCHEMA_EDGE,
 } SchemaType;
 
 /* Schema represents the structure of a typed graph entity (Node/Edge).
  * similar to a relational table structure, our schemas are a collection
  * of attributes we've encountered overtime as entities were created or updated. */
 typedef struct {
-  int id;               // Internal ID to a matrix within the graph.
-  char *name;           // Schema name.
-  Index* index;         // Exact match index.
-  Index* fulltextIdx;   // Full-text index.
+	int id;               // Internal ID to a matrix within the graph.
+	char *name;           // Schema name.
+	Index *index;         // Exact match index.
+	Index *fulltextIdx;   // Full-text index.
 } Schema;
 
 /* Creates a new schema. */
-Schema* Schema_New(const char *label, int id);
+Schema *Schema_New(const char *label, int id);
 
 const char *Schema_GetName(const Schema *s);
 
@@ -38,9 +38,9 @@ bool Schema_HasIndices(const Schema *s);
 /* Returns number of indices in schema. */
 unsigned short Schema_IndexCount(const Schema *s);
 
-/* Retrieves index from attribute. 
+/* Retrieves index from attribute.
  * Returns NULL if index wasn't found. */
-Index* Schema_GetIndex(const Schema *s, const char *field, IndexType type);
+Index *Schema_GetIndex(const Schema *s, const char *field, IndexType type);
 
 /* Assign a new index to attribute
  * attribute must already exists and not associated with an index. */

--- a/src/value.h
+++ b/src/value.h
@@ -79,7 +79,8 @@ SIValue SI_PtrVal(void *v);
 SIValue SI_Node(void *n);
 SIValue SI_Edge(void *e);
 SIValue SI_DuplicateStringVal(const char *s); // Duplicate and ultimately free the input string
-SIValue SI_ConstStringVal(char *s);           // Neither duplicate nor assume ownership of input string
+SIValue SI_ConstStringVal(char
+						  *s);           // Neither duplicate nor assume ownership of input string
 SIValue SI_TransferStringVal(char *s);        // Don't duplicate input string, but assume ownership
 
 /* Functions for copying and guaranteeing memory safety for SIValues. */

--- a/tests/unit/test_aggregate_functions.cpp
+++ b/tests/unit/test_aggregate_functions.cpp
@@ -18,8 +18,9 @@ extern "C" {
 #include "../../src/util/arr.h"
 
 // Declaration of used functions not in header files
-extern AR_ExpNode** _BuildReturnExpressions(RecordMap *record_map, const cypher_astnode_t *ret_clause);
-extern AR_ExpNode* AR_EXP_NewOpNode(const char *func_name, uint child_count);
+extern AR_ExpNode **_BuildReturnExpressions(RecordMap *record_map,
+											const cypher_astnode_t *ret_clause);
+extern AR_ExpNode *AR_EXP_NewOpNode(const char *func_name, uint child_count);
 
 pthread_key_t _tlsASTKey;
 
@@ -29,216 +30,216 @@ pthread_key_t _tlsASTKey;
 
 class AggregateTest: public ::testing::Test {
   protected:
-    Record r = NULL;
-    static void SetUpTestCase() {
-      // Use the malloc family for allocations
-      Alloc_Reset();
-      AR_RegisterFuncs();
-      Agg_RegisterFuncs();
-      pthread_key_create(&_tlsASTKey, NULL);
-    }
+	Record r = NULL;
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
+		AR_RegisterFuncs();
+		Agg_RegisterFuncs();
+		pthread_key_create(&_tlsASTKey, NULL);
+	}
 };
 
-AR_ExpNode* _exp_from_query(const char *query) {
-  cypher_parse_result_t *parse_result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
-  AST *ast = AST_Build(parse_result);
+AR_ExpNode *_exp_from_query(const char *query) {
+	cypher_parse_result_t *parse_result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
+	AST *ast = AST_Build(parse_result);
 
-  const cypher_astnode_t *ret_clause = AST_GetClause(ast, CYPHER_AST_RETURN);
-  AR_ExpNode **return_elems = _BuildReturnExpressions(NULL, ret_clause);
+	const cypher_astnode_t *ret_clause = AST_GetClause(ast, CYPHER_AST_RETURN);
+	AR_ExpNode **return_elems = _BuildReturnExpressions(NULL, ret_clause);
 
-  return return_elems[0];
+	return return_elems[0];
 }
 
 // Count valid entities
 TEST_F(AggregateTest, CountTest) {
-  SIValue result;
-  const char *query;
-  AR_ExpNode *arExp;
-  Record r = Record_New(0);
-  
-  /* count(1) */
-  query = "RETURN count(1)";
-  arExp = _exp_from_query(query);
+	SIValue result;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-  int num_values = 5;
-  for (int i = 0; i < num_values; i ++) AR_EXP_Aggregate(arExp, r);
-  AR_EXP_Reduce(arExp);
-  result = AR_EXP_Evaluate(arExp, r);
-  ASSERT_EQ(result.longval, num_values);
-  AR_EXP_Free(arExp);
+	/* count(1) */
+	query = "RETURN count(1)";
+	arExp = _exp_from_query(query);
+
+	int num_values = 5;
+	for(int i = 0; i < num_values; i ++) AR_EXP_Aggregate(arExp, r);
+	AR_EXP_Reduce(arExp);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.longval, num_values);
+	AR_EXP_Free(arExp);
 }
 
 // Count a mix of valid and invalid entities
 TEST_F(AggregateTest, PartialCountTest) {
-  const char *query;
-  AR_ExpNode *arExp;
-  AR_ExpNode *arExpOne;
-  AR_ExpNode *arExpNULL;
-  Record r = Record_New(0);
+	const char *query;
+	AR_ExpNode *arExp;
+	AR_ExpNode *arExpOne;
+	AR_ExpNode *arExpNULL;
+	Record r = Record_New(0);
 
-  query = "RETURN 1";
-  arExpOne = _exp_from_query(query);
+	query = "RETURN 1";
+	arExpOne = _exp_from_query(query);
 
-  query = "RETURN NULL";
-  arExpNULL = _exp_from_query(query);
+	query = "RETURN NULL";
+	arExpNULL = _exp_from_query(query);
 
-  /* count(1) */
-  query = "RETURN count(1)";
-  arExp = _exp_from_query(query);
+	/* count(1) */
+	query = "RETURN count(1)";
+	arExp = _exp_from_query(query);
 
-  int num_values = 10;
-  for (int i = 0; i < num_values; i ++) {
-    // Every odd entity will be a valid numeric,
-    // and every even entity will be a null value
-    if (i % 2) arExp->op.children[0] = arExpOne;
-    else arExp->op.children[0] = arExpNULL;
-    AR_EXP_Aggregate(arExp, r);
-  }
-  AR_EXP_Reduce(arExp);
-  SIValue res = AR_EXP_Evaluate(arExp, r);
+	int num_values = 10;
+	for(int i = 0; i < num_values; i ++) {
+		// Every odd entity will be a valid numeric,
+		// and every even entity will be a null value
+		if(i % 2) arExp->op.children[0] = arExpOne;
+		else arExp->op.children[0] = arExpNULL;
+		AR_EXP_Aggregate(arExp, r);
+	}
+	AR_EXP_Reduce(arExp);
+	SIValue res = AR_EXP_Evaluate(arExp, r);
 
-  // The counted result should be half the number of inserted entities,
-  // as the null values are ignored.
-  ASSERT_EQ(res.longval, num_values / 2);
-  AR_EXP_Free(arExp);
+	// The counted result should be half the number of inserted entities,
+	// as the null values are ignored.
+	ASSERT_EQ(res.longval, num_values / 2);
+	AR_EXP_Free(arExp);
 }
 
 TEST_F(AggregateTest, PercentileContTest) {
-  // Percentiles to check
-  AR_ExpNode *zero = AR_EXP_NewConstOperandNode(SI_DoubleVal(0));
-  AR_ExpNode *dot_one = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.1));
-  AR_ExpNode *one_third = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.33));
-  AR_ExpNode *half = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.5));
-  AR_ExpNode *one = AR_EXP_NewConstOperandNode(SI_DoubleVal(1));
+	// Percentiles to check
+	AR_ExpNode *zero = AR_EXP_NewConstOperandNode(SI_DoubleVal(0));
+	AR_ExpNode *dot_one = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.1));
+	AR_ExpNode *one_third = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.33));
+	AR_ExpNode *half = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.5));
+	AR_ExpNode *one = AR_EXP_NewConstOperandNode(SI_DoubleVal(1));
 
-  AR_ExpNode *test_percentiles[5] = {zero, dot_one, one_third, half, one};
-  /*
-   * The correct value for each percentile will be:
-   * x = percentile * (count - 1)
-   * if x is an integer return value[x]
-   * else:
-   * (value[floor(x)] * fraction(x)) + (value[ceil(x)] * (1 - fraction(x)))
-   */
-  double expected_values[5];
-  double arr[5] = {2, 4, 6, 8, 10};
-  int count = 5;
+	AR_ExpNode *test_percentiles[5] = {zero, dot_one, one_third, half, one};
+	/*
+	 * The correct value for each percentile will be:
+	 * x = percentile * (count - 1)
+	 * if x is an integer return value[x]
+	 * else:
+	 * (value[floor(x)] * fraction(x)) + (value[ceil(x)] * (1 - fraction(x)))
+	 */
+	double expected_values[5];
+	double arr[5] = {2, 4, 6, 8, 10};
+	int count = 5;
 
-  double percentile_doubles[5] = {0, 0.1, 0.33, 0.5, 1};
-  double x;
-  int lower_idx, upper_idx;
-  double lower, upper;
+	double percentile_doubles[5] = {0, 0.1, 0.33, 0.5, 1};
+	double x;
+	int lower_idx, upper_idx;
+	double lower, upper;
 
-  for (int i = 0; i < 5; i ++) {
-    x = percentile_doubles[i] * (count - 1);
-    lower_idx = floor(x);
-    upper_idx = ceil(x);
+	for(int i = 0; i < 5; i ++) {
+		x = percentile_doubles[i] * (count - 1);
+		lower_idx = floor(x);
+		upper_idx = ceil(x);
 
-    if (lower_idx == upper_idx || lower_idx == (count - 1)) {
-      expected_values[i] = arr[lower_idx];
-      continue;
-    }
+		if(lower_idx == upper_idx || lower_idx == (count - 1)) {
+			expected_values[i] = arr[lower_idx];
+			continue;
+		}
 
-    lower = arr[lower_idx];
-    upper = arr[upper_idx];
+		lower = arr[lower_idx];
+		upper = arr[upper_idx];
 
-    expected_values[i] = (lower * ((double)upper_idx - x)) + (upper * (x - (double)lower_idx));
-  }
+		expected_values[i] = (lower * ((double)upper_idx - x)) + (upper * (x - (double)lower_idx));
+	}
 
-  AR_ExpNode *perc;
-  SIValue result;
-  for (int i = 0; i < 5; i ++) {
-    perc = AR_EXP_NewOpNode("percentileCont", 6);
-    for (int j = 1; j <= 5; j ++) {
-      perc->op.children[j - 1] = AR_EXP_NewConstOperandNode(SI_DoubleVal(j * 2));
-    }
-    // The last child of this node will be the requested percentile
-    perc->op.children[5] = test_percentiles[i];
-    AR_EXP_Aggregate(perc, r);
-    // Reduce sorts the list and applies the percentile formula
-    AR_EXP_Reduce(perc);
-    result = AR_EXP_Evaluate(perc, r);
-    ASSERT_EQ(result.doubleval, expected_values[i]);    
-    AR_EXP_Free(perc);
-  }
+	AR_ExpNode *perc;
+	SIValue result;
+	for(int i = 0; i < 5; i ++) {
+		perc = AR_EXP_NewOpNode("percentileCont", 6);
+		for(int j = 1; j <= 5; j ++) {
+			perc->op.children[j - 1] = AR_EXP_NewConstOperandNode(SI_DoubleVal(j * 2));
+		}
+		// The last child of this node will be the requested percentile
+		perc->op.children[5] = test_percentiles[i];
+		AR_EXP_Aggregate(perc, r);
+		// Reduce sorts the list and applies the percentile formula
+		AR_EXP_Reduce(perc);
+		result = AR_EXP_Evaluate(perc, r);
+		ASSERT_EQ(result.doubleval, expected_values[i]);
+		AR_EXP_Free(perc);
+	}
 }
 
 TEST_F(AggregateTest, PercentileDiscTest) {
-  // Percentiles to check
-  AR_ExpNode *zero = AR_EXP_NewConstOperandNode(SI_DoubleVal(0));
-  AR_ExpNode *dot_one = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.1));
-  AR_ExpNode *one_third = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.33));
-  AR_ExpNode *half = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.5));
-  AR_ExpNode *one = AR_EXP_NewConstOperandNode(SI_DoubleVal(1));
+	// Percentiles to check
+	AR_ExpNode *zero = AR_EXP_NewConstOperandNode(SI_DoubleVal(0));
+	AR_ExpNode *dot_one = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.1));
+	AR_ExpNode *one_third = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.33));
+	AR_ExpNode *half = AR_EXP_NewConstOperandNode(SI_DoubleVal(0.5));
+	AR_ExpNode *one = AR_EXP_NewConstOperandNode(SI_DoubleVal(1));
 
-  AR_ExpNode *test_percentiles[5] = {zero, dot_one, one_third, half, one};
-  // percentileDisc should always return a value actually contained in the set
-  int expected[5] = {0, 0, 1, 2, 4};
+	AR_ExpNode *test_percentiles[5] = {zero, dot_one, one_third, half, one};
+	// percentileDisc should always return a value actually contained in the set
+	int expected[5] = {0, 0, 1, 2, 4};
 
-  SIValue expected_outcome;
-  AR_ExpNode *perc;
-  for (int i = 0; i < 5; i ++) {
-    perc = AR_EXP_NewOpNode("percentileDisc", 6);
-    for (int j = 1; j <= 5; j ++) {
-      perc->op.children[j - 1] = AR_EXP_NewConstOperandNode(SI_DoubleVal(j * 2));
-    }
-    // The last child of this node will be the requested percentile
-    perc->op.children[5] = test_percentiles[i];
-    AR_EXP_Aggregate(perc, r);
-    // Reduce sorts the list and applies the percentile formula
-    AR_EXP_Reduce(perc);
-    SIValue res = AR_EXP_Evaluate(perc, r);
-    expected_outcome = AR_EXP_Evaluate(perc->op.children[expected[i]], r);
-    ASSERT_EQ(res.doubleval, expected_outcome.doubleval);
-    AR_EXP_Free(perc);
-  }
+	SIValue expected_outcome;
+	AR_ExpNode *perc;
+	for(int i = 0; i < 5; i ++) {
+		perc = AR_EXP_NewOpNode("percentileDisc", 6);
+		for(int j = 1; j <= 5; j ++) {
+			perc->op.children[j - 1] = AR_EXP_NewConstOperandNode(SI_DoubleVal(j * 2));
+		}
+		// The last child of this node will be the requested percentile
+		perc->op.children[5] = test_percentiles[i];
+		AR_EXP_Aggregate(perc, r);
+		// Reduce sorts the list and applies the percentile formula
+		AR_EXP_Reduce(perc);
+		SIValue res = AR_EXP_Evaluate(perc, r);
+		expected_outcome = AR_EXP_Evaluate(perc->op.children[expected[i]], r);
+		ASSERT_EQ(res.doubleval, expected_outcome.doubleval);
+		AR_EXP_Free(perc);
+	}
 }
 
 // Tests both stDev and stDevP
 TEST_F(AggregateTest, StDevTest) {
-  // Edge case - operation called on < 2 values
-  AR_ExpNode *stdev = AR_EXP_NewOpNode("stDev", 1);
-  stdev->op.children[0] = AR_EXP_NewConstOperandNode(SI_DoubleVal(5.1));
-  AR_EXP_Aggregate(stdev, r);
-  AR_EXP_Reduce(stdev);
-  SIValue result = AR_EXP_Evaluate(stdev, r);
-  ASSERT_EQ(result.doubleval, 0);
-  AR_EXP_Free(stdev);
+	// Edge case - operation called on < 2 values
+	AR_ExpNode *stdev = AR_EXP_NewOpNode("stDev", 1);
+	stdev->op.children[0] = AR_EXP_NewConstOperandNode(SI_DoubleVal(5.1));
+	AR_EXP_Aggregate(stdev, r);
+	AR_EXP_Reduce(stdev);
+	SIValue result = AR_EXP_Evaluate(stdev, r);
+	ASSERT_EQ(result.doubleval, 0);
+	AR_EXP_Free(stdev);
 
-  // Stdev of squares of first 10 positive integers
-  stdev = AR_EXP_NewOpNode("stDev", 10);
-  double sum = 0;
-  for (int i = 1; i <= 10; i ++) {
-    stdev->op.children[i - 1] = AR_EXP_NewConstOperandNode(SI_DoubleVal(i));
-    sum += i;
-  }
-  double mean = sum / 10;
-  double tmp_variance = 0;
-  for (int i = 1; i <= 10; i ++)  {
-    tmp_variance += pow(i - mean, 2);
-  }
-  double sample_variance = tmp_variance / 9;
-  double sample_result = sqrt(sample_variance);
+	// Stdev of squares of first 10 positive integers
+	stdev = AR_EXP_NewOpNode("stDev", 10);
+	double sum = 0;
+	for(int i = 1; i <= 10; i ++) {
+		stdev->op.children[i - 1] = AR_EXP_NewConstOperandNode(SI_DoubleVal(i));
+		sum += i;
+	}
+	double mean = sum / 10;
+	double tmp_variance = 0;
+	for(int i = 1; i <= 10; i ++)  {
+		tmp_variance += pow(i - mean, 2);
+	}
+	double sample_variance = tmp_variance / 9;
+	double sample_result = sqrt(sample_variance);
 
-  AR_EXP_Aggregate(stdev, r);
-  AR_EXP_Reduce(stdev);
-  result = AR_EXP_Evaluate(stdev, r);
+	AR_EXP_Aggregate(stdev, r);
+	AR_EXP_Reduce(stdev);
+	result = AR_EXP_Evaluate(stdev, r);
 
-  ASSERT_EQ(result.doubleval, sample_result);
-  AR_EXP_Free(stdev);
+	ASSERT_EQ(result.doubleval, sample_result);
+	AR_EXP_Free(stdev);
 
-  // Perform last test with stDevP
-  AR_ExpNode *stdevp = AR_EXP_NewOpNode("stDevP", 10);
-  for (int i = 1; i <= 10; i ++) {
-    stdevp->op.children[i - 1] = AR_EXP_NewConstOperandNode(SI_DoubleVal(i));
-  }
+	// Perform last test with stDevP
+	AR_ExpNode *stdevp = AR_EXP_NewOpNode("stDevP", 10);
+	for(int i = 1; i <= 10; i ++) {
+		stdevp->op.children[i - 1] = AR_EXP_NewConstOperandNode(SI_DoubleVal(i));
+	}
 
-  double pop_variance = tmp_variance / 10;
-  double pop_result = sqrt(pop_variance);
+	double pop_variance = tmp_variance / 10;
+	double pop_result = sqrt(pop_variance);
 
-  AR_EXP_Aggregate(stdevp, r);
-  AR_EXP_Reduce(stdevp);
-  result = AR_EXP_Evaluate(stdevp, r);
+	AR_EXP_Aggregate(stdevp, r);
+	AR_EXP_Reduce(stdevp);
+	result = AR_EXP_Evaluate(stdevp, r);
 
-  ASSERT_EQ(result.doubleval, pop_result);
-  AR_EXP_Free(stdevp);
+	ASSERT_EQ(result.doubleval, pop_result);
+	AR_EXP_Free(stdevp);
 }

--- a/tests/unit/test_algebraic_expression.cpp
+++ b/tests/unit/test_algebraic_expression.cpp
@@ -21,7 +21,8 @@ extern "C" {
 #include "../../src/util/rmalloc.h"
 #include "../../deps/GraphBLAS/Include/GraphBLAS.h"
 
-extern AR_ExpNode** _BuildReturnExpressions(RecordMap *record_map, const cypher_astnode_t *ret_clause);
+extern AR_ExpNode **_BuildReturnExpressions(RecordMap *record_map,
+											const cypher_astnode_t *ret_clause);
 
 #ifdef __cplusplus
 }
@@ -41,1184 +42,1200 @@ GrB_Matrix mat_c;
 GrB_Matrix mat_ew;
 GrB_Matrix mat_e;
 
-const char *query_no_intermidate_return_nodes = "MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p, e";
-const char *query_one_intermidate_return_nodes = "MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p, c, e";
-const char *query_multiple_intermidate_return_nodes = "MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p, f, c, e";
+const char *query_no_intermidate_return_nodes =
+	"MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p, e";
+const char *query_one_intermidate_return_nodes =
+	"MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p, c, e";
+const char *query_multiple_intermidate_return_nodes =
+	"MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p, f, c, e";
 
-const char *query_return_first_edge = "MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ef";
-const char *query_return_intermidate_edge = "MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ev";
-const char *query_return_last_edge = "MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ew";
+const char *query_return_first_edge =
+	"MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ef";
+const char *query_return_intermidate_edge =
+	"MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ev";
+const char *query_return_last_edge =
+	"MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ew";
 
 class AlgebraicExpressionTest: public ::testing::Test {
-    protected:
-    static void SetUpTestCase() {
-        // Use the malloc family for allocations
-        Alloc_Reset();
+  protected:
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
 
-        // Initialize GraphBLAS.
-        GrB_init(GrB_NONBLOCKING);
-        GxB_Global_Option_set(GxB_FORMAT, GxB_BY_COL); // all matrices in CSC format
-        GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
+		// Initialize GraphBLAS.
+		GrB_init(GrB_NONBLOCKING);
+		GxB_Global_Option_set(GxB_FORMAT, GxB_BY_COL); // all matrices in CSC format
+		GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
 
-        // Create a graph
-        _fake_graph_context();
-        _build_graph();
-        _bind_matrices();
-        int error = pthread_key_create(&_tlsASTKey, NULL);
-        ASSERT_EQ(error, 0);
-    }
+		// Create a graph
+		_fake_graph_context();
+		_build_graph();
+		_bind_matrices();
+		int error = pthread_key_create(&_tlsASTKey, NULL);
+		ASSERT_EQ(error, 0);
+	}
 
-    static void TearDownTestCase() {
-        _free_fake_graph_context();
-        GrB_finalize();
-    }
+	static void TearDownTestCase() {
+		_free_fake_graph_context();
+		GrB_finalize();
+	}
 
-    void SetUp() {
-        qg = QueryGraph_New(16, 16);
-    }
+	void SetUp() {
+		qg = QueryGraph_New(16, 16);
+	}
 
-    void TearDown() {
-        QueryGraph_Free(qg);
-    }
+	void TearDown() {
+		QueryGraph_Free(qg);
+	}
 
-    static void _fake_graph_context() {
-        GraphContext *gc = (GraphContext*)malloc(sizeof(GraphContext));
+	static void _fake_graph_context() {
+		GraphContext *gc = (GraphContext *)malloc(sizeof(GraphContext));
 
-        gc->g = Graph_New(16, 16);
-        gc->index_count = 0;
-        gc->graph_name = strdup("G");
-        gc->attributes = raxNew();
-        gc->string_mapping = (char**)array_new(char*, 64);
-        gc->node_schemas = (Schema**)array_new(Schema*, GRAPH_DEFAULT_LABEL_CAP);
-        gc->relation_schemas = (Schema**)array_new(Schema*, GRAPH_DEFAULT_RELATION_TYPE_CAP);
+		gc->g = Graph_New(16, 16);
+		gc->index_count = 0;
+		gc->graph_name = strdup("G");
+		gc->attributes = raxNew();
+		gc->string_mapping = (char **)array_new(char *, 64);
+		gc->node_schemas = (Schema **)array_new(Schema *, GRAPH_DEFAULT_LABEL_CAP);
+		gc->relation_schemas = (Schema **)array_new(Schema *, GRAPH_DEFAULT_RELATION_TYPE_CAP);
 
-        GraphContext_AddSchema(gc, "Person", SCHEMA_NODE);
-        GraphContext_AddSchema(gc, "City", SCHEMA_NODE);
-        GraphContext_AddSchema(gc, "friend", SCHEMA_EDGE);
-        GraphContext_AddSchema(gc, "visit", SCHEMA_EDGE);
-        GraphContext_AddSchema(gc, "war", SCHEMA_EDGE);
+		GraphContext_AddSchema(gc, "Person", SCHEMA_NODE);
+		GraphContext_AddSchema(gc, "City", SCHEMA_NODE);
+		GraphContext_AddSchema(gc, "friend", SCHEMA_EDGE);
+		GraphContext_AddSchema(gc, "visit", SCHEMA_EDGE);
+		GraphContext_AddSchema(gc, "war", SCHEMA_EDGE);
 
-        int error = pthread_key_create(&_tlsGCKey, NULL);
-        ASSERT_EQ(error, 0);
-        pthread_setspecific(_tlsGCKey, gc);
-    }
+		int error = pthread_key_create(&_tlsGCKey, NULL);
+		ASSERT_EQ(error, 0);
+		pthread_setspecific(_tlsGCKey, gc);
+	}
 
-    /* Create a graph containing:
-     * Entities: 'people' and 'countries'.
-     * Relations: 'friend', 'visit' and 'war'. */
-    static void _build_graph() {
-        GraphContext *gc = GraphContext_GetFromTLS();
+	/* Create a graph containing:
+	 * Entities: 'people' and 'countries'.
+	 * Relations: 'friend', 'visit' and 'war'. */
+	static void _build_graph() {
+		GraphContext *gc = GraphContext_GetFromTLS();
 
-        Node n;
-        Graph *g = gc->g;
-        Graph_AcquireWriteLock(g);
+		Node n;
+		Graph *g = gc->g;
+		Graph_AcquireWriteLock(g);
 
-        size_t city_count = 2;
-        size_t person_count = 2;
-        size_t node_count = person_count + city_count;
+		size_t city_count = 2;
+		size_t person_count = 2;
+		size_t node_count = person_count + city_count;
 
-        // Introduce person and country labels.
-        int city_label = GraphContext_GetSchema(gc, "City", SCHEMA_NODE)->id;
-        int person_label = GraphContext_GetSchema(gc, "Person", SCHEMA_NODE)->id;
-        Graph_AllocateNodes(g, node_count);
+		// Introduce person and country labels.
+		int city_label = GraphContext_GetSchema(gc, "City", SCHEMA_NODE)->id;
+		int person_label = GraphContext_GetSchema(gc, "Person", SCHEMA_NODE)->id;
+		Graph_AllocateNodes(g, node_count);
 
-        for(int i = 0; i < person_count; i++) {
-            Graph_CreateNode(g, person_label, &n);
-        }
+		for(int i = 0; i < person_count; i++) {
+			Graph_CreateNode(g, person_label, &n);
+		}
 
-        for(int i = 0; i < city_count; i++) {
-            Graph_CreateNode(g, city_label, &n);
-        }
+		for(int i = 0; i < city_count; i++) {
+			Graph_CreateNode(g, city_label, &n);
+		}
 
-        // Creates a relation matrices.
-        GrB_Index war_relation_id = GraphContext_GetSchema(gc, "war", SCHEMA_EDGE)->id;
-        GrB_Index visit_relation_id = GraphContext_GetSchema(gc, "visit", SCHEMA_EDGE)->id;
-        GrB_Index friend_relation_id = GraphContext_GetSchema(gc, "friend", SCHEMA_EDGE)->id;
+		// Creates a relation matrices.
+		GrB_Index war_relation_id = GraphContext_GetSchema(gc, "war", SCHEMA_EDGE)->id;
+		GrB_Index visit_relation_id = GraphContext_GetSchema(gc, "visit", SCHEMA_EDGE)->id;
+		GrB_Index friend_relation_id = GraphContext_GetSchema(gc, "friend", SCHEMA_EDGE)->id;
 
-        // Introduce relations, connect nodes.
-        Edge e;
-        Graph_ConnectNodes(g, 0, 1, friend_relation_id, &e);
-        Graph_ConnectNodes(g, 1, 0, friend_relation_id, &e);
+		// Introduce relations, connect nodes.
+		Edge e;
+		Graph_ConnectNodes(g, 0, 1, friend_relation_id, &e);
+		Graph_ConnectNodes(g, 1, 0, friend_relation_id, &e);
 
-        Graph_ConnectNodes(g, 0, 2, visit_relation_id, &e);
-        Graph_ConnectNodes(g, 0, 3, visit_relation_id, &e);
-        Graph_ConnectNodes(g, 1, 2, visit_relation_id, &e);        
+		Graph_ConnectNodes(g, 0, 2, visit_relation_id, &e);
+		Graph_ConnectNodes(g, 0, 3, visit_relation_id, &e);
+		Graph_ConnectNodes(g, 1, 2, visit_relation_id, &e);
 
-        Graph_ConnectNodes(g, 2, 3, war_relation_id, &e);
-        Graph_ConnectNodes(g, 3, 2, war_relation_id, &e);
+		Graph_ConnectNodes(g, 2, 3, war_relation_id, &e);
+		Graph_ConnectNodes(g, 3, 2, war_relation_id, &e);
 
-        Graph_ReleaseLock(g);
-    }
+		Graph_ReleaseLock(g);
+	}
 
-    static void _bind_matrices() {
-        int mat_id;
-        GraphContext *gc = GraphContext_GetFromTLS();
-        Graph *g = gc->g;
+	static void _bind_matrices() {
+		int mat_id;
+		GraphContext *gc = GraphContext_GetFromTLS();
+		Graph *g = gc->g;
 
-        mat_id = GraphContext_GetSchema(gc, "Person", SCHEMA_NODE)->id;        
-        mat_p = Graph_GetLabelMatrix(g, mat_id);
-        mat_f = Graph_GetLabelMatrix(g, mat_id);
-        
-        mat_id = GraphContext_GetSchema(gc, "City", SCHEMA_NODE)->id;
-        mat_c = Graph_GetLabelMatrix(g, mat_id);
-        mat_e = Graph_GetLabelMatrix(g, mat_id);
-        
-        mat_id = GraphContext_GetSchema(gc, "friend", SCHEMA_EDGE)->id;
-        mat_ef = Graph_GetRelationMatrix(g, mat_id);
+		mat_id = GraphContext_GetSchema(gc, "Person", SCHEMA_NODE)->id;
+		mat_p = Graph_GetLabelMatrix(g, mat_id);
+		mat_f = Graph_GetLabelMatrix(g, mat_id);
 
-        mat_id = GraphContext_GetSchema(gc, "visit", SCHEMA_EDGE)->id;
-        mat_ev = Graph_GetRelationMatrix(g, mat_id);
-        
-        mat_id = GraphContext_GetSchema(gc, "war", SCHEMA_EDGE)->id;
-        mat_ew = Graph_GetRelationMatrix(g, mat_id);
-    }
+		mat_id = GraphContext_GetSchema(gc, "City", SCHEMA_NODE)->id;
+		mat_c = Graph_GetLabelMatrix(g, mat_id);
+		mat_e = Graph_GetLabelMatrix(g, mat_id);
 
-    static void _free_fake_graph_context() {
-        GraphContext *gc = GraphContext_GetFromTLS();
-        GraphContext_Free(gc);
-    }
+		mat_id = GraphContext_GetSchema(gc, "friend", SCHEMA_EDGE)->id;
+		mat_ef = Graph_GetRelationMatrix(g, mat_id);
 
-    AlgebraicExpression **build_algebraic_expression(const char *query, size_t *exp_count) {
-        GraphContext *gc = GraphContext_GetFromTLS();
-        cypher_parse_result_t *parse_result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
-        AST *ast = AST_Build(parse_result);
-        QueryGraph *qg = BuildQueryGraph(gc, ast);
-        RecordMap *map = RecordMap_New();
-        _BuildReturnExpressions(map, AST_GetClause(ast, CYPHER_AST_RETURN));
-        AlgebraicExpression **ae = AlgebraicExpression_FromQueryGraph(qg, map, exp_count);
+		mat_id = GraphContext_GetSchema(gc, "visit", SCHEMA_EDGE)->id;
+		mat_ev = Graph_GetRelationMatrix(g, mat_id);
 
-        return ae;
-    }
+		mat_id = GraphContext_GetSchema(gc, "war", SCHEMA_EDGE)->id;
+		mat_ew = Graph_GetRelationMatrix(g, mat_id);
+	}
 
-    void _print_matrix(GrB_Matrix mat) {
-        GrB_Index ncols, nrows, nvals;
-        GrB_Matrix_ncols(&ncols, mat);
-        GrB_Matrix_nrows(&nrows, mat);
-        GrB_Matrix_nvals(&nvals, mat);
-        printf("ncols: %llu, nrows: %llu, nvals: %llu\n", ncols, nrows, nvals);
+	static void _free_fake_graph_context() {
+		GraphContext *gc = GraphContext_GetFromTLS();
+		GraphContext_Free(gc);
+	}
 
-        GrB_Index I[nvals];     // array for returning row indices of tuples
-        GrB_Index J[nvals];     // array for returning col indices of tuples
-        bool X[nvals];          // array for returning values of tuples
+	AlgebraicExpression **build_algebraic_expression(const char *query, size_t *exp_count) {
+		GraphContext *gc = GraphContext_GetFromTLS();
+		cypher_parse_result_t *parse_result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
+		AST *ast = AST_Build(parse_result);
+		QueryGraph *qg = BuildQueryGraph(gc, ast);
+		RecordMap *map = RecordMap_New();
+		_BuildReturnExpressions(map, AST_GetClause(ast, CYPHER_AST_RETURN));
+		AlgebraicExpression **ae = AlgebraicExpression_FromQueryGraph(qg, map, exp_count);
 
-        GrB_Matrix_extractTuples_BOOL(I, J, X, &nvals, mat);
-        for(int i = 0; i < nvals; i++) {
-            printf("[%llu,%llu,%d]\n", I[i], J[i], X[i]);
-        }
-    }
+		return ae;
+	}
 
-    bool _compare_matrices(GrB_Matrix a, GrB_Matrix b) {
-        GrB_Index acols, arows, avals;
-        GrB_Index bcols, brows, bvals;
-        
-        GrB_Matrix_ncols(&acols, a);
-        GrB_Matrix_nrows(&arows, a);
-        GrB_Matrix_nvals(&avals, a);
-        GrB_Matrix_ncols(&bcols, b);
-        GrB_Matrix_nrows(&brows, b);
-        GrB_Matrix_nvals(&bvals, b);
+	void _print_matrix(GrB_Matrix mat) {
+		GrB_Index ncols, nrows, nvals;
+		GrB_Matrix_ncols(&ncols, mat);
+		GrB_Matrix_nrows(&nrows, mat);
+		GrB_Matrix_nvals(&nvals, mat);
+		printf("ncols: %llu, nrows: %llu, nvals: %llu\n", ncols, nrows, nvals);
 
-        if (acols != bcols || arows != brows || avals != bvals) {
-            printf("acols: %llu bcols: %llu", acols, bcols);
-            printf("arows: %llu brows: %llu", arows, brows);
-            printf("avals: %llu bvals: %llu", avals, bvals);
-            return false;
-        }
+		GrB_Index I[nvals];     // array for returning row indices of tuples
+		GrB_Index J[nvals];     // array for returning col indices of tuples
+		bool X[nvals];          // array for returning values of tuples
 
-        GrB_Index aI[avals];     // array for returning row indices of tuples
-        GrB_Index aJ[avals];     // array for returning col indices of tuples
-        bool aX[avals];          // array for returning values of tuples
-        GrB_Index bI[bvals];     // array for returning row indices of tuples
-        GrB_Index bJ[bvals];     // array for returning col indices of tuples
-        bool bX[bvals];          // array for returning values of tuples
+		GrB_Matrix_extractTuples_BOOL(I, J, X, &nvals, mat);
+		for(int i = 0; i < nvals; i++) {
+			printf("[%llu,%llu,%d]\n", I[i], J[i], X[i]);
+		}
+	}
 
-        GrB_Matrix_extractTuples_BOOL(aI, aJ, aX, &avals, a);
-        GrB_Matrix_extractTuples_BOOL(bI, bJ, bX, &bvals, b);
+	bool _compare_matrices(GrB_Matrix a, GrB_Matrix b) {
+		GrB_Index acols, arows, avals;
+		GrB_Index bcols, brows, bvals;
 
-        for(int i = 0; i < avals; i++) {
-            if(aI[i] != bI[i] || aJ[i] != bJ[i] || aX[i] != bX[i]) {
-                printf("Matrix A \n");
-                _print_matrix(a);
-                printf("\n\n");
-                printf("Matrix B \n");
-                _print_matrix(b);
-                printf("\n\n");
-                return false;
-            }
-        }
+		GrB_Matrix_ncols(&acols, a);
+		GrB_Matrix_nrows(&arows, a);
+		GrB_Matrix_nvals(&avals, a);
+		GrB_Matrix_ncols(&bcols, b);
+		GrB_Matrix_nrows(&brows, b);
+		GrB_Matrix_nvals(&bvals, b);
 
-        return true;
-    }
+		if(acols != bcols || arows != brows || avals != bvals) {
+			printf("acols: %llu bcols: %llu", acols, bcols);
+			printf("arows: %llu brows: %llu", arows, brows);
+			printf("avals: %llu bvals: %llu", avals, bvals);
+			return false;
+		}
 
-    void _compare_algebraic_operand(AlgebraicExpressionOperand *a, AlgebraicExpressionOperand *b) {
-        ASSERT_EQ(a->free, b->free);
-        ASSERT_EQ(a->operand, b->operand);
-        ASSERT_EQ(a->diagonal, b->diagonal);
-        ASSERT_EQ(a->transpose, b->transpose);
-    }
+		GrB_Index aI[avals];     // array for returning row indices of tuples
+		GrB_Index aJ[avals];     // array for returning col indices of tuples
+		bool aX[avals];          // array for returning values of tuples
+		GrB_Index bI[bvals];     // array for returning row indices of tuples
+		GrB_Index bJ[bvals];     // array for returning col indices of tuples
+		bool bX[bvals];          // array for returning values of tuples
 
-    void _compare_algebraic_expression(AlgebraicExpression *a, AlgebraicExpression *b) {
-        ASSERT_EQ(a->operand_count, b->operand_count);
-        for(uint i = 0; i < a->operand_count; i++) {
-            _compare_algebraic_operand(a->operands + i, b->operands + i);
-        }
-    }
+		GrB_Matrix_extractTuples_BOOL(aI, aJ, aX, &avals, a);
+		GrB_Matrix_extractTuples_BOOL(bI, bJ, bX, &bvals, b);
 
-    void compare_algebraic_expressions(AlgebraicExpression **actual, AlgebraicExpression **expected, uint count) {
-        for(uint i = 0; i < count; i++) {
-            _compare_algebraic_expression(actual[i], expected[i]);
-        }
-    }
+		for(int i = 0; i < avals; i++) {
+			if(aI[i] != bI[i] || aJ[i] != bJ[i] || aX[i] != bX[i]) {
+				printf("Matrix A \n");
+				_print_matrix(a);
+				printf("\n\n");
+				printf("Matrix B \n");
+				_print_matrix(b);
+				printf("\n\n");
+				return false;
+			}
+		}
 
-    void free_algebraic_expressions(AlgebraicExpression **exps, uint count) {
-        for(uint i = 0; i < count; i++) {
-            AlgebraicExpression *exp = exps[i];
-            AlgebraicExpression_Free(exp);
-        }
-    }
+		return true;
+	}
+
+	void _compare_algebraic_operand(AlgebraicExpressionOperand *a, AlgebraicExpressionOperand *b) {
+		ASSERT_EQ(a->free, b->free);
+		ASSERT_EQ(a->operand, b->operand);
+		ASSERT_EQ(a->diagonal, b->diagonal);
+		ASSERT_EQ(a->transpose, b->transpose);
+	}
+
+	void _compare_algebraic_expression(AlgebraicExpression *a, AlgebraicExpression *b) {
+		ASSERT_EQ(a->operand_count, b->operand_count);
+		for(uint i = 0; i < a->operand_count; i++) {
+			_compare_algebraic_operand(a->operands + i, b->operands + i);
+		}
+	}
+
+	void compare_algebraic_expressions(AlgebraicExpression **actual, AlgebraicExpression **expected,
+									   uint count) {
+		for(uint i = 0; i < count; i++) {
+			_compare_algebraic_expression(actual[i], expected[i]);
+		}
+	}
+
+	void free_algebraic_expressions(AlgebraicExpression **exps, uint count) {
+		for(uint i = 0; i < count; i++) {
+			AlgebraicExpression *exp = exps[i];
+			AlgebraicExpression_Free(exp);
+		}
+	}
 };
 
 TEST_F(AlgebraicExpressionTest, Exp_OP_ADD) {
-    // Exp = A + B
-    GrB_Matrix A;
-    GrB_Matrix B;
-    GrB_Matrix C;
-    GrB_Matrix res;
+	// Exp = A + B
+	GrB_Matrix A;
+	GrB_Matrix B;
+	GrB_Matrix C;
+	GrB_Matrix res;
 
-    // A
-    // 1 1
-    // 0 0
-    GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(A, true, 0, 0);
-    GrB_Matrix_setElement_BOOL(A, true, 0, 1);
+	// A
+	// 1 1
+	// 0 0
+	GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(A, true, 0, 0);
+	GrB_Matrix_setElement_BOOL(A, true, 0, 1);
 
-    // B
-    // 0 1
-    // 1 1
-    GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(B, true, 0, 1);
-    GrB_Matrix_setElement_BOOL(B, true, 1, 0);
-    GrB_Matrix_setElement_BOOL(B, true, 1, 1);
+	// B
+	// 0 1
+	// 1 1
+	GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(B, true, 0, 1);
+	GrB_Matrix_setElement_BOOL(B, true, 1, 0);
+	GrB_Matrix_setElement_BOOL(B, true, 1, 1);
 
-    // C
-    // 1 1
-    // 1 1
-    GrB_Matrix_new(&C, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(C, true, 0, 0);
-    GrB_Matrix_setElement_BOOL(C, true, 0, 1);
-    GrB_Matrix_setElement_BOOL(C, true, 1, 0);
-    GrB_Matrix_setElement_BOOL(C, true, 1, 1);
+	// C
+	// 1 1
+	// 1 1
+	GrB_Matrix_new(&C, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(C, true, 0, 0);
+	GrB_Matrix_setElement_BOOL(C, true, 0, 1);
+	GrB_Matrix_setElement_BOOL(C, true, 1, 0);
+	GrB_Matrix_setElement_BOOL(C, true, 1, 1);
 
-    // Matrix used for intermidate computations of AlgebraicExpression_Eval
-    // but also contains the result of expression evaluation.
-    GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
-    
-    // A + B
-    AlgebraicExpressionNode *exp = AlgebraicExpressionNode_NewOperationNode(AL_EXP_ADD);
-    AlgebraicExpressionNode *a = AlgebraicExpressionNode_NewOperandNode(A);
-    AlgebraicExpressionNode *b = AlgebraicExpressionNode_NewOperandNode(B);
-    AlgebraicExpressionNode_AppendLeftChild(exp, a);
-    AlgebraicExpressionNode_AppendRightChild(exp, b);
+	// Matrix used for intermidate computations of AlgebraicExpression_Eval
+	// but also contains the result of expression evaluation.
+	GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
 
-    AlgebraicExpression_SumOfMul(&exp);
-    AlgebraicExpression_Eval(exp, res);
+	// A + B
+	AlgebraicExpressionNode *exp = AlgebraicExpressionNode_NewOperationNode(AL_EXP_ADD);
+	AlgebraicExpressionNode *a = AlgebraicExpressionNode_NewOperandNode(A);
+	AlgebraicExpressionNode *b = AlgebraicExpressionNode_NewOperandNode(B);
+	AlgebraicExpressionNode_AppendLeftChild(exp, a);
+	AlgebraicExpressionNode_AppendRightChild(exp, b);
 
-    // Using the A matrix described above,
-    // A + B = C.
-    ASSERT_TRUE(_compare_matrices(res, C));
+	AlgebraicExpression_SumOfMul(&exp);
+	AlgebraicExpression_Eval(exp, res);
 
-    GrB_Matrix_free(&A);
-    GrB_Matrix_free(&B);
-    GrB_Matrix_free(&C);
-    GrB_Matrix_free(&res);
-    AlgebraicExpressionNode_Free(exp);
+	// Using the A matrix described above,
+	// A + B = C.
+	ASSERT_TRUE(_compare_matrices(res, C));
+
+	GrB_Matrix_free(&A);
+	GrB_Matrix_free(&B);
+	GrB_Matrix_free(&C);
+	GrB_Matrix_free(&res);
+	AlgebraicExpressionNode_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, Exp_OP_MUL) {
-    // Exp = A * I
-    GrB_Matrix A;
-    GrB_Matrix I;
-    
-    // A
-    // 1 1
-    // 0 0
-    GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(A, true, 0, 0);
-    GrB_Matrix_setElement_BOOL(A, true, 0, 1);
+	// Exp = A * I
+	GrB_Matrix A;
+	GrB_Matrix I;
 
-    // I
-    // 1 0
-    // 0 1
-    GrB_Matrix_new(&I, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(I, true, 0, 0);
-    GrB_Matrix_setElement_BOOL(I, true, 1, 1);
-    GrB_Matrix res;
+	// A
+	// 1 1
+	// 0 0
+	GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(A, true, 0, 0);
+	GrB_Matrix_setElement_BOOL(A, true, 0, 1);
 
-    // Matrix used for intermidate computations of AlgebraicExpression_Eval
-    // but also contains the result of expression evaluation.
-    GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
-    
-    // A * I
-    AlgebraicExpressionNode *exp = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
-    AlgebraicExpressionNode *a = AlgebraicExpressionNode_NewOperandNode(A);
-    AlgebraicExpressionNode *i = AlgebraicExpressionNode_NewOperandNode(I);
-    AlgebraicExpressionNode_AppendLeftChild(exp, a);
-    AlgebraicExpressionNode_AppendRightChild(exp, i);
+	// I
+	// 1 0
+	// 0 1
+	GrB_Matrix_new(&I, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(I, true, 0, 0);
+	GrB_Matrix_setElement_BOOL(I, true, 1, 1);
+	GrB_Matrix res;
 
-    AlgebraicExpression_SumOfMul(&exp);
-    AlgebraicExpression_Eval(exp, res);
+	// Matrix used for intermidate computations of AlgebraicExpression_Eval
+	// but also contains the result of expression evaluation.
+	GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
 
-    // Using the A matrix described above,
-    // A * I = A.
-    ASSERT_TRUE(_compare_matrices(res, A));
+	// A * I
+	AlgebraicExpressionNode *exp = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
+	AlgebraicExpressionNode *a = AlgebraicExpressionNode_NewOperandNode(A);
+	AlgebraicExpressionNode *i = AlgebraicExpressionNode_NewOperandNode(I);
+	AlgebraicExpressionNode_AppendLeftChild(exp, a);
+	AlgebraicExpressionNode_AppendRightChild(exp, i);
 
-    GrB_Matrix_free(&A);    
-    GrB_Matrix_free(&I);
-    GrB_Matrix_free(&res);
-    AlgebraicExpressionNode_Free(exp);
+	AlgebraicExpression_SumOfMul(&exp);
+	AlgebraicExpression_Eval(exp, res);
+
+	// Using the A matrix described above,
+	// A * I = A.
+	ASSERT_TRUE(_compare_matrices(res, A));
+
+	GrB_Matrix_free(&A);
+	GrB_Matrix_free(&I);
+	GrB_Matrix_free(&res);
+	AlgebraicExpressionNode_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, Exp_OP_ADD_Transpose) {
-    // Exp = A + Transpose(A)
-    GrB_Matrix A;
-    GrB_Matrix B;
-    GrB_Matrix res;
+	// Exp = A + Transpose(A)
+	GrB_Matrix A;
+	GrB_Matrix B;
+	GrB_Matrix res;
 
-    // A
-    // 1 1
-    // 0 0
-    GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(A, true, 0, 0);
-    GrB_Matrix_setElement_BOOL(A, true, 0, 1);
+	// A
+	// 1 1
+	// 0 0
+	GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(A, true, 0, 0);
+	GrB_Matrix_setElement_BOOL(A, true, 0, 1);
 
-    // B
-    // 1 0
-    // 1 0
-    GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(B, true, 0, 0);
-    GrB_Matrix_setElement_BOOL(B, true, 1, 0);
+	// B
+	// 1 0
+	// 1 0
+	GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(B, true, 0, 0);
+	GrB_Matrix_setElement_BOOL(B, true, 1, 0);
 
-    // Matrix used for intermidate computations of AlgebraicExpression_Eval
-    // but also contains the result of expression evaluation.
-    GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
-    
-    // A + Transpose(A)
-    AlgebraicExpressionNode *exp = AlgebraicExpressionNode_NewOperationNode(AL_EXP_ADD);
-    AlgebraicExpressionNode *transpose = AlgebraicExpressionNode_NewOperationNode(AL_EXP_TRANSPOSE);
-    AlgebraicExpressionNode *a = AlgebraicExpressionNode_NewOperandNode(A);
-    AlgebraicExpressionNode *b = AlgebraicExpressionNode_NewOperandNode(B);
-    
-    AlgebraicExpressionNode_AppendLeftChild(exp, transpose);
-    AlgebraicExpressionNode_AppendLeftChild(transpose, a);
-    AlgebraicExpressionNode_AppendRightChild(exp, b);
+	// Matrix used for intermidate computations of AlgebraicExpression_Eval
+	// but also contains the result of expression evaluation.
+	GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
 
-    AlgebraicExpression_SumOfMul(&exp);
-    AlgebraicExpression_Eval(exp, res);
+	// A + Transpose(A)
+	AlgebraicExpressionNode *exp = AlgebraicExpressionNode_NewOperationNode(AL_EXP_ADD);
+	AlgebraicExpressionNode *transpose = AlgebraicExpressionNode_NewOperationNode(AL_EXP_TRANSPOSE);
+	AlgebraicExpressionNode *a = AlgebraicExpressionNode_NewOperandNode(A);
+	AlgebraicExpressionNode *b = AlgebraicExpressionNode_NewOperandNode(B);
 
-    // Using the A matrix described above,
-    // A + Transpose(A) = B.
-    ASSERT_TRUE(_compare_matrices(res, B));
+	AlgebraicExpressionNode_AppendLeftChild(exp, transpose);
+	AlgebraicExpressionNode_AppendLeftChild(transpose, a);
+	AlgebraicExpressionNode_AppendRightChild(exp, b);
 
-    GrB_Matrix_free(&A);
-    GrB_Matrix_free(&B);
-    GrB_Matrix_free(&res);
-    AlgebraicExpressionNode_Free(exp);
+	AlgebraicExpression_SumOfMul(&exp);
+	AlgebraicExpression_Eval(exp, res);
+
+	// Using the A matrix described above,
+	// A + Transpose(A) = B.
+	ASSERT_TRUE(_compare_matrices(res, B));
+
+	GrB_Matrix_free(&A);
+	GrB_Matrix_free(&B);
+	GrB_Matrix_free(&res);
+	AlgebraicExpressionNode_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, Exp_OP_MUL_Transpose) {
-    // Exp = Transpose(A) * A
-    GrB_Matrix A;
-    GrB_Matrix B;
-    GrB_Matrix res;
+	// Exp = Transpose(A) * A
+	GrB_Matrix A;
+	GrB_Matrix B;
+	GrB_Matrix res;
 
-    // A
-    // 1 1
-    // 0 0
-    GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(A, true, 0, 0);
-    GrB_Matrix_setElement_BOOL(A, true, 0, 1);
+	// A
+	// 1 1
+	// 0 0
+	GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(A, true, 0, 0);
+	GrB_Matrix_setElement_BOOL(A, true, 0, 1);
 
-    // B
-    // 1 1
-    // 1 1
-    GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(B, true, 0, 0);
-    GrB_Matrix_setElement_BOOL(B, true, 0, 1);
-    GrB_Matrix_setElement_BOOL(B, true, 1, 0);
-    GrB_Matrix_setElement_BOOL(B, true, 1, 1);
+	// B
+	// 1 1
+	// 1 1
+	GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(B, true, 0, 0);
+	GrB_Matrix_setElement_BOOL(B, true, 0, 1);
+	GrB_Matrix_setElement_BOOL(B, true, 1, 0);
+	GrB_Matrix_setElement_BOOL(B, true, 1, 1);
 
-    // Matrix used for intermidate computations of AlgebraicExpression_Eval
-    // but also contains the result of expression evaluation.
-    GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
-    
-    // Transpose(A) * A
-    AlgebraicExpressionNode *exp = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
-    AlgebraicExpressionNode *transpose = AlgebraicExpressionNode_NewOperationNode(AL_EXP_TRANSPOSE);
-    AlgebraicExpressionNode *a = AlgebraicExpressionNode_NewOperandNode(A);
-    
-    AlgebraicExpressionNode_AppendLeftChild(exp, transpose);
-    AlgebraicExpressionNode_AppendRightChild(transpose, a);
-    AlgebraicExpressionNode_AppendRightChild(exp, a);
+	// Matrix used for intermidate computations of AlgebraicExpression_Eval
+	// but also contains the result of expression evaluation.
+	GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
 
-    AlgebraicExpression_SumOfMul(&exp);
-    AlgebraicExpression_Eval(exp, res);
+	// Transpose(A) * A
+	AlgebraicExpressionNode *exp = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
+	AlgebraicExpressionNode *transpose = AlgebraicExpressionNode_NewOperationNode(AL_EXP_TRANSPOSE);
+	AlgebraicExpressionNode *a = AlgebraicExpressionNode_NewOperandNode(A);
 
-    // Using the A matrix described above,
-    // Transpose(A) * A = B.
-    ASSERT_TRUE(_compare_matrices(res, B));
+	AlgebraicExpressionNode_AppendLeftChild(exp, transpose);
+	AlgebraicExpressionNode_AppendRightChild(transpose, a);
+	AlgebraicExpressionNode_AppendRightChild(exp, a);
 
-    GrB_Matrix_free(&A);
-    GrB_Matrix_free(&B);
-    GrB_Matrix_free(&res);
-    AlgebraicExpressionNode_Free(exp);
+	AlgebraicExpression_SumOfMul(&exp);
+	AlgebraicExpression_Eval(exp, res);
+
+	// Using the A matrix described above,
+	// Transpose(A) * A = B.
+	ASSERT_TRUE(_compare_matrices(res, B));
+
+	GrB_Matrix_free(&A);
+	GrB_Matrix_free(&B);
+	GrB_Matrix_free(&res);
+	AlgebraicExpressionNode_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, Exp_OP_A_MUL_B_Plus_C) {
-    // Exp = A*(B+C)
-    GrB_Matrix A;
-    GrB_Matrix B;
-    GrB_Matrix C;
-    GrB_Matrix res;
+	// Exp = A*(B+C)
+	GrB_Matrix A;
+	GrB_Matrix B;
+	GrB_Matrix C;
+	GrB_Matrix res;
 
-    // A
-    // 1 1
-    // 0 0
-    GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(A, true, 0, 0);
-    GrB_Matrix_setElement_BOOL(A, true, 0, 1);
+	// A
+	// 1 1
+	// 0 0
+	GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(A, true, 0, 0);
+	GrB_Matrix_setElement_BOOL(A, true, 0, 1);
 
-    // B
-    // 1 0
-    // 0 0
-    GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(B, true, 0, 0);
+	// B
+	// 1 0
+	// 0 0
+	GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(B, true, 0, 0);
 
-    // C
-    // 0 0
-    // 0 1
-    GrB_Matrix_new(&C, GrB_BOOL, 2, 2);
-    GrB_Matrix_setElement_BOOL(C, true, 1, 1);
+	// C
+	// 0 0
+	// 0 1
+	GrB_Matrix_new(&C, GrB_BOOL, 2, 2);
+	GrB_Matrix_setElement_BOOL(C, true, 1, 1);
 
-    // Matrix used for intermidate computations of AlgebraicExpression_Eval
-    // but also contains the result of expression evaluation.
-    GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
-    
-    // A * (B+C) = A.
-    AlgebraicExpressionNode *exp = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
-    AlgebraicExpressionNode *add = AlgebraicExpressionNode_NewOperationNode(AL_EXP_ADD);
-    AlgebraicExpressionNode *a = AlgebraicExpressionNode_NewOperandNode(A);
-    AlgebraicExpressionNode *b = AlgebraicExpressionNode_NewOperandNode(B);
-    AlgebraicExpressionNode *c = AlgebraicExpressionNode_NewOperandNode(C);
-    
-    AlgebraicExpressionNode_AppendLeftChild(exp, a);
-    AlgebraicExpressionNode_AppendRightChild(exp, add);
-    AlgebraicExpressionNode_AppendLeftChild(add, b);
-    AlgebraicExpressionNode_AppendRightChild(add, c);
+	// Matrix used for intermidate computations of AlgebraicExpression_Eval
+	// but also contains the result of expression evaluation.
+	GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
 
-    // AB + AC.
-    AlgebraicExpression_SumOfMul(&exp);
-    AlgebraicExpression_Eval(exp, res);
-    ASSERT_TRUE(_compare_matrices(res, A));
+	// A * (B+C) = A.
+	AlgebraicExpressionNode *exp = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
+	AlgebraicExpressionNode *add = AlgebraicExpressionNode_NewOperationNode(AL_EXP_ADD);
+	AlgebraicExpressionNode *a = AlgebraicExpressionNode_NewOperandNode(A);
+	AlgebraicExpressionNode *b = AlgebraicExpressionNode_NewOperandNode(B);
+	AlgebraicExpressionNode *c = AlgebraicExpressionNode_NewOperandNode(C);
 
-    GrB_Matrix_free(&A);
-    GrB_Matrix_free(&B);
-    GrB_Matrix_free(&C);
-    GrB_Matrix_free(&res);
-    AlgebraicExpressionNode_Free(exp);
+	AlgebraicExpressionNode_AppendLeftChild(exp, a);
+	AlgebraicExpressionNode_AppendRightChild(exp, add);
+	AlgebraicExpressionNode_AppendLeftChild(add, b);
+	AlgebraicExpressionNode_AppendRightChild(add, c);
+
+	// AB + AC.
+	AlgebraicExpression_SumOfMul(&exp);
+	AlgebraicExpression_Eval(exp, res);
+	ASSERT_TRUE(_compare_matrices(res, A));
+
+	GrB_Matrix_free(&A);
+	GrB_Matrix_free(&B);
+	GrB_Matrix_free(&C);
+	GrB_Matrix_free(&res);
+	AlgebraicExpressionNode_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, ExpTransform_A_Times_B_Plus_C) {
-    // Test Mul / Add transformation:
-    // A*(B+C) -> A*B + A*C
-    AlgebraicExpressionNode *root = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
-    AlgebraicExpressionNode *add = AlgebraicExpressionNode_NewOperationNode(AL_EXP_ADD);
+	// Test Mul / Add transformation:
+	// A*(B+C) -> A*B + A*C
+	AlgebraicExpressionNode *root = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
+	AlgebraicExpressionNode *add = AlgebraicExpressionNode_NewOperationNode(AL_EXP_ADD);
 
-    GrB_Matrix A;
-    GrB_Matrix B;    
-    GrB_Matrix C;
-    
-    GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
-    GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
-    GrB_Matrix_new(&C, GrB_BOOL, 2, 2);
+	GrB_Matrix A;
+	GrB_Matrix B;
+	GrB_Matrix C;
 
-    AlgebraicExpressionNode *aExp = AlgebraicExpressionNode_NewOperandNode(A);
-    AlgebraicExpressionNode *bExp = AlgebraicExpressionNode_NewOperandNode(B);
-    AlgebraicExpressionNode *cExp = AlgebraicExpressionNode_NewOperandNode(C);
-    
-    // A*(B+C)
-    AlgebraicExpressionNode_AppendLeftChild(root, aExp);
-    AlgebraicExpressionNode_AppendRightChild(root, add);
-    AlgebraicExpressionNode_AppendLeftChild(add, bExp);
-    AlgebraicExpressionNode_AppendRightChild(add, cExp);
+	GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
+	GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
+	GrB_Matrix_new(&C, GrB_BOOL, 2, 2);
 
-    AlgebraicExpression_SumOfMul(&root);
+	AlgebraicExpressionNode *aExp = AlgebraicExpressionNode_NewOperandNode(A);
+	AlgebraicExpressionNode *bExp = AlgebraicExpressionNode_NewOperandNode(B);
+	AlgebraicExpressionNode *cExp = AlgebraicExpressionNode_NewOperandNode(C);
 
-    // Verifications
-    // (A*B)+(A*C)
-    ASSERT_TRUE(root->type == AL_OPERATION && root->operation.op == AL_EXP_ADD);
+	// A*(B+C)
+	AlgebraicExpressionNode_AppendLeftChild(root, aExp);
+	AlgebraicExpressionNode_AppendRightChild(root, add);
+	AlgebraicExpressionNode_AppendLeftChild(add, bExp);
+	AlgebraicExpressionNode_AppendRightChild(add, cExp);
 
-    AlgebraicExpressionNode *rootLeftChild = root->operation.l;
-    AlgebraicExpressionNode *rootRightChild = root->operation.r;
-    ASSERT_TRUE(rootLeftChild && rootLeftChild->type == AL_OPERATION && rootLeftChild->operation.op == AL_EXP_MUL);
-    ASSERT_TRUE(rootRightChild && rootRightChild->type == AL_OPERATION && rootRightChild->operation.op == AL_EXP_MUL);
+	AlgebraicExpression_SumOfMul(&root);
 
-    AlgebraicExpressionNode *leftLeft = rootLeftChild->operation.l;
-    ASSERT_TRUE(leftLeft->type == AL_OPERAND && leftLeft->operand == A);
+	// Verifications
+	// (A*B)+(A*C)
+	ASSERT_TRUE(root->type == AL_OPERATION && root->operation.op == AL_EXP_ADD);
 
-    AlgebraicExpressionNode *leftRight = rootLeftChild->operation.r;
-    ASSERT_TRUE(leftRight->type == AL_OPERAND && leftRight->operand == B);
+	AlgebraicExpressionNode *rootLeftChild = root->operation.l;
+	AlgebraicExpressionNode *rootRightChild = root->operation.r;
+	ASSERT_TRUE(rootLeftChild && rootLeftChild->type == AL_OPERATION &&
+				rootLeftChild->operation.op == AL_EXP_MUL);
+	ASSERT_TRUE(rootRightChild && rootRightChild->type == AL_OPERATION &&
+				rootRightChild->operation.op == AL_EXP_MUL);
 
-    AlgebraicExpressionNode *rightLeft = rootRightChild->operation.l;
-    ASSERT_TRUE(rightLeft->type == AL_OPERAND && rightLeft->operand == A);
+	AlgebraicExpressionNode *leftLeft = rootLeftChild->operation.l;
+	ASSERT_TRUE(leftLeft->type == AL_OPERAND && leftLeft->operand == A);
 
-    AlgebraicExpressionNode *rightRight = rootRightChild->operation.r;
-    ASSERT_TRUE(rightRight->type == AL_OPERAND && rightRight->operand == C);
+	AlgebraicExpressionNode *leftRight = rootLeftChild->operation.r;
+	ASSERT_TRUE(leftRight->type == AL_OPERAND && leftRight->operand == B);
 
-    GrB_Matrix_free(&A);
-    GrB_Matrix_free(&B);
-    GrB_Matrix_free(&C);
-    AlgebraicExpressionNode_Free(root);
+	AlgebraicExpressionNode *rightLeft = rootRightChild->operation.l;
+	ASSERT_TRUE(rightLeft->type == AL_OPERAND && rightLeft->operand == A);
+
+	AlgebraicExpressionNode *rightRight = rootRightChild->operation.r;
+	ASSERT_TRUE(rightRight->type == AL_OPERAND && rightRight->operand == C);
+
+	GrB_Matrix_free(&A);
+	GrB_Matrix_free(&B);
+	GrB_Matrix_free(&C);
+	AlgebraicExpressionNode_Free(root);
 }
 
 TEST_F(AlgebraicExpressionTest, ExpTransform_AB_Times_C_Plus_D) {
-    // Test Mul / Add transformation:
-    // A*B*(C+D) -> A*B*C + A*B*D
-    AlgebraicExpressionNode *root = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
-    AlgebraicExpressionNode *mul = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
-    AlgebraicExpressionNode *add = AlgebraicExpressionNode_NewOperationNode(AL_EXP_ADD);
+	// Test Mul / Add transformation:
+	// A*B*(C+D) -> A*B*C + A*B*D
+	AlgebraicExpressionNode *root = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
+	AlgebraicExpressionNode *mul = AlgebraicExpressionNode_NewOperationNode(AL_EXP_MUL);
+	AlgebraicExpressionNode *add = AlgebraicExpressionNode_NewOperationNode(AL_EXP_ADD);
 
-    GrB_Matrix A;
-    GrB_Matrix B;    
-    GrB_Matrix C;
-    GrB_Matrix D;
-    
-    GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
-    GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
-    GrB_Matrix_new(&C, GrB_BOOL, 2, 2);
-    GrB_Matrix_new(&D, GrB_BOOL, 2, 2);
+	GrB_Matrix A;
+	GrB_Matrix B;
+	GrB_Matrix C;
+	GrB_Matrix D;
 
-    AlgebraicExpressionNode *aExp = AlgebraicExpressionNode_NewOperandNode(A);
-    AlgebraicExpressionNode *bExp = AlgebraicExpressionNode_NewOperandNode(B);
-    AlgebraicExpressionNode *cExp = AlgebraicExpressionNode_NewOperandNode(C);
-    AlgebraicExpressionNode *dExp = AlgebraicExpressionNode_NewOperandNode(D);
-    
-    // A*B*(C+D)
-    AlgebraicExpressionNode_AppendLeftChild(root, mul);
-    AlgebraicExpressionNode_AppendRightChild(root, add);
+	GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
+	GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
+	GrB_Matrix_new(&C, GrB_BOOL, 2, 2);
+	GrB_Matrix_new(&D, GrB_BOOL, 2, 2);
 
-    AlgebraicExpressionNode_AppendLeftChild(mul, aExp);
-    AlgebraicExpressionNode_AppendRightChild(mul, bExp);
+	AlgebraicExpressionNode *aExp = AlgebraicExpressionNode_NewOperandNode(A);
+	AlgebraicExpressionNode *bExp = AlgebraicExpressionNode_NewOperandNode(B);
+	AlgebraicExpressionNode *cExp = AlgebraicExpressionNode_NewOperandNode(C);
+	AlgebraicExpressionNode *dExp = AlgebraicExpressionNode_NewOperandNode(D);
 
-    AlgebraicExpressionNode_AppendLeftChild(add, cExp);
-    AlgebraicExpressionNode_AppendRightChild(add, dExp);
+	// A*B*(C+D)
+	AlgebraicExpressionNode_AppendLeftChild(root, mul);
+	AlgebraicExpressionNode_AppendRightChild(root, add);
 
-    AlgebraicExpression_SumOfMul(&root);
+	AlgebraicExpressionNode_AppendLeftChild(mul, aExp);
+	AlgebraicExpressionNode_AppendRightChild(mul, bExp);
 
-    // Verifications
-    // (A*B*C)+(A*B*D)
-    ASSERT_TRUE(root->type == AL_OPERATION && root->operation.op == AL_EXP_ADD);
+	AlgebraicExpressionNode_AppendLeftChild(add, cExp);
+	AlgebraicExpressionNode_AppendRightChild(add, dExp);
 
-    AlgebraicExpressionNode *rootLeftChild = root->operation.l;
-    ASSERT_TRUE(rootLeftChild && rootLeftChild->type == AL_OPERATION && rootLeftChild->operation.op == AL_EXP_MUL);
+	AlgebraicExpression_SumOfMul(&root);
 
-    AlgebraicExpressionNode *rootRightChild = root->operation.r;
-    ASSERT_TRUE(rootRightChild && rootRightChild->type == AL_OPERATION && rootRightChild->operation.op == AL_EXP_MUL);
+	// Verifications
+	// (A*B*C)+(A*B*D)
+	ASSERT_TRUE(root->type == AL_OPERATION && root->operation.op == AL_EXP_ADD);
 
-    AlgebraicExpressionNode *leftLeft = rootLeftChild->operation.l;
-    ASSERT_TRUE(leftLeft->type == AL_OPERATION && leftLeft->operation.op == AL_EXP_MUL && leftLeft->operation.reusable == true);
+	AlgebraicExpressionNode *rootLeftChild = root->operation.l;
+	ASSERT_TRUE(rootLeftChild && rootLeftChild->type == AL_OPERATION &&
+				rootLeftChild->operation.op == AL_EXP_MUL);
 
-    AlgebraicExpressionNode *leftLeftLeft = leftLeft->operation.l;
-    ASSERT_TRUE(leftLeftLeft->type == AL_OPERAND && leftLeftLeft->operand == A);
+	AlgebraicExpressionNode *rootRightChild = root->operation.r;
+	ASSERT_TRUE(rootRightChild && rootRightChild->type == AL_OPERATION &&
+				rootRightChild->operation.op == AL_EXP_MUL);
 
-    AlgebraicExpressionNode *leftLeftRight = leftLeft->operation.r;
-    ASSERT_TRUE(leftLeftRight->type == AL_OPERAND && leftLeftRight->operand == B);
+	AlgebraicExpressionNode *leftLeft = rootLeftChild->operation.l;
+	ASSERT_TRUE(leftLeft->type == AL_OPERATION && leftLeft->operation.op == AL_EXP_MUL &&
+				leftLeft->operation.reusable == true);
 
-    AlgebraicExpressionNode *leftRight = rootLeftChild->operation.r;
-    ASSERT_TRUE(leftRight->type == AL_OPERAND && leftRight->operand == C);
+	AlgebraicExpressionNode *leftLeftLeft = leftLeft->operation.l;
+	ASSERT_TRUE(leftLeftLeft->type == AL_OPERAND && leftLeftLeft->operand == A);
 
-    AlgebraicExpressionNode *rightLeft = rootRightChild->operation.l;
-    ASSERT_TRUE(rightLeft->type == AL_OPERATION && rightLeft->operation.op == AL_EXP_MUL && rightLeft->operation.reusable == true);
+	AlgebraicExpressionNode *leftLeftRight = leftLeft->operation.r;
+	ASSERT_TRUE(leftLeftRight->type == AL_OPERAND && leftLeftRight->operand == B);
 
-    AlgebraicExpressionNode *rightLeftLeft = rightLeft->operation.l;
-    ASSERT_TRUE(rightLeftLeft->type == AL_OPERAND && rightLeftLeft->operand == A);
+	AlgebraicExpressionNode *leftRight = rootLeftChild->operation.r;
+	ASSERT_TRUE(leftRight->type == AL_OPERAND && leftRight->operand == C);
 
-    AlgebraicExpressionNode *rightLeftRight = rightLeft->operation.r;
-    ASSERT_TRUE(rightLeftRight->type == AL_OPERAND && rightLeftRight->operand == B);
+	AlgebraicExpressionNode *rightLeft = rootRightChild->operation.l;
+	ASSERT_TRUE(rightLeft->type == AL_OPERATION && rightLeft->operation.op == AL_EXP_MUL &&
+				rightLeft->operation.reusable == true);
 
-    AlgebraicExpressionNode *rightRight = rootRightChild->operation.r;
-    ASSERT_TRUE(rightRight->type == AL_OPERAND && rightRight->operand == D);
+	AlgebraicExpressionNode *rightLeftLeft = rightLeft->operation.l;
+	ASSERT_TRUE(rightLeftLeft->type == AL_OPERAND && rightLeftLeft->operand == A);
 
-    GrB_Matrix_free(&A);
-    GrB_Matrix_free(&B);
-    GrB_Matrix_free(&C);
-    GrB_Matrix_free(&D);
-    AlgebraicExpressionNode_Free(root);
+	AlgebraicExpressionNode *rightLeftRight = rightLeft->operation.r;
+	ASSERT_TRUE(rightLeftRight->type == AL_OPERAND && rightLeftRight->operand == B);
+
+	AlgebraicExpressionNode *rightRight = rootRightChild->operation.r;
+	ASSERT_TRUE(rightRight->type == AL_OPERAND && rightRight->operand == D);
+
+	GrB_Matrix_free(&A);
+	GrB_Matrix_free(&B);
+	GrB_Matrix_free(&C);
+	GrB_Matrix_free(&D);
+	AlgebraicExpressionNode_Free(root);
 }
 
 TEST_F(AlgebraicExpressionTest, MultipleIntermidateReturnNodes) {
-    size_t exp_count = 0;
-    const char *q = query_multiple_intermidate_return_nodes;
-    AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 3);
+	size_t exp_count = 0;
+	const char *q = query_multiple_intermidate_return_nodes;
+	AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 3);
 
-    AlgebraicExpression **expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 3);
-    AlgebraicExpression *exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    expected[0] = exp;
+	AlgebraicExpression **expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 3);
+	AlgebraicExpression *exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	expected[0] = exp;
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    expected[1] = exp;
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	expected[1] = exp;
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    expected[2] = exp;
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	expected[2] = exp;
 
-    compare_algebraic_expressions(actual, expected, 3);
+	compare_algebraic_expressions(actual, expected, 3);
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 }
 
 TEST_F(AlgebraicExpressionTest, OneIntermidateReturnNode) {
-    size_t exp_count = 0;
-    const char *q = query_one_intermidate_return_nodes;
-    AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 2);
+	size_t exp_count = 0;
+	const char *q = query_one_intermidate_return_nodes;
+	AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 2);
 
-    AlgebraicExpression **expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 2);
-    AlgebraicExpression *exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    expected[0] = exp;
+	AlgebraicExpression **expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 2);
+	AlgebraicExpression *exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	expected[0] = exp;
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    expected[1] = exp;
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	expected[1] = exp;
 
-    compare_algebraic_expressions(actual, expected, 2);
+	compare_algebraic_expressions(actual, expected, 2);
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 }
 
 TEST_F(AlgebraicExpressionTest, NoIntermidateReturnNodes) {
-    size_t exp_count = 0;
-    const char *q = query_no_intermidate_return_nodes;
-    AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 1);
-    
-    AlgebraicExpression **expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 1);
-    AlgebraicExpression *exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    expected[0] = exp;
+	size_t exp_count = 0;
+	const char *q = query_no_intermidate_return_nodes;
+	AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 1);
 
-    compare_algebraic_expressions(actual, expected, 1);
+	AlgebraicExpression **expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 1);
+	AlgebraicExpression *exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	expected[0] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	compare_algebraic_expressions(actual, expected, 1);
+
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 }
 
 TEST_F(AlgebraicExpressionTest, OneIntermidateReturnEdge) {
-    size_t exp_count;
-    const char *q;
-    AlgebraicExpression **actual;
+	size_t exp_count;
+	const char *q;
+	AlgebraicExpression **actual;
 
-    //==============================================================================================
-    //=== MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ef
-    //==============================================================================================
+	//==============================================================================================
+	//=== MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ef
+	//==============================================================================================
 
-    q = query_return_first_edge;
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 2);
+	q = query_return_first_edge;
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 2);
 
-    AlgebraicExpression **expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 2);
-    AlgebraicExpression *exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    expected[0] = exp;
-    
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    expected[1] = exp;
+	AlgebraicExpression **expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 2);
+	AlgebraicExpression *exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	expected[0] = exp;
 
-    compare_algebraic_expressions(actual, expected, 2);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	expected[1] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	compare_algebraic_expressions(actual, expected, 2);
 
-    //==============================================================================================
-    //=== MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ev
-    //==============================================================================================
-    q = query_return_intermidate_edge;
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 3);
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 
-    expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 3);
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    expected[0] = exp;
-    
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    expected[1] = exp;
+	//==============================================================================================
+	//=== MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ev
+	//==============================================================================================
+	q = query_return_intermidate_edge;
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 3);
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    expected[2] = exp;
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 3);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	expected[0] = exp;
 
-    compare_algebraic_expressions(actual, expected, 3);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	expected[1] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	expected[2] = exp;
 
-    //==============================================================================================
-    //=== MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ew
-    //==============================================================================================
-    q = query_return_last_edge;
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 2);
-    
-    expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 2);
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    expected[0] = exp;
+	compare_algebraic_expressions(actual, expected, 3);
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    expected[1] = exp;
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 
-    compare_algebraic_expressions(actual, expected, 2);
+	//==============================================================================================
+	//=== MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN ew
+	//==============================================================================================
+	q = query_return_last_edge;
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 2);
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 2);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	expected[0] = exp;
+
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	expected[1] = exp;
+
+	compare_algebraic_expressions(actual, expected, 2);
+
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 }
 
 TEST_F(AlgebraicExpressionTest, BothDirections) {
-    size_t exp_count = 0;
-    const char *q = "MATCH (p:Person)-[ef:friend]->(f:Person)<-[ev:visit]-(c:City)-[ew:war]->(e:City) RETURN p,e";
-    AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 1);
+	size_t exp_count = 0;
+	const char *q =
+		"MATCH (p:Person)-[ef:friend]->(f:Person)<-[ev:visit]-(c:City)-[ew:war]->(e:City) RETURN p,e";
+	AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 1);
 
-    AlgebraicExpression **expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 1);
-    AlgebraicExpression *exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ev, true, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    expected[0] = exp;
+	AlgebraicExpression **expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 1);
+	AlgebraicExpression *exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ev, true, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	expected[0] = exp;
 
-    compare_algebraic_expressions(actual, expected, 1);
+	compare_algebraic_expressions(actual, expected, 1);
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 }
 
 TEST_F(AlgebraicExpressionTest, SingleNode) {
-    size_t exp_count = 0;
-    const char *q = "MATCH (p:Person) RETURN p";
-    AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 0);
+	size_t exp_count = 0;
+	const char *q = "MATCH (p:Person) RETURN p";
+	AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 0);
 
-    AlgebraicExpression **expected = NULL;
+	AlgebraicExpression **expected = NULL;
 
-    compare_algebraic_expressions(actual, expected, 0);
+	compare_algebraic_expressions(actual, expected, 0);
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free(actual);
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free(actual);
 }
 
 TEST_F(AlgebraicExpressionTest, ShareableEntity) {
-    size_t exp_count = 0;
-    const char *q = "MATCH (p:Person)-[ef:friend]->(f:Person) MATCH (f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p,e";
-    AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 1);
-    
-    AlgebraicExpression **expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 1);
-    AlgebraicExpression *exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    expected[0] = exp;
+	size_t exp_count = 0;
+	const char *q =
+		"MATCH (p:Person)-[ef:friend]->(f:Person) MATCH (f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p,e";
+	AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 1);
 
-    compare_algebraic_expressions(actual, expected, 1);
+	AlgebraicExpression **expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 1);
+	AlgebraicExpression *exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	expected[0] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	compare_algebraic_expressions(actual, expected, 1);
 
-    exp_count = 0;
-    q = "MATCH (p:Person)-[ef:friend]->(f:Person) MATCH (f:Person)<-[ev:visit]-(c:City)<-[ew:war]-(e:City) RETURN p,e";
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 1);
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 
-    expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 1);
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, true, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	exp_count = 0;
+	q = "MATCH (p:Person)-[ef:friend]->(f:Person) MATCH (f:Person)<-[ev:visit]-(c:City)<-[ew:war]-(e:City) RETURN p,e";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 1);
 
-    expected[0] = exp;
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 1);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, true, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
 
-    compare_algebraic_expressions(actual, expected, 1);
+	expected[0] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	compare_algebraic_expressions(actual, expected, 1);
 
-    exp_count = 0;
-    q = "MATCH (p:Person)-[ef:friend]->(f:Person) MATCH (f:Person)-[ev:visit]->(c:City) MATCH (c:City)-[ew:war]->(e:City) RETURN p,e";
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 1);
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 
-    expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 1);
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    expected[0] = exp;
+	exp_count = 0;
+	q = "MATCH (p:Person)-[ef:friend]->(f:Person) MATCH (f:Person)-[ev:visit]->(c:City) MATCH (c:City)-[ew:war]->(e:City) RETURN p,e";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 1);
 
-    compare_algebraic_expressions(actual, expected, 1);
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 1);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	expected[0] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	compare_algebraic_expressions(actual, expected, 1);
 
-    exp_count = 0;
-    q = "MATCH (a:Person)-[:friend]->(f:Person) MATCH (b:Person)-[:friend]->(f:Person) RETURN a,b";
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 1);
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 
-    expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 1);
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, true, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[0] = exp;
+	exp_count = 0;
+	q = "MATCH (a:Person)-[:friend]->(f:Person) MATCH (b:Person)-[:friend]->(f:Person) RETURN a,b";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 1);
 
-    compare_algebraic_expressions(actual, expected, 1);
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 1);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, true, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[0] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	compare_algebraic_expressions(actual, expected, 1);
 
-    // High incoming degree.
-    exp_count = 0;
-    q = "MATCH (a:Person)-[:friend]->(d:Person) MATCH (b:Person)-[:friend]->(d:Person) MATCH (c:Person)-[:friend]->(d:Person) RETURN a";
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 3);
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 
-    expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 3);
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[0] = exp;
+	// High incoming degree.
+	exp_count = 0;
+	q = "MATCH (a:Person)-[:friend]->(d:Person) MATCH (b:Person)-[:friend]->(d:Person) MATCH (c:Person)-[:friend]->(d:Person) RETURN a";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 3);
 
-    exp = AlgebraicExpression_Empty();    
-    AlgebraicExpression_AppendTerm(exp, mat_ef, true, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[1] = exp;
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 3);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[0] = exp;
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[2] = exp;
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, true, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[1] = exp;
 
-    compare_algebraic_expressions(actual, expected, 3);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[2] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	compare_algebraic_expressions(actual, expected, 3);
 
-    // High outgoing degree.
-    exp_count = 0;
-    q = "MATCH (a:Person)-[:friend]->(b:Person) MATCH (a:Person)-[:friend]->(c:Person) MATCH (a:Person)-[:friend]->(d:Person) RETURN a";
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 3);
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 
-    expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 3);
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, true, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[0] = exp;
+	// High outgoing degree.
+	exp_count = 0;
+	q = "MATCH (a:Person)-[:friend]->(b:Person) MATCH (a:Person)-[:friend]->(c:Person) MATCH (a:Person)-[:friend]->(d:Person) RETURN a";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 3);
 
-    exp = AlgebraicExpression_Empty();    
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[1] = exp;
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 3);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, true, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[0] = exp;
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[2] = exp;
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[1] = exp;
 
-    compare_algebraic_expressions(actual, expected, 3);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[2] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	compare_algebraic_expressions(actual, expected, 3);
 
-    // Cycle.
-    exp_count = 0;
-    q = "MATCH (a:Person)-[:friend]->(b:Person)-[:friend]->(a:Person) RETURN a";
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 2);
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 
-    expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 2);
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[0] = exp;
+	// Cycle.
+	exp_count = 0;
+	q = "MATCH (a:Person)-[:friend]->(b:Person)-[:friend]->(a:Person) RETURN a";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 2);
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[1] = exp;
-    
-    compare_algebraic_expressions(actual, expected, 2);
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 2);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[0] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[1] = exp;
 
-    // Longer cycle.
-    exp_count = 0;
-    q = "MATCH (a:Person)-[:friend]->(b:Person)-[:friend]->(c:Person)-[:friend]->(a:Person) RETURN a";
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 2);
+	compare_algebraic_expressions(actual, expected, 2);
 
-    expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 2);
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[0] = exp;
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[1] = exp;
+	// Longer cycle.
+	exp_count = 0;
+	q = "MATCH (a:Person)-[:friend]->(b:Person)-[:friend]->(c:Person)-[:friend]->(a:Person) RETURN a";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 2);
 
-    compare_algebraic_expressions(actual, expected, 2);
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 2);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[0] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[1] = exp;
 
-    // Self pointing node.
-    exp_count = 0;
-    q = "MATCH (a:Person)-[:friend]->(a) RETURN a";
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 1);
+	compare_algebraic_expressions(actual, expected, 2);
 
-    expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 1);
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    expected[0] = exp;
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 
-    compare_algebraic_expressions(actual, expected, 1);
+	// Self pointing node.
+	exp_count = 0;
+	q = "MATCH (a:Person)-[:friend]->(a) RETURN a";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 1);
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 1);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	expected[0] = exp;
+
+	compare_algebraic_expressions(actual, expected, 1);
+
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 }
 
 TEST_F(AlgebraicExpressionTest, VariableLength) {
-    size_t exp_count = 0;
-    const char *q = "MATCH (p:Person)-[ef:friend]->(f:Person)-[:visit*1..3]->(c:City)-[ew:war]->(e:City) RETURN p,e";
-    AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 3);
-    
-    AlgebraicExpression **expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 3);
-    AlgebraicExpression *exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    expected[0] = exp;
+	size_t exp_count = 0;
+	const char *q =
+		"MATCH (p:Person)-[ef:friend]->(f:Person)-[:visit*1..3]->(c:City)-[ew:war]->(e:City) RETURN p,e";
+	AlgebraicExpression **actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 3);
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
-    expected[1] = exp;
+	AlgebraicExpression **expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 3);
+	AlgebraicExpression *exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	expected[0] = exp;
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    expected[2] = exp;
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ev, false, false, false);
+	expected[1] = exp;
 
-    compare_algebraic_expressions(actual, expected, 3);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	expected[2] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	compare_algebraic_expressions(actual, expected, 3);
 
-    // Transposed variable length.
-    exp_count = 0;
-    q = "MATCH (p:Person)-[ef:friend]->(f:Person)<-[:visit*1..3]-(c:City)-[ew:war]->(e:City) RETURN p,e";
-    actual = build_algebraic_expression(q, &exp_count);
-    ASSERT_EQ(exp_count, 3);
-    
-    expected = (AlgebraicExpression**)malloc(sizeof(AlgebraicExpression*) * 3);
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
-    expected[0] = exp;
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_ev, true, false, false);
-    expected[1] = exp;
+	// Transposed variable length.
+	exp_count = 0;
+	q = "MATCH (p:Person)-[ef:friend]->(f:Person)<-[:visit*1..3]-(c:City)-[ew:war]->(e:City) RETURN p,e";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 3);
 
-    exp = AlgebraicExpression_Empty();
-    AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
-    AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
-    AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
-    expected[2] = exp;
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 3);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_p, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_f, false, false, true);
+	expected[0] = exp;
 
-    compare_algebraic_expressions(actual, expected, 3);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ev, true, false, false);
+	expected[1] = exp;
 
-    // Clean up.
-    free_algebraic_expressions(actual, exp_count);
-    free_algebraic_expressions(expected, exp_count);
-    free(expected);
-    free(actual);
+	exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_c, false, false, true);
+	AlgebraicExpression_AppendTerm(exp, mat_ew, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_e, false, false, true);
+	expected[2] = exp;
+
+	compare_algebraic_expressions(actual, expected, 3);
+
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 }
 
 TEST_F(AlgebraicExpressionTest, ExpressionExecute) {
-    size_t exp_count = 0;
-    GraphContext *gc = GraphContext_GetFromTLS();
-    Graph *g = gc->g;
+	size_t exp_count = 0;
+	GraphContext *gc = GraphContext_GetFromTLS();
+	Graph *g = gc->g;
 
-    const char *q = query_no_intermidate_return_nodes;
-    AlgebraicExpression **ae = build_algebraic_expression(q, &exp_count);
+	const char *q = query_no_intermidate_return_nodes;
+	AlgebraicExpression **ae = build_algebraic_expression(q, &exp_count);
 
-    GrB_Matrix res;
-    GrB_Matrix_new(&res, GrB_BOOL, Graph_RequiredMatrixDim(g), Graph_RequiredMatrixDim(g));
+	GrB_Matrix res;
+	GrB_Matrix_new(&res, GrB_BOOL, Graph_RequiredMatrixDim(g), Graph_RequiredMatrixDim(g));
 
-    AlgebraicExpression *exp = ae[0];
-    AlgebraicExpression_Execute(exp, res);
+	AlgebraicExpression *exp = ae[0];
+	AlgebraicExpression_Execute(exp, res);
 
-    ASSERT_STREQ(exp->src_node->alias, "p");
-    ASSERT_STREQ(exp->dest_node->alias, "e");
-    
-    // Validate result matrix.
-    GrB_Index ncols, nrows;
-    GrB_Matrix_ncols(&ncols, res);
-    GrB_Matrix_nrows(&nrows, res);    
-    assert(ncols == Graph_RequiredMatrixDim(g));
-    assert(nrows == Graph_RequiredMatrixDim(g));
+	ASSERT_STREQ(exp->src_node->alias, "p");
+	ASSERT_STREQ(exp->dest_node->alias, "e");
 
-    GrB_Index expected_entries[6] = {1,2, 0,3, 1,3};
-    GrB_Matrix expected = NULL;
+	// Validate result matrix.
+	GrB_Index ncols, nrows;
+	GrB_Matrix_ncols(&ncols, res);
+	GrB_Matrix_nrows(&nrows, res);
+	assert(ncols == Graph_RequiredMatrixDim(g));
+	assert(nrows == Graph_RequiredMatrixDim(g));
 
-    GrB_Matrix_dup(&expected, res);
-    GrB_Matrix_clear(expected);
-    for(int i = 0; i < 6; i+=2) {
-        GrB_Matrix_setElement_BOOL(expected, true, expected_entries[i], expected_entries[i+1]);
-    }
+	GrB_Index expected_entries[6] = {1, 2, 0, 3, 1, 3};
+	GrB_Matrix expected = NULL;
 
-    assert(_compare_matrices(res, expected));
+	GrB_Matrix_dup(&expected, res);
+	GrB_Matrix_clear(expected);
+	for(int i = 0; i < 6; i += 2) {
+		GrB_Matrix_setElement_BOOL(expected, true, expected_entries[i], expected_entries[i + 1]);
+	}
 
-    // Clean up
-    AlgebraicExpression_Free(ae[0]);
-    free(ae);
-    GrB_Matrix_free(&expected);
-    GrB_Matrix_free(&res);
+	assert(_compare_matrices(res, expected));
+
+	// Clean up
+	AlgebraicExpression_Free(ae[0]);
+	free(ae);
+	GrB_Matrix_free(&expected);
+	GrB_Matrix_free(&res);
 }

--- a/tests/unit/test_all_paths.cpp
+++ b/tests/unit/test_all_paths.cpp
@@ -18,230 +18,231 @@ extern "C" {
 #endif
 
 class AllPathsTest: public ::testing::Test {
-    protected:
-    static void SetUpTestCase()
-    {
-        // Use the malloc family for allocations
-        Alloc_Reset();
+  protected:
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
 
-        // Initialize GraphBLAS.
-        GrB_init(GrB_NONBLOCKING);
-        GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW); // all matrices in CSR format
-        GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
-    }
+		// Initialize GraphBLAS.
+		GrB_init(GrB_NONBLOCKING);
+		GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW); // all matrices in CSR format
+		GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
+	}
 
-    static void TearDownTestCase()
-    {
-        GrB_finalize();
-    }
+	static void TearDownTestCase() {
+		GrB_finalize();
+	}
 
-    static Graph* BuildGraph()
-    {
-        Edge e;
-        Node n;
-        size_t nodeCount = 4;
-        Graph *g = Graph_New(nodeCount, nodeCount);
-        int relation = Graph_AddRelationType(g);
-        for(int i = 0; i < 4; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
+	static Graph *BuildGraph() {
+		Edge e;
+		Node n;
+		size_t nodeCount = 4;
+		Graph *g = Graph_New(nodeCount, nodeCount);
+		int relation = Graph_AddRelationType(g);
+		for(int i = 0; i < 4; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
 
-        /* Connections:
-         * 0 -> 1
-         * 0 -> 2
-         * 1 -> 0
-         * 1 -> 2
-         * 2 -> 1
-         * 2 -> 3
-         * 3 -> 0 */
+		/* Connections:
+		 * 0 -> 1
+		 * 0 -> 2
+		 * 1 -> 0
+		 * 1 -> 2
+		 * 2 -> 1
+		 * 2 -> 3
+		 * 3 -> 0 */
 
-        // Connections:
-        // 0 -> 1
-        Graph_ConnectNodes(g, 0, 1, relation, &e);
-        // 0 -> 2
-        Graph_ConnectNodes(g, 0, 2, relation, &e);
-        // 1 -> 0
-        Graph_ConnectNodes(g, 1, 0, relation, &e);
-        // 1 -> 2
-        Graph_ConnectNodes(g, 1, 2, relation, &e);
-        // 2 -> 1
-        Graph_ConnectNodes(g, 2, 1, relation, &e);
-        // 2 -> 3
-        Graph_ConnectNodes(g, 2, 3, relation, &e);
-        // 3 -> 0
-        Graph_ConnectNodes(g, 3, 0, relation, &e);
-        return g;
-    }
+		// Connections:
+		// 0 -> 1
+		Graph_ConnectNodes(g, 0, 1, relation, &e);
+		// 0 -> 2
+		Graph_ConnectNodes(g, 0, 2, relation, &e);
+		// 1 -> 0
+		Graph_ConnectNodes(g, 1, 0, relation, &e);
+		// 1 -> 2
+		Graph_ConnectNodes(g, 1, 2, relation, &e);
+		// 2 -> 1
+		Graph_ConnectNodes(g, 2, 1, relation, &e);
+		// 2 -> 3
+		Graph_ConnectNodes(g, 2, 3, relation, &e);
+		// 3 -> 0
+		Graph_ConnectNodes(g, 3, 0, relation, &e);
+		return g;
+	}
 };
 
 TEST_F(AllPathsTest, NoPaths) {
-    Graph *g = BuildGraph();
+	Graph *g = BuildGraph();
 
-    NodeID srcNodeID = 0;
-    unsigned int minLen = 999;
-    unsigned int maxLen = minLen + 1;
+	NodeID srcNodeID = 0;
+	unsigned int minLen = 999;
+	unsigned int maxLen = minLen + 1;
 
-    Node src;
-    Graph_GetNode(g, srcNodeID, &src);
+	Node src;
+	Graph_GetNode(g, srcNodeID, &src);
 
-    int relationships[] = { GRAPH_NO_RELATION };
-    AllPathsCtx *ctx = AllPathsCtx_New(&src, g, relationships, 1, GRAPH_EDGE_DIR_OUTGOING, minLen, maxLen);
-    Path p = AllPathsCtx_NextPath(ctx);
+	int relationships[] = { GRAPH_NO_RELATION };
+	AllPathsCtx *ctx = AllPathsCtx_New(&src, g, relationships, 1, GRAPH_EDGE_DIR_OUTGOING, minLen,
+									   maxLen);
+	Path p = AllPathsCtx_NextPath(ctx);
 
-    ASSERT_TRUE(p == NULL);
-    
-    AllPathsCtx_Free(ctx);
-    Graph_Free(g);
+	ASSERT_TRUE(p == NULL);
+
+	AllPathsCtx_Free(ctx);
+	Graph_Free(g);
 }
 
 TEST_F(AllPathsTest, LongestPaths) {
-    Graph *g = BuildGraph();
+	Graph *g = BuildGraph();
 
-    NodeID srcNodeID = 0;
-    Node src;
-    Graph_GetNode(g, srcNodeID, &src);
+	NodeID srcNodeID = 0;
+	Node src;
+	Graph_GetNode(g, srcNodeID, &src);
 
-    unsigned int minLen = 0;
-    unsigned int maxLen = UINT_MAX-2;
-    int relationships[] = { GRAPH_NO_RELATION };
-    AllPathsCtx *ctx = AllPathsCtx_New(&src, g, relationships, 1, GRAPH_EDGE_DIR_OUTGOING, minLen, maxLen);
-    Path path;
+	unsigned int minLen = 0;
+	unsigned int maxLen = UINT_MAX - 2;
+	int relationships[] = { GRAPH_NO_RELATION };
+	AllPathsCtx *ctx = AllPathsCtx_New(&src, g, relationships, 1, GRAPH_EDGE_DIR_OUTGOING, minLen,
+									   maxLen);
+	Path path;
 
-    unsigned int longestPath = 0;
-    while((path = AllPathsCtx_NextPath(ctx))) {
-        size_t pathLen = Path_len(path);
-        if(longestPath < pathLen) longestPath = pathLen;
-    }
+	unsigned int longestPath = 0;
+	while((path = AllPathsCtx_NextPath(ctx))) {
+		size_t pathLen = Path_len(path);
+		if(longestPath < pathLen) longestPath = pathLen;
+	}
 
-    // 0,1,2,3,0
-    ASSERT_EQ(longestPath, 5);
-    
-    AllPathsCtx_Free(ctx);
-    Graph_Free(g);
+	// 0,1,2,3,0
+	ASSERT_EQ(longestPath, 5);
+
+	AllPathsCtx_Free(ctx);
+	Graph_Free(g);
 }
 
 TEST_F(AllPathsTest, UpToThreeLegsPaths) {
-    Graph *g = BuildGraph();
+	Graph *g = BuildGraph();
 
-    NodeID srcNodeID = 0;
-    Node src;
-    Graph_GetNode(g, srcNodeID, &src);
+	NodeID srcNodeID = 0;
+	Node src;
+	Graph_GetNode(g, srcNodeID, &src);
 
-    Node *path = NULL;
-    unsigned int minLen = 0;
-    unsigned int maxLen = 3;
-    uint pathsCount = 0;
-    int relationships[] = { GRAPH_NO_RELATION };
-    AllPathsCtx *ctx = AllPathsCtx_New(&src, g, relationships, 1, GRAPH_EDGE_DIR_OUTGOING, minLen, maxLen);
+	Node *path = NULL;
+	unsigned int minLen = 0;
+	unsigned int maxLen = 3;
+	uint pathsCount = 0;
+	int relationships[] = { GRAPH_NO_RELATION };
+	AllPathsCtx *ctx = AllPathsCtx_New(&src, g, relationships, 1, GRAPH_EDGE_DIR_OUTGOING, minLen,
+									   maxLen);
 
-    /* Connections:
-     * 0 -> 1
-     * 0 -> 2
-     * 1 -> 0
-     * 1 -> 2
-     * 2 -> 1
-     * 2 -> 3
-     * 3 -> 0 */
+	/* Connections:
+	 * 0 -> 1
+	 * 0 -> 2
+	 * 1 -> 0
+	 * 1 -> 2
+	 * 2 -> 1
+	 * 2 -> 3
+	 * 3 -> 0 */
 
-    // Zero leg paths.
-    NodeID p0[3] = {1, 0};
+	// Zero leg paths.
+	NodeID p0[3] = {1, 0};
 
-    // One leg paths.
-    NodeID p1[3] = {2, 0, 1};
-    NodeID p2[3] = {2, 0, 2};
+	// One leg paths.
+	NodeID p1[3] = {2, 0, 1};
+	NodeID p2[3] = {2, 0, 2};
 
-    // Two leg paths.
-    NodeID p3[4] = {3, 0, 1, 0};
-    NodeID p4[4] = {3, 0, 1, 2};
-    NodeID p5[4] = {3, 0, 2, 1};
-    NodeID p6[4] = {3, 0, 2, 3};
+	// Two leg paths.
+	NodeID p3[4] = {3, 0, 1, 0};
+	NodeID p4[4] = {3, 0, 1, 2};
+	NodeID p5[4] = {3, 0, 2, 1};
+	NodeID p6[4] = {3, 0, 2, 3};
 
-    // Three leg paths.
-    NodeID p7[5] = {4, 0, 1, 2, 1};
-    NodeID p8[5] = {4, 0, 1, 2, 3};
-    NodeID p9[5] = {4, 0, 2, 1, 0};
-    NodeID p10[5] = {4, 0, 2, 1, 2};
-    NodeID p11[5] = {4, 0, 2, 3, 0};
+	// Three leg paths.
+	NodeID p7[5] = {4, 0, 1, 2, 1};
+	NodeID p8[5] = {4, 0, 1, 2, 3};
+	NodeID p9[5] = {4, 0, 2, 1, 0};
+	NodeID p10[5] = {4, 0, 2, 1, 2};
+	NodeID p11[5] = {4, 0, 2, 3, 0};
 
-    NodeID *expectedPaths[12] = {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11};
-    
-    while((path = AllPathsCtx_NextPath(ctx))) {
-        bool expectedPathFound = false;
-        assert(pathsCount < 12);
+	NodeID *expectedPaths[12] = {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11};
 
-        // Try to match a path.
-        for(int i = 0; i < 12; i++) {
-            NodeID *expectedPath = expectedPaths[i];
-            size_t expectedPathLen = expectedPath[0];
-            expectedPath++; // Skip path length.
+	while((path = AllPathsCtx_NextPath(ctx))) {
+		bool expectedPathFound = false;
+		assert(pathsCount < 12);
 
-            if(Path_len(path) != expectedPathLen) continue;
-            
-            int j = 0;
-            for(; j < expectedPathLen; j++) {
-                Node n = path[j];
-                if(ENTITY_GET_ID(&n) != expectedPath[j]) break;
-            }
-            if(j == expectedPathLen) {
-                expectedPathFound = true;
-                break;
-            }
-        }
-        ASSERT_TRUE(expectedPathFound);
-        pathsCount++;
-    }
-    ASSERT_EQ(pathsCount, 12);
+		// Try to match a path.
+		for(int i = 0; i < 12; i++) {
+			NodeID *expectedPath = expectedPaths[i];
+			size_t expectedPathLen = expectedPath[0];
+			expectedPath++; // Skip path length.
 
-    AllPathsCtx_Free(ctx);    
-    Graph_Free(g);
+			if(Path_len(path) != expectedPathLen) continue;
+
+			int j = 0;
+			for(; j < expectedPathLen; j++) {
+				Node n = path[j];
+				if(ENTITY_GET_ID(&n) != expectedPath[j]) break;
+			}
+			if(j == expectedPathLen) {
+				expectedPathFound = true;
+				break;
+			}
+		}
+		ASSERT_TRUE(expectedPathFound);
+		pathsCount++;
+	}
+	ASSERT_EQ(pathsCount, 12);
+
+	AllPathsCtx_Free(ctx);
+	Graph_Free(g);
 }
 
 TEST_F(AllPathsTest, TwoLegPaths) {
-    Graph *g = BuildGraph();
+	Graph *g = BuildGraph();
 
-    NodeID srcNodeID = 0;
-    Node src;
-    Node *path = NULL;
-    Graph_GetNode(g, srcNodeID, &src);
-    unsigned int minLen = 2;
-    unsigned int maxLen = 2;
-    unsigned int pathsCount = 0;
-    int relationships[] = { GRAPH_NO_RELATION };
-    AllPathsCtx *ctx = AllPathsCtx_New(&src, g, relationships, 1, GRAPH_EDGE_DIR_OUTGOING, minLen, maxLen);
-    /* Connections:
-     * 0 -> 1
-     * 0 -> 2
-     * 1 -> 0
-     * 1 -> 2
-     * 2 -> 1
-     * 2 -> 3
-     * 3 -> 0 */
-    NodeID p0[3] = {0, 1, 0};
-    NodeID p1[3] = {0, 1, 2};
-    NodeID p2[3] = {0, 2, 1};
-    NodeID p3[3] = {0, 2, 3};
-    NodeID *expectedPaths[4] = {p0, p1, p2, p3};
+	NodeID srcNodeID = 0;
+	Node src;
+	Node *path = NULL;
+	Graph_GetNode(g, srcNodeID, &src);
+	unsigned int minLen = 2;
+	unsigned int maxLen = 2;
+	unsigned int pathsCount = 0;
+	int relationships[] = { GRAPH_NO_RELATION };
+	AllPathsCtx *ctx = AllPathsCtx_New(&src, g, relationships, 1, GRAPH_EDGE_DIR_OUTGOING, minLen,
+									   maxLen);
+	/* Connections:
+	 * 0 -> 1
+	 * 0 -> 2
+	 * 1 -> 0
+	 * 1 -> 2
+	 * 2 -> 1
+	 * 2 -> 3
+	 * 3 -> 0 */
+	NodeID p0[3] = {0, 1, 0};
+	NodeID p1[3] = {0, 1, 2};
+	NodeID p2[3] = {0, 2, 1};
+	NodeID p3[3] = {0, 2, 3};
+	NodeID *expectedPaths[4] = {p0, p1, p2, p3};
 
-    while((path = AllPathsCtx_NextPath(ctx))) {
-        ASSERT_LT(pathsCount, 4);
-        ASSERT_EQ(Path_len(path), 3);
-        bool expectedPathFound = false;
+	while((path = AllPathsCtx_NextPath(ctx))) {
+		ASSERT_LT(pathsCount, 4);
+		ASSERT_EQ(Path_len(path), 3);
+		bool expectedPathFound = false;
 
-        for(int i = 0; i < 4; i++) {
-            NodeID *expectedPath = expectedPaths[i];
-            int j;
-            for(j = 0; j < 3; j++) {
-                Node n = path[j];
-                if(ENTITY_GET_ID(&n) != expectedPath[j]) break;
-            }
-            expectedPathFound = (j == 3);
-            if(expectedPathFound) break;
-        }
+		for(int i = 0; i < 4; i++) {
+			NodeID *expectedPath = expectedPaths[i];
+			int j;
+			for(j = 0; j < 3; j++) {
+				Node n = path[j];
+				if(ENTITY_GET_ID(&n) != expectedPath[j]) break;
+			}
+			expectedPathFound = (j == 3);
+			if(expectedPathFound) break;
+		}
 
-        ASSERT_TRUE(expectedPathFound);
-        pathsCount++;
-    }
+		ASSERT_TRUE(expectedPathFound);
+		pathsCount++;
+	}
 
-    ASSERT_EQ(pathsCount, 4);
-    
-    AllPathsCtx_Free(ctx);
-    Graph_Free(g);
+	ASSERT_EQ(pathsCount, 4);
+
+	AllPathsCtx_Free(ctx);
+	Graph_Free(g);
 }

--- a/tests/unit/test_arithmetic_expression.cpp
+++ b/tests/unit/test_arithmetic_expression.cpp
@@ -22,7 +22,7 @@ extern "C"
 #include <time.h>
 
 // Declaration of function in execution_plan.h
-AR_ExpNode** _BuildReturnExpressions(RecordMap *record_map, const cypher_astnode_t *ret_clause);
+AR_ExpNode **_BuildReturnExpressions(RecordMap *record_map, const cypher_astnode_t *ret_clause);
 
 #ifdef __cplusplus
 }
@@ -32,1191 +32,1152 @@ pthread_key_t _tlsASTKey;  // Thread local storage AST key.
 
 class ArithmeticTest: public ::testing::Test {
   protected:
-    static void SetUpTestCase() {
-      // Use the malloc family for allocations
-      Alloc_Reset();
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
 
-      AR_RegisterFuncs();
-      Agg_RegisterFuncs();
+		AR_RegisterFuncs();
+		Agg_RegisterFuncs();
 
-      int error = pthread_key_create(&_tlsASTKey, NULL);
-      ASSERT_EQ(error, 0);
-    }
+		int error = pthread_key_create(&_tlsASTKey, NULL);
+		ASSERT_EQ(error, 0);
+	}
 
-    static void TearDownTestCase()
-    {
-    }
+	static void TearDownTestCase() {
+	}
 };
 
-void _test_string(const AR_ExpNode *exp, const char *expected)
-{
-    char *str;
-    AR_EXP_ToString(exp, &str);
-    ASSERT_STREQ(str, expected);
-    free(str);
+void _test_string(const AR_ExpNode *exp, const char *expected) {
+	char *str;
+	AR_EXP_ToString(exp, &str);
+	ASSERT_STREQ(str, expected);
+	free(str);
 }
 
-void _test_ar_func(AR_ExpNode *root, SIValue expected, const Record r)
-{
-    SIValue res = AR_EXP_Evaluate(root, r);
-    if (SI_TYPE(res) == T_NULL && SI_TYPE(expected) == T_NULL)
-    {
-        // NULLs implicitly match
-        return;
-    }
-    else if (SI_TYPE(res) & SI_NUMERIC && SI_TYPE(expected) & SI_NUMERIC)
-    {
-        // Compare numerics by internal value
-        ASSERT_EQ(SI_GET_NUMERIC(res), SI_GET_NUMERIC(expected));
-    }
-    else
-    {
-        FAIL() << "Tried to compare disjoint types";
-    }
+void _test_ar_func(AR_ExpNode *root, SIValue expected, const Record r) {
+	SIValue res = AR_EXP_Evaluate(root, r);
+	if(SI_TYPE(res) == T_NULL && SI_TYPE(expected) == T_NULL) {
+		// NULLs implicitly match
+		return;
+	} else if(SI_TYPE(res) & SI_NUMERIC && SI_TYPE(expected) & SI_NUMERIC) {
+		// Compare numerics by internal value
+		ASSERT_EQ(SI_GET_NUMERIC(res), SI_GET_NUMERIC(expected));
+	} else {
+		FAIL() << "Tried to compare disjoint types";
+	}
 }
 
-AR_ExpNode* _exp_from_query(const char *query) {
-  cypher_parse_result_t *parse_result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
-  AST *ast = AST_Build(parse_result);
-  ast->entity_map = raxNew();
+AR_ExpNode *_exp_from_query(const char *query) {
+	cypher_parse_result_t *parse_result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
+	AST *ast = AST_Build(parse_result);
+	ast->entity_map = raxNew();
 
-  const cypher_astnode_t *ret_clause = AST_GetClause(ast, CYPHER_AST_RETURN);
-  AR_ExpNode **return_elems = _BuildReturnExpressions(NULL, ret_clause);
+	const cypher_astnode_t *ret_clause = AST_GetClause(ast, CYPHER_AST_RETURN);
+	AR_ExpNode **return_elems = _BuildReturnExpressions(NULL, ret_clause);
 
-  return return_elems[0];
+	return return_elems[0];
 }
 
-TEST_F(ArithmeticTest, ExpressionTest)
-{
-    SIValue result;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, ExpressionTest) {
+	SIValue result;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* muchacho */
-    query = "RETURN 'muchacho'";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_STREQ(result.stringval, "muchacho");
-    AR_EXP_Free(arExp);
+	/* muchacho */
+	query = "RETURN 'muchacho'";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_STREQ(result.stringval, "muchacho");
+	AR_EXP_Free(arExp);
 
-    /* 1 */
-    query = "RETURN 1";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.longval, 1);
-    AR_EXP_Free(arExp);
+	/* 1 */
+	query = "RETURN 1";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.longval, 1);
+	AR_EXP_Free(arExp);
 
-    /* 1+2*3 */
-    query = "RETURN 1+2*3";
-    arExp = _exp_from_query(query);
-    // Entire expression should be reduce to a single constant.
-    ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.longval, 7);
-    AR_EXP_Free(arExp);
+	/* 1+2*3 */
+	query = "RETURN 1+2*3";
+	arExp = _exp_from_query(query);
+	// Entire expression should be reduce to a single constant.
+	ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.longval, 7);
+	AR_EXP_Free(arExp);
 
-    /* 1 + 1 + 1 + 1 + 1 + 1 */
-    query = "RETURN 1 + 1 + 1 + 1 + 1 + 1";
-    arExp = _exp_from_query(query);
-    ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
+	/* 1 + 1 + 1 + 1 + 1 + 1 */
+	query = "RETURN 1 + 1 + 1 + 1 + 1 + 1";
+	arExp = _exp_from_query(query);
+	ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
 
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.longval, 6);
-    AR_EXP_Free(arExp);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.longval, 6);
+	AR_EXP_Free(arExp);
 
-    /* ABS(-5 + 2 * 1) */
-    query = "RETURN ABS(-5 + 2 * 1)";
-    arExp = _exp_from_query(query);
-    ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.longval, 3);
-    AR_EXP_Free(arExp);
+	/* ABS(-5 + 2 * 1) */
+	query = "RETURN ABS(-5 + 2 * 1)";
+	arExp = _exp_from_query(query);
+	ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.longval, 3);
+	AR_EXP_Free(arExp);
 
-    /* 'a' + 'b' */
-    query = "RETURN 'a' + 'b'";
-    arExp = _exp_from_query(query);
-    ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_TRUE(strcmp(result.stringval, "ab") == 0);
-    AR_EXP_Free(arExp);
+	/* 'a' + 'b' */
+	query = "RETURN 'a' + 'b'";
+	arExp = _exp_from_query(query);
+	ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_TRUE(strcmp(result.stringval, "ab") == 0);
+	AR_EXP_Free(arExp);
 
-    /* 1 + 2 + 'a' + 2 + 1 */
-    query = "RETURN 1 + 2 + 'a' + 2 + 1";
-    arExp = _exp_from_query(query);
-    ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_TRUE(strcmp(result.stringval, "3a21") == 0);
-    AR_EXP_Free(arExp);
+	/* 1 + 2 + 'a' + 2 + 1 */
+	query = "RETURN 1 + 2 + 'a' + 2 + 1";
+	arExp = _exp_from_query(query);
+	ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_TRUE(strcmp(result.stringval, "3a21") == 0);
+	AR_EXP_Free(arExp);
 
-    /* 2 * 2 + 'a' + 3 * 3 */
-    query = "RETURN 2 * 2 + 'a' + 3 * 3";
-    arExp = _exp_from_query(query);
-    ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_TRUE(strcmp(result.stringval, "4a9") == 0);
-    AR_EXP_Free(arExp);
+	/* 2 * 2 + 'a' + 3 * 3 */
+	query = "RETURN 2 * 2 + 'a' + 3 * 3";
+	arExp = _exp_from_query(query);
+	ASSERT_EQ(arExp->type, AR_EXP_OPERAND);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_TRUE(strcmp(result.stringval, "4a9") == 0);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, NullArithmetic)
-{
-    SIValue result;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, NullArithmetic) {
+	SIValue result;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* null + 1 */
-    query = "RETURN null + 1";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_TRUE(SIValue_IsNull(result));
-    AR_EXP_Free(arExp);
+	/* null + 1 */
+	query = "RETURN null + 1";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_TRUE(SIValue_IsNull(result));
+	AR_EXP_Free(arExp);
 
-    /* 1 + null */
-    query = "RETURN 1 + null";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_TRUE(SIValue_IsNull(result));
-    AR_EXP_Free(arExp);
+	/* 1 + null */
+	query = "RETURN 1 + null";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_TRUE(SIValue_IsNull(result));
+	AR_EXP_Free(arExp);
 
-    /* null - 1 */
-    query = "RETURN null - 1";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_TRUE(SIValue_IsNull(result));
-    AR_EXP_Free(arExp);
+	/* null - 1 */
+	query = "RETURN null - 1";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_TRUE(SIValue_IsNull(result));
+	AR_EXP_Free(arExp);
 
-    /* 1 - null */
-    query = "RETURN 1 - null";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_TRUE(SIValue_IsNull(result));
-    AR_EXP_Free(arExp);
+	/* 1 - null */
+	query = "RETURN 1 - null";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_TRUE(SIValue_IsNull(result));
+	AR_EXP_Free(arExp);
 
-    /* null * 1 */
-    query = "RETURN null * 1";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_TRUE(SIValue_IsNull(result));
-    AR_EXP_Free(arExp);
+	/* null * 1 */
+	query = "RETURN null * 1";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_TRUE(SIValue_IsNull(result));
+	AR_EXP_Free(arExp);
 
-    /* 1 * null */
-    query = "RETURN 1 * null";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_TRUE(SIValue_IsNull(result));
-    AR_EXP_Free(arExp);
+	/* 1 * null */
+	query = "RETURN 1 * null";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_TRUE(SIValue_IsNull(result));
+	AR_EXP_Free(arExp);
 
-    /* null / 1 */
-    query = "RETURN null / 1";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_TRUE(SIValue_IsNull(result));
-    AR_EXP_Free(arExp);
+	/* null / 1 */
+	query = "RETURN null / 1";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_TRUE(SIValue_IsNull(result));
+	AR_EXP_Free(arExp);
 
-    /* 1 / null */
-    query = "RETURN 1 / null";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_TRUE(SIValue_IsNull(result));
-    AR_EXP_Free(arExp);
+	/* 1 / null */
+	query = "RETURN 1 / null";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_TRUE(SIValue_IsNull(result));
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, AggregateTest)
-{
-    SIValue result;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, AggregateTest) {
+	SIValue result;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* SUM(1) */
-    query = "RETURN SUM(1)";
-    arExp = _exp_from_query(query);
+	/* SUM(1) */
+	query = "RETURN SUM(1)";
+	arExp = _exp_from_query(query);
 
-    AR_EXP_Aggregate(arExp, r);
-    AR_EXP_Aggregate(arExp, r);
-    AR_EXP_Aggregate(arExp, r);
-    AR_EXP_Reduce(arExp);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.doubleval, 3);
-    AR_EXP_Free(arExp);
+	AR_EXP_Aggregate(arExp, r);
+	AR_EXP_Aggregate(arExp, r);
+	AR_EXP_Aggregate(arExp, r);
+	AR_EXP_Reduce(arExp);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.doubleval, 3);
+	AR_EXP_Free(arExp);
 
-    /* 2+SUM(1) */
-    query = "RETURN 2+SUM(1)";
-    arExp = _exp_from_query(query);
-    AR_EXP_Aggregate(arExp, r);
-    AR_EXP_Aggregate(arExp, r);
-    AR_EXP_Aggregate(arExp, r);
-    AR_EXP_Reduce(arExp);
-    /* Just for the kick of it, call reduce more than once.*/
-    AR_EXP_Reduce(arExp);
+	/* 2+SUM(1) */
+	query = "RETURN 2+SUM(1)";
+	arExp = _exp_from_query(query);
+	AR_EXP_Aggregate(arExp, r);
+	AR_EXP_Aggregate(arExp, r);
+	AR_EXP_Aggregate(arExp, r);
+	AR_EXP_Reduce(arExp);
+	/* Just for the kick of it, call reduce more than once.*/
+	AR_EXP_Reduce(arExp);
 
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.doubleval, 5);
-    AR_EXP_Free(arExp);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.doubleval, 5);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, AbsTest)
-{
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, AbsTest) {
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* ABS(1) */
-    query = "RETURN ABS(1)";
-    arExp = _exp_from_query(query);
-    SIValue expected = SI_LongVal(1);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* ABS(1) */
+	query = "RETURN ABS(1)";
+	arExp = _exp_from_query(query);
+	SIValue expected = SI_LongVal(1);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* ABS(-1) */
-    query = "RETURN ABS(-1)";
-    arExp = _exp_from_query(query);
-    expected = SI_LongVal(1);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* ABS(-1) */
+	query = "RETURN ABS(-1)";
+	arExp = _exp_from_query(query);
+	expected = SI_LongVal(1);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* ABS(0) */
-    query = "RETURN ABS(0)";
-    arExp = _exp_from_query(query);
-    expected = SI_LongVal(0);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* ABS(0) */
+	query = "RETURN ABS(0)";
+	arExp = _exp_from_query(query);
+	expected = SI_LongVal(0);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* ABS() */
-    query = "RETURN ABS(NULL)";
-    arExp = _exp_from_query(query);
-    expected = SI_NullVal();
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* ABS() */
+	query = "RETURN ABS(NULL)";
+	arExp = _exp_from_query(query);
+	expected = SI_NullVal();
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, CeilTest)
-{
-    SIValue expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, CeilTest) {
+	SIValue expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* CEIL(0.5) */
-    query = "RETURN CEIL(0.5)";
-    arExp = _exp_from_query(query);
-    expected = SI_DoubleVal(1);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* CEIL(0.5) */
+	query = "RETURN CEIL(0.5)";
+	arExp = _exp_from_query(query);
+	expected = SI_DoubleVal(1);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* CEIL(1) */
-    query = "RETURN CEIL(1)";
-    arExp = _exp_from_query(query);
-    expected = SI_DoubleVal(1);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* CEIL(1) */
+	query = "RETURN CEIL(1)";
+	arExp = _exp_from_query(query);
+	expected = SI_DoubleVal(1);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* CEIL(0.1) */
-    query = "RETURN CEIL(0.1)";
-    arExp = _exp_from_query(query);
-    expected = SI_DoubleVal(1);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* CEIL(0.1) */
+	query = "RETURN CEIL(0.1)";
+	arExp = _exp_from_query(query);
+	expected = SI_DoubleVal(1);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* CEIL() */
-    query = "RETURN CEIL(NULL)";
-    arExp = _exp_from_query(query);
-    expected = SI_NullVal();
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* CEIL() */
+	query = "RETURN CEIL(NULL)";
+	arExp = _exp_from_query(query);
+	expected = SI_NullVal();
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, FloorTest)
-{
-    SIValue expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, FloorTest) {
+	SIValue expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* FLOOR(0.5) */
-    query = "RETURN FLOOR(0.5)";
-    arExp = _exp_from_query(query);
-    expected = SI_DoubleVal(0);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* FLOOR(0.5) */
+	query = "RETURN FLOOR(0.5)";
+	arExp = _exp_from_query(query);
+	expected = SI_DoubleVal(0);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* FLOOR(1) */
-    query = "RETURN FLOOR(1)";
-    arExp = _exp_from_query(query);
-    expected = SI_DoubleVal(1);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* FLOOR(1) */
+	query = "RETURN FLOOR(1)";
+	arExp = _exp_from_query(query);
+	expected = SI_DoubleVal(1);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* FLOOR(0.1) */
-    query = "RETURN FLOOR(0.1)";
-    arExp = _exp_from_query(query);
-    expected = SI_DoubleVal(0);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* FLOOR(0.1) */
+	query = "RETURN FLOOR(0.1)";
+	arExp = _exp_from_query(query);
+	expected = SI_DoubleVal(0);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* FLOOR() */
-    query = "RETURN FLOOR(NULL)";
-    arExp = _exp_from_query(query);
-    expected = SI_NullVal();
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* FLOOR() */
+	query = "RETURN FLOOR(NULL)";
+	arExp = _exp_from_query(query);
+	expected = SI_NullVal();
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, RoundTest)
-{
-    SIValue expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, RoundTest) {
+	SIValue expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* ROUND(0) */
-    query = "RETURN ROUND(0)";
-    arExp = _exp_from_query(query);
-    expected = SI_DoubleVal(0);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* ROUND(0) */
+	query = "RETURN ROUND(0)";
+	arExp = _exp_from_query(query);
+	expected = SI_DoubleVal(0);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* ROUND(0.49) */
-    query = "RETURN ROUND(0.49)";
-    arExp = _exp_from_query(query);
-    expected = SI_DoubleVal(0);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* ROUND(0.49) */
+	query = "RETURN ROUND(0.49)";
+	arExp = _exp_from_query(query);
+	expected = SI_DoubleVal(0);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* ROUND(0.5) */
-    query = "RETURN ROUND(0.5)";
-    arExp = _exp_from_query(query);
-    expected = SI_DoubleVal(1);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* ROUND(0.5) */
+	query = "RETURN ROUND(0.5)";
+	arExp = _exp_from_query(query);
+	expected = SI_DoubleVal(1);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* ROUND(1) */
-    query = "RETURN ROUND(1)";
-    arExp = _exp_from_query(query);
-    expected = SI_DoubleVal(1);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* ROUND(1) */
+	query = "RETURN ROUND(1)";
+	arExp = _exp_from_query(query);
+	expected = SI_DoubleVal(1);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* ROUND() */
-    query = "RETURN ROUND(NULL)";
-    arExp = _exp_from_query(query);
-    expected = SI_NullVal();
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* ROUND() */
+	query = "RETURN ROUND(NULL)";
+	arExp = _exp_from_query(query);
+	expected = SI_NullVal();
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, SignTest)
-{
-    SIValue expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, SignTest) {
+	SIValue expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* SIGN(0) */
-    query = "RETURN SIGN(0)";
-    arExp = _exp_from_query(query);
-    expected = SI_LongVal(0);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* SIGN(0) */
+	query = "RETURN SIGN(0)";
+	arExp = _exp_from_query(query);
+	expected = SI_LongVal(0);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* SIGN(-1) */
-    query = "RETURN SIGN(-1)";
-    arExp = _exp_from_query(query);
-    expected = SI_LongVal(-1);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* SIGN(-1) */
+	query = "RETURN SIGN(-1)";
+	arExp = _exp_from_query(query);
+	expected = SI_LongVal(-1);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* SIGN(1) */
-    query = "RETURN SIGN(1)";
-    arExp = _exp_from_query(query);
-    expected = SI_LongVal(1);
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* SIGN(1) */
+	query = "RETURN SIGN(1)";
+	arExp = _exp_from_query(query);
+	expected = SI_LongVal(1);
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 
-    /* SIGN() */
-    query = "RETURN SIGN(NULL)";
-    arExp = _exp_from_query(query);
-    expected = SI_NullVal();
-    _test_ar_func(arExp, expected, r);
-    AR_EXP_Free(arExp);
+	/* SIGN() */
+	query = "RETURN SIGN(NULL)";
+	arExp = _exp_from_query(query);
+	expected = SI_NullVal();
+	_test_ar_func(arExp, expected, r);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, ReverseTest)
-{
-    SIValue result;
-    const char *expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, ReverseTest) {
+	SIValue result;
+	const char *expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* REVERSE("muchacho") */
-    query = "RETURN REVERSE('muchacho')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "ohcahcum";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* REVERSE("muchacho") */
+	query = "RETURN REVERSE('muchacho')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "ohcahcum";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* REVERSE("") */
-    query = "RETURN REVERSE('')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* REVERSE("") */
+	query = "RETURN REVERSE('')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* REVERSE() */
-    query = "RETURN REVERSE(NULL)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_NULL);
-    AR_EXP_Free(arExp);
+	/* REVERSE() */
+	query = "RETURN REVERSE(NULL)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_NULL);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, LeftTest)
-{
-    SIValue result;
-    const char *expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, LeftTest) {
+	SIValue result;
+	const char *expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* LEFT("muchacho", 4) */
-    query = "RETURN LEFT('muchacho', 4)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "much";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* LEFT("muchacho", 4) */
+	query = "RETURN LEFT('muchacho', 4)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "much";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* LEFT("muchacho", 100) */
-    query = "RETURN LEFT('muchacho', 100)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* LEFT("muchacho", 100) */
+	query = "RETURN LEFT('muchacho', 100)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* LEFT(NULL, 100) */
-    query = "RETURN LEFT(NULL, 100)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_NULL);
-    AR_EXP_Free(arExp);
+	/* LEFT(NULL, 100) */
+	query = "RETURN LEFT(NULL, 100)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_NULL);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, RightTest)
-{
-    SIValue result;
-    const char *expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, RightTest) {
+	SIValue result;
+	const char *expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* RIGHT("muchacho", 4) */
-    query = "RETURN RIGHT('muchacho', 4)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "acho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* RIGHT("muchacho", 4) */
+	query = "RETURN RIGHT('muchacho', 4)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "acho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* RIGHT("muchacho", 100) */
-    query = "RETURN RIGHT('muchacho', 100)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* RIGHT("muchacho", 100) */
+	query = "RETURN RIGHT('muchacho', 100)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* RIGHT(NULL, 100) */
-    query = "RETURN RIGHT(NULL, 100)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_NULL);
-    AR_EXP_Free(arExp);
+	/* RIGHT(NULL, 100) */
+	query = "RETURN RIGHT(NULL, 100)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_NULL);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, LTrimTest)
-{
-    SIValue result;
-    const char *expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, LTrimTest) {
+	SIValue result;
+	const char *expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* lTrim("   muchacho") */
-    query = "RETURN lTrim('   muchacho')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* lTrim("   muchacho") */
+	query = "RETURN lTrim('   muchacho')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* lTrim("muchacho   ") */
-    query = "RETURN lTrim('muchacho   ')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho   ";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* lTrim("muchacho   ") */
+	query = "RETURN lTrim('muchacho   ')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho   ";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* lTrim("   much   acho   ") */
-    query = "RETURN lTrim('   much   acho   ')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "much   acho   ";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* lTrim("   much   acho   ") */
+	query = "RETURN lTrim('   much   acho   ')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "much   acho   ";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* lTrim("muchacho") */
-    query = "RETURN lTrim('muchacho')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* lTrim("muchacho") */
+	query = "RETURN lTrim('muchacho')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* lTrim() */
-    query = "RETURN lTrim(NULL)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_NULL);
-    AR_EXP_Free(arExp);
+	/* lTrim() */
+	query = "RETURN lTrim(NULL)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_NULL);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, RTrimTest)
-{
-    SIValue result;
-    const char *expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, RTrimTest) {
+	SIValue result;
+	const char *expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* rTrim("   muchacho") */
-    query = "RETURN rTrim('   muchacho')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "   muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* rTrim("   muchacho") */
+	query = "RETURN rTrim('   muchacho')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "   muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* rTrim("muchacho   ") */
-    query = "RETURN rTrim('muchacho   ')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* rTrim("muchacho   ") */
+	query = "RETURN rTrim('muchacho   ')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* rTrim("   much   acho   ") */
-    query = "RETURN rTrim('   much   acho   ')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "   much   acho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* rTrim("   much   acho   ") */
+	query = "RETURN rTrim('   much   acho   ')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "   much   acho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* rTrim("muchacho") */
-    query = "RETURN rTrim('muchacho')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* rTrim("muchacho") */
+	query = "RETURN rTrim('muchacho')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* rTrim() */
-    query = "RETURN rTrim(NULL)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_NULL);
-    AR_EXP_Free(arExp);
+	/* rTrim() */
+	query = "RETURN rTrim(NULL)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_NULL);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, TrimTest)
-{
-    SIValue result;
-    const char *expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, TrimTest) {
+	SIValue result;
+	const char *expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* trim("   muchacho") */
-    query = "RETURN trim('   muchacho')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* trim("   muchacho") */
+	query = "RETURN trim('   muchacho')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* trim("muchacho   ") */
-    query = "RETURN trim('muchacho   ')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* trim("muchacho   ") */
+	query = "RETURN trim('muchacho   ')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* trim("   much   acho   ") */
-    query = "RETURN trim('   much   acho   ')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "much   acho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* trim("   much   acho   ") */
+	query = "RETURN trim('   much   acho   ')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "much   acho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* trim("muchacho") */
-    query = "RETURN trim('muchacho')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* trim("muchacho") */
+	query = "RETURN trim('muchacho')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* trim() */
-    query = "RETURN trim(NULL)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_NULL);
-    AR_EXP_Free(arExp);
+	/* trim() */
+	query = "RETURN trim(NULL)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_NULL);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, SubstringTest)
-{
-    SIValue result;
-    const char *expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, SubstringTest) {
+	SIValue result;
+	const char *expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* SUBSTRING("muchacho", 0, 4) */
-    query = "RETURN SUBSTRING('muchacho', 0, 4)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "much";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* SUBSTRING("muchacho", 0, 4) */
+	query = "RETURN SUBSTRING('muchacho', 0, 4)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "much";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* SUBSTRING("muchacho", 3, 20) */
-    query = "RETURN SUBSTRING('muchacho', 3, 20)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "hacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* SUBSTRING("muchacho", 3, 20) */
+	query = "RETURN SUBSTRING('muchacho', 3, 20)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "hacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* SUBSTRING(NULL, 3, 20) */
-    query = "RETURN SUBSTRING(NULL, 3, 20)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_NULL);
-    AR_EXP_Free(arExp);
+	/* SUBSTRING(NULL, 3, 20) */
+	query = "RETURN SUBSTRING(NULL, 3, 20)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_NULL);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, ToLowerTest)
-{
-    SIValue result;
-    const char *expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, ToLowerTest) {
+	SIValue result;
+	const char *expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* toLower("MuChAcHo") */
-    query = "RETURN toLower('MuChAcHo')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* toLower("MuChAcHo") */
+	query = "RETURN toLower('MuChAcHo')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* toLower("mUcHaChO") */
-    query = "RETURN toLower('mUcHaChO')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* toLower("mUcHaChO") */
+	query = "RETURN toLower('mUcHaChO')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* toLower("mUcHaChO") */
-    query = "RETURN toLower(NULL)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_NULL);
-    AR_EXP_Free(arExp);
+	/* toLower("mUcHaChO") */
+	query = "RETURN toLower(NULL)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_NULL);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, ToUpperTest)
-{
-    SIValue result;
-    const char *expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, ToUpperTest) {
+	SIValue result;
+	const char *expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* toUpper("MuChAcHo") */
-    query = "RETURN toUpper('MuChAcHo')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "MUCHACHO";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* toUpper("MuChAcHo") */
+	query = "RETURN toUpper('MuChAcHo')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "MUCHACHO";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* toUpper("mUcHaChO") */
-    query = "RETURN toUpper('mUcHaChO')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "MUCHACHO";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* toUpper("mUcHaChO") */
+	query = "RETURN toUpper('mUcHaChO')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "MUCHACHO";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* toUpper("mUcHaChO") */
-    query = "RETURN toUpper(NULL)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_NULL);
-    AR_EXP_Free(arExp);
+	/* toUpper("mUcHaChO") */
+	query = "RETURN toUpper(NULL)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_NULL);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, ToStringTest)
-{
-    SIValue result;
-    const char *expected;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, ToStringTest) {
+	SIValue result;
+	const char *expected;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* toString("muchacho") */
-    query = "RETURN toString('muchacho')";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "muchacho";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* toString("muchacho") */
+	query = "RETURN toString('muchacho')";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "muchacho";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* toString("3.14") */
-    query = "RETURN toString(3.14)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    expected = "3.140000";
-    ASSERT_STREQ(result.stringval, expected);
-    AR_EXP_Free(arExp);
+	/* toString("3.14") */
+	query = "RETURN toString(3.14)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	expected = "3.140000";
+	ASSERT_STREQ(result.stringval, expected);
+	AR_EXP_Free(arExp);
 
-    /* toString() */
-    query = "RETURN toString(NULL)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_NULL);
-    AR_EXP_Free(arExp);
+	/* toString() */
+	query = "RETURN toString(NULL)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_NULL);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, ExistsTest)
-{
-    /* Although EXISTS is supposed to be called 
-   * using entity alias and property, to make things easy 
-   * within a unit-test context we simply pass an evaluation
-   * of an expression such as n.v, `null` when property `v`
-   * isn't in `n` and `1` when n.v evaluates to 1. */
+TEST_F(ArithmeticTest, ExistsTest) {
+	/* Although EXISTS is supposed to be called
+	* using entity alias and property, to make things easy
+	* within a unit-test context we simply pass an evaluation
+	* of an expression such as n.v, `null` when property `v`
+	* isn't in `n` and `1` when n.v evaluates to 1. */
 
-    SIValue result;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+	SIValue result;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    /* Pass NULL indicating n.v doesn't exists. */
-    query = "RETURN EXISTS(null)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_BOOL);
-    ASSERT_EQ(result.longval, 0);
-    AR_EXP_Free(arExp);
+	/* Pass NULL indicating n.v doesn't exists. */
+	query = "RETURN EXISTS(null)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_BOOL);
+	ASSERT_EQ(result.longval, 0);
+	AR_EXP_Free(arExp);
 
-    /* Pass 1, in case n.v exists and evaluates to 1. */
-    query = "RETURN EXISTS(1)";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
-    ASSERT_EQ(result.type, T_BOOL);
-    ASSERT_EQ(result.longval, 1);
-    AR_EXP_Free(arExp);
+	/* Pass 1, in case n.v exists and evaluates to 1. */
+	query = "RETURN EXISTS(1)";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
+	ASSERT_EQ(result.type, T_BOOL);
+	ASSERT_EQ(result.longval, 1);
+	AR_EXP_Free(arExp);
 }
 
-TEST_F(ArithmeticTest, TimestampTest)
-{
-    SIValue result;
-    const char *query;
-    AR_ExpNode *arExp;
-    Record r = Record_New(0);
+TEST_F(ArithmeticTest, TimestampTest) {
+	SIValue result;
+	const char *query;
+	AR_ExpNode *arExp;
+	Record r = Record_New(0);
 
-    struct timespec ts;
-    clock_gettime(CLOCK_REALTIME, &ts);
+	struct timespec ts;
+	clock_gettime(CLOCK_REALTIME, &ts);
 
-    query = "RETURN timestamp()";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, r);
+	query = "RETURN timestamp()";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, r);
 
-    ASSERT_LE(abs((1000 * ts.tv_sec + ts.tv_nsec / 1000000) - result.longval), 5);
+	ASSERT_LE(abs((1000 * ts.tv_sec + ts.tv_nsec / 1000000) - result.longval), 5);
 }
 
-TEST_F(ArithmeticTest, CaseTest)
-{
-    SIValue result;
-    SIValue expected = SI_LongVal(2);
-    const char *query;
-    AR_ExpNode *arExp;
+TEST_F(ArithmeticTest, CaseTest) {
+	SIValue result;
+	SIValue expected = SI_LongVal(2);
+	const char *query;
+	AR_ExpNode *arExp;
 
-    /* Test "Simple form"
-     * Match one of the alternatives. */
-    query = "RETURN CASE 'brown' WHEN 'blue' THEN 1+0 WHEN 'brown' THEN 2-0 ELSE 3*1 END";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, NULL);
-    AR_EXP_Free(arExp);
-    ASSERT_EQ(result.longval, expected.longval);
+	/* Test "Simple form"
+	 * Match one of the alternatives. */
+	query = "RETURN CASE 'brown' WHEN 'blue' THEN 1+0 WHEN 'brown' THEN 2-0 ELSE 3*1 END";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, NULL);
+	AR_EXP_Free(arExp);
+	ASSERT_EQ(result.longval, expected.longval);
 
-    /* Do not match any of the alternatives, return default. */
-    query = "RETURN CASE 'green' WHEN 'blue' THEN 1+0 WHEN 'brown' THEN 2-0 ELSE 3*1 END";
-    expected = SI_LongVal(3);
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, NULL);
-    AR_EXP_Free(arExp);
-    ASSERT_EQ(result.longval, expected.longval);
+	/* Do not match any of the alternatives, return default. */
+	query = "RETURN CASE 'green' WHEN 'blue' THEN 1+0 WHEN 'brown' THEN 2-0 ELSE 3*1 END";
+	expected = SI_LongVal(3);
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, NULL);
+	AR_EXP_Free(arExp);
+	ASSERT_EQ(result.longval, expected.longval);
 
-     /* Test "Generic form"
-     * One of the alternatives evaluates to a none null value. 
-     * Default not specified. */
-    query = "RETURN CASE WHEN NULL THEN 1+0 WHEN true THEN 2-0 END";
-    expected = SI_LongVal(2);
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, NULL);
-    AR_EXP_Free(arExp);    
-    ASSERT_EQ(result.longval, expected.longval);
+	/* Test "Generic form"
+	* One of the alternatives evaluates to a none null value.
+	* Default not specified. */
+	query = "RETURN CASE WHEN NULL THEN 1+0 WHEN true THEN 2-0 END";
+	expected = SI_LongVal(2);
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, NULL);
+	AR_EXP_Free(arExp);
+	ASSERT_EQ(result.longval, expected.longval);
 
-    /* None of the alternatives evaluates to a none null value. 
-     * Default specified, expecting default. */
-    query = "RETURN CASE WHEN NULL THEN 1+0 WHEN NULL THEN 2-0 ELSE 3*1 END";
-    expected = SI_LongVal(3);
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, NULL);
-    AR_EXP_Free(arExp);    
-    ASSERT_EQ(result.longval, expected.longval);
+	/* None of the alternatives evaluates to a none null value.
+	 * Default specified, expecting default. */
+	query = "RETURN CASE WHEN NULL THEN 1+0 WHEN NULL THEN 2-0 ELSE 3*1 END";
+	expected = SI_LongVal(3);
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, NULL);
+	AR_EXP_Free(arExp);
+	ASSERT_EQ(result.longval, expected.longval);
 
-    /* None of the alternatives evaluates to a none null value. 
-     * Default not specified, expecting NULL */
-    query = "RETURN CASE WHEN NULL THEN 1+0 WHEN NULL THEN 2-0 END";
-    arExp = _exp_from_query(query);
-    result = AR_EXP_Evaluate(arExp, NULL);
-    AR_EXP_Free(arExp);    
-    ASSERT_TRUE(SIValue_IsNull(result));
+	/* None of the alternatives evaluates to a none null value.
+	 * Default not specified, expecting NULL */
+	query = "RETURN CASE WHEN NULL THEN 1+0 WHEN NULL THEN 2-0 END";
+	arExp = _exp_from_query(query);
+	result = AR_EXP_Evaluate(arExp, NULL);
+	AR_EXP_Free(arExp);
+	ASSERT_TRUE(SIValue_IsNull(result));
 }
 
-TEST_F(ArithmeticTest, AND)
-{
-    SIValue truth_table [27] = {
-        SI_ConstStringVal("false"), SI_ConstStringVal("false"), SI_BoolVal(false),
-        SI_ConstStringVal("false"), SI_ConstStringVal("true"), SI_BoolVal(false),
-        SI_ConstStringVal("false"), SI_NullVal(), SI_NullVal(),
-        SI_ConstStringVal("true"), SI_ConstStringVal("false"), SI_BoolVal(false),
-        SI_ConstStringVal("true"), SI_ConstStringVal("true"), SI_BoolVal(true),
-        SI_ConstStringVal("true"), SI_NullVal(), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("false"), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("true"), SI_NullVal(),
-        SI_NullVal(), SI_NullVal(), SI_NullVal()
-    };
+TEST_F(ArithmeticTest, AND) {
+	SIValue truth_table [27] = {
+		SI_ConstStringVal("false"), SI_ConstStringVal("false"), SI_BoolVal(false),
+		SI_ConstStringVal("false"), SI_ConstStringVal("true"), SI_BoolVal(false),
+		SI_ConstStringVal("false"), SI_NullVal(), SI_NullVal(),
+		SI_ConstStringVal("true"), SI_ConstStringVal("false"), SI_BoolVal(false),
+		SI_ConstStringVal("true"), SI_ConstStringVal("true"), SI_BoolVal(true),
+		SI_ConstStringVal("true"), SI_NullVal(), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("false"), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("true"), SI_NullVal(),
+		SI_NullVal(), SI_NullVal(), SI_NullVal()
+	};
 
-    for(int i = 0; i < 27; i += 3) {
-        SIValue a = truth_table[i];
-        SIValue b = truth_table[i + 1];
-        SIValue expected = truth_table[i + 2];
+	for(int i = 0; i < 27; i += 3) {
+		SIValue a = truth_table[i];
+		SIValue b = truth_table[i + 1];
+		SIValue expected = truth_table[i + 2];
 
-        char *query;
-        asprintf(&query, "RETURN %s AND %s", a.stringval, b.stringval);
-        AR_ExpNode *arExp = _exp_from_query(query);
-        SIValue result = AR_EXP_Evaluate(arExp, NULL);
-        AR_EXP_Free(arExp);
+		char *query;
+		asprintf(&query, "RETURN %s AND %s", a.stringval, b.stringval);
+		AR_ExpNode *arExp = _exp_from_query(query);
+		SIValue result = AR_EXP_Evaluate(arExp, NULL);
+		AR_EXP_Free(arExp);
 
-        ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
-        if(SI_TYPE(result) != T_NULL) {
-            ASSERT_EQ(result.longval, expected.longval);
-        }
-    }
+		ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
+		if(SI_TYPE(result) != T_NULL) {
+			ASSERT_EQ(result.longval, expected.longval);
+		}
+	}
 }
 
-TEST_F(ArithmeticTest, OR)
-{
-    SIValue truth_table [27] = {
-        SI_ConstStringVal("false"), SI_ConstStringVal("false"), SI_BoolVal(false),
-        SI_ConstStringVal("false"), SI_ConstStringVal("true"), SI_BoolVal(true),
-        SI_ConstStringVal("false"), SI_NullVal(), SI_NullVal(),
-        SI_ConstStringVal("true"), SI_ConstStringVal("false"), SI_BoolVal(true),
-        SI_ConstStringVal("true"), SI_ConstStringVal("true"), SI_BoolVal(true),
-        SI_ConstStringVal("true"), SI_NullVal(), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("false"), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("true"), SI_NullVal(),
-        SI_NullVal(), SI_NullVal(), SI_NullVal()
-    };
+TEST_F(ArithmeticTest, OR) {
+	SIValue truth_table [27] = {
+		SI_ConstStringVal("false"), SI_ConstStringVal("false"), SI_BoolVal(false),
+		SI_ConstStringVal("false"), SI_ConstStringVal("true"), SI_BoolVal(true),
+		SI_ConstStringVal("false"), SI_NullVal(), SI_NullVal(),
+		SI_ConstStringVal("true"), SI_ConstStringVal("false"), SI_BoolVal(true),
+		SI_ConstStringVal("true"), SI_ConstStringVal("true"), SI_BoolVal(true),
+		SI_ConstStringVal("true"), SI_NullVal(), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("false"), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("true"), SI_NullVal(),
+		SI_NullVal(), SI_NullVal(), SI_NullVal()
+	};
 
-    for(int i = 0; i < 27; i += 3) {
-        SIValue a = truth_table[i];
-        SIValue b = truth_table[i + 1];
-        SIValue expected = truth_table[i + 2];
+	for(int i = 0; i < 27; i += 3) {
+		SIValue a = truth_table[i];
+		SIValue b = truth_table[i + 1];
+		SIValue expected = truth_table[i + 2];
 
-        char *query;
-        asprintf(&query, "RETURN %s OR %s", a.stringval, b.stringval);
-        AR_ExpNode *arExp = _exp_from_query(query);
-        SIValue result = AR_EXP_Evaluate(arExp, NULL);
-        AR_EXP_Free(arExp);
+		char *query;
+		asprintf(&query, "RETURN %s OR %s", a.stringval, b.stringval);
+		AR_ExpNode *arExp = _exp_from_query(query);
+		SIValue result = AR_EXP_Evaluate(arExp, NULL);
+		AR_EXP_Free(arExp);
 
-        ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
-        if(SI_TYPE(result) != T_NULL) {
-            ASSERT_EQ(result.longval, expected.longval);
-        }
-    }
+		ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
+		if(SI_TYPE(result) != T_NULL) {
+			ASSERT_EQ(result.longval, expected.longval);
+		}
+	}
 }
 
-TEST_F(ArithmeticTest, XOR)
-{
-    SIValue truth_table [27] = {
-        SI_ConstStringVal("false"), SI_ConstStringVal("false"), SI_BoolVal(false),
-        SI_ConstStringVal("false"), SI_ConstStringVal("true"), SI_BoolVal(true),
-        SI_ConstStringVal("false"), SI_NullVal(), SI_NullVal(),
-        SI_ConstStringVal("true"), SI_ConstStringVal("false"), SI_BoolVal(true),
-        SI_ConstStringVal("true"), SI_ConstStringVal("true"), SI_BoolVal(false),
-        SI_ConstStringVal("true"), SI_NullVal(), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("false"), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("true"), SI_NullVal(),
-        SI_NullVal(), SI_NullVal(), SI_NullVal()
-    };
+TEST_F(ArithmeticTest, XOR) {
+	SIValue truth_table [27] = {
+		SI_ConstStringVal("false"), SI_ConstStringVal("false"), SI_BoolVal(false),
+		SI_ConstStringVal("false"), SI_ConstStringVal("true"), SI_BoolVal(true),
+		SI_ConstStringVal("false"), SI_NullVal(), SI_NullVal(),
+		SI_ConstStringVal("true"), SI_ConstStringVal("false"), SI_BoolVal(true),
+		SI_ConstStringVal("true"), SI_ConstStringVal("true"), SI_BoolVal(false),
+		SI_ConstStringVal("true"), SI_NullVal(), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("false"), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("true"), SI_NullVal(),
+		SI_NullVal(), SI_NullVal(), SI_NullVal()
+	};
 
-    for(int i = 0; i < 27; i += 3) {
-        SIValue a = truth_table[i];
-        SIValue b = truth_table[i + 1];
-        SIValue expected = truth_table[i + 2];
+	for(int i = 0; i < 27; i += 3) {
+		SIValue a = truth_table[i];
+		SIValue b = truth_table[i + 1];
+		SIValue expected = truth_table[i + 2];
 
-        char *query;
-        asprintf(&query, "RETURN %s XOR %s", a.stringval, b.stringval);
-        AR_ExpNode *arExp = _exp_from_query(query);
-        SIValue result = AR_EXP_Evaluate(arExp, NULL);
-        AR_EXP_Free(arExp);
+		char *query;
+		asprintf(&query, "RETURN %s XOR %s", a.stringval, b.stringval);
+		AR_ExpNode *arExp = _exp_from_query(query);
+		SIValue result = AR_EXP_Evaluate(arExp, NULL);
+		AR_EXP_Free(arExp);
 
-        ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
-        if(SI_TYPE(result) != T_NULL) {
-            ASSERT_EQ(result.longval, expected.longval);
-        }
-    }
+		ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
+		if(SI_TYPE(result) != T_NULL) {
+			ASSERT_EQ(result.longval, expected.longval);
+		}
+	}
 }
 
-TEST_F(ArithmeticTest, NOT)
-{
-SIValue truth_table [6] = {
-        SI_ConstStringVal("false"), SI_BoolVal(true),
-        SI_ConstStringVal("true"), SI_BoolVal(false),
-        SI_NullVal(),  SI_NullVal()
-    };
+TEST_F(ArithmeticTest, NOT) {
+	SIValue truth_table [6] = {
+		SI_ConstStringVal("false"), SI_BoolVal(true),
+		SI_ConstStringVal("true"), SI_BoolVal(false),
+		SI_NullVal(),  SI_NullVal()
+	};
 
-    for(int i = 0; i < 6; i += 2) {
-        SIValue a = truth_table[i];
-        SIValue expected = truth_table[i + 1];
+	for(int i = 0; i < 6; i += 2) {
+		SIValue a = truth_table[i];
+		SIValue expected = truth_table[i + 1];
 
-        char *query;
-        asprintf(&query, "RETURN NOT %s", a.stringval);
-        AR_ExpNode *arExp = _exp_from_query(query);
-        SIValue result = AR_EXP_Evaluate(arExp, NULL);
-        AR_EXP_Free(arExp);
+		char *query;
+		asprintf(&query, "RETURN NOT %s", a.stringval);
+		AR_ExpNode *arExp = _exp_from_query(query);
+		SIValue result = AR_EXP_Evaluate(arExp, NULL);
+		AR_EXP_Free(arExp);
 
-        ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
-        if(SI_TYPE(result) != T_NULL) {
-            ASSERT_EQ(result.longval, expected.longval);
-        }
-    }
+		ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
+		if(SI_TYPE(result) != T_NULL) {
+			ASSERT_EQ(result.longval, expected.longval);
+		}
+	}
 }
 
-TEST_F(ArithmeticTest, GT)
-{
-    SIValue truth_table [27] = {
-        SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(false),
-        SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(false),
-        SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
-        SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(true),
-        SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(false),
-        SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
-        SI_NullVal(), SI_NullVal(), SI_NullVal()
-    };
+TEST_F(ArithmeticTest, GT) {
+	SIValue truth_table [27] = {
+		SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(false),
+		SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(false),
+		SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
+		SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(true),
+		SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(false),
+		SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
+		SI_NullVal(), SI_NullVal(), SI_NullVal()
+	};
 
-    for(int i = 0; i < 27; i += 3) {
-        SIValue a = truth_table[i];
-        SIValue b = truth_table[i + 1];
-        SIValue expected = truth_table[i + 2];
+	for(int i = 0; i < 27; i += 3) {
+		SIValue a = truth_table[i];
+		SIValue b = truth_table[i + 1];
+		SIValue expected = truth_table[i + 2];
 
-        char *query;
-        asprintf(&query, "RETURN %s > %s", a.stringval, b.stringval);
-        AR_ExpNode *arExp = _exp_from_query(query);
-        SIValue result = AR_EXP_Evaluate(arExp, NULL);
-        AR_EXP_Free(arExp);
+		char *query;
+		asprintf(&query, "RETURN %s > %s", a.stringval, b.stringval);
+		AR_ExpNode *arExp = _exp_from_query(query);
+		SIValue result = AR_EXP_Evaluate(arExp, NULL);
+		AR_EXP_Free(arExp);
 
-        ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
-        if(SI_TYPE(result) != T_NULL) {
-            ASSERT_EQ(result.longval, expected.longval);
-        }
-    }
+		ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
+		if(SI_TYPE(result) != T_NULL) {
+			ASSERT_EQ(result.longval, expected.longval);
+		}
+	}
 }
 
-TEST_F(ArithmeticTest, GE)
-{
-    SIValue truth_table [27] = {
-        SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(true),
-        SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(false),
-        SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
-        SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(true),
-        SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(true),
-        SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
-        SI_NullVal(), SI_NullVal(), SI_NullVal()
-    };
+TEST_F(ArithmeticTest, GE) {
+	SIValue truth_table [27] = {
+		SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(true),
+		SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(false),
+		SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
+		SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(true),
+		SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(true),
+		SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
+		SI_NullVal(), SI_NullVal(), SI_NullVal()
+	};
 
-    for(int i = 0; i < 27; i += 3) {
-        SIValue a = truth_table[i];
-        SIValue b = truth_table[i + 1];
-        SIValue expected = truth_table[i + 2];
+	for(int i = 0; i < 27; i += 3) {
+		SIValue a = truth_table[i];
+		SIValue b = truth_table[i + 1];
+		SIValue expected = truth_table[i + 2];
 
-        char *query;
-        asprintf(&query, "RETURN %s >= %s", a.stringval, b.stringval);
-        AR_ExpNode *arExp = _exp_from_query(query);
-        SIValue result = AR_EXP_Evaluate(arExp, NULL);
-        AR_EXP_Free(arExp);
+		char *query;
+		asprintf(&query, "RETURN %s >= %s", a.stringval, b.stringval);
+		AR_ExpNode *arExp = _exp_from_query(query);
+		SIValue result = AR_EXP_Evaluate(arExp, NULL);
+		AR_EXP_Free(arExp);
 
-        ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
-        if(SI_TYPE(result) != T_NULL) {
-            ASSERT_EQ(result.longval, expected.longval);
-        }
-    }
+		ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
+		if(SI_TYPE(result) != T_NULL) {
+			ASSERT_EQ(result.longval, expected.longval);
+		}
+	}
 }
 
-TEST_F(ArithmeticTest, LT)
-{
-    SIValue truth_table [27] = {
-        SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(false),
-        SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(true),
-        SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
-        SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(false),
-        SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(false),
-        SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
-        SI_NullVal(), SI_NullVal(), SI_NullVal()
-    };
+TEST_F(ArithmeticTest, LT) {
+	SIValue truth_table [27] = {
+		SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(false),
+		SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(true),
+		SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
+		SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(false),
+		SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(false),
+		SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
+		SI_NullVal(), SI_NullVal(), SI_NullVal()
+	};
 
-    for(int i = 0; i < 27; i += 3) {
-        SIValue a = truth_table[i];
-        SIValue b = truth_table[i + 1];
-        SIValue expected = truth_table[i + 2];
+	for(int i = 0; i < 27; i += 3) {
+		SIValue a = truth_table[i];
+		SIValue b = truth_table[i + 1];
+		SIValue expected = truth_table[i + 2];
 
-        char *query;
-        asprintf(&query, "RETURN %s < %s", a.stringval, b.stringval);
-        AR_ExpNode *arExp = _exp_from_query(query);
-        SIValue result = AR_EXP_Evaluate(arExp, NULL);
-        AR_EXP_Free(arExp);
+		char *query;
+		asprintf(&query, "RETURN %s < %s", a.stringval, b.stringval);
+		AR_ExpNode *arExp = _exp_from_query(query);
+		SIValue result = AR_EXP_Evaluate(arExp, NULL);
+		AR_EXP_Free(arExp);
 
-        ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
-        if(SI_TYPE(result) != T_NULL) {
-            ASSERT_EQ(result.longval, expected.longval);
-        }
-    }
+		ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
+		if(SI_TYPE(result) != T_NULL) {
+			ASSERT_EQ(result.longval, expected.longval);
+		}
+	}
 }
 
-TEST_F(ArithmeticTest, LE)
-{
-    SIValue truth_table [27] = {
-        SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(true),
-        SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(true),
-        SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
-        SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(false),
-        SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(true),
-        SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
-        SI_NullVal(), SI_NullVal(), SI_NullVal()
-    };
+TEST_F(ArithmeticTest, LE) {
+	SIValue truth_table [27] = {
+		SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(true),
+		SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(true),
+		SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
+		SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(false),
+		SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(true),
+		SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
+		SI_NullVal(), SI_NullVal(), SI_NullVal()
+	};
 
-    for(int i = 0; i < 27; i += 3) {
-        SIValue a = truth_table[i];
-        SIValue b = truth_table[i + 1];
-        SIValue expected = truth_table[i + 2];
+	for(int i = 0; i < 27; i += 3) {
+		SIValue a = truth_table[i];
+		SIValue b = truth_table[i + 1];
+		SIValue expected = truth_table[i + 2];
 
-        char *query;
-        asprintf(&query, "RETURN %s <= %s", a.stringval, b.stringval);
-        AR_ExpNode *arExp = _exp_from_query(query);
-        SIValue result = AR_EXP_Evaluate(arExp, NULL);
-        AR_EXP_Free(arExp);
+		char *query;
+		asprintf(&query, "RETURN %s <= %s", a.stringval, b.stringval);
+		AR_ExpNode *arExp = _exp_from_query(query);
+		SIValue result = AR_EXP_Evaluate(arExp, NULL);
+		AR_EXP_Free(arExp);
 
-        ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
-        if(SI_TYPE(result) != T_NULL) {
-            ASSERT_EQ(result.longval, expected.longval);
-        }
-    }
+		ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
+		if(SI_TYPE(result) != T_NULL) {
+			ASSERT_EQ(result.longval, expected.longval);
+		}
+	}
 }
 
-TEST_F(ArithmeticTest, EQ)
-{
-    SIValue truth_table [27] = {
-        SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(true),
-        SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(false),
-        SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
-        SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(false),
-        SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(true),
-        SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
-        SI_NullVal(), SI_NullVal(), SI_NullVal()
-    };
+TEST_F(ArithmeticTest, EQ) {
+	SIValue truth_table [27] = {
+		SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(true),
+		SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(false),
+		SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
+		SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(false),
+		SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(true),
+		SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
+		SI_NullVal(), SI_NullVal(), SI_NullVal()
+	};
 
-    for(int i = 0; i < 27; i += 3) {
-        SIValue a = truth_table[i];
-        SIValue b = truth_table[i + 1];
-        SIValue expected = truth_table[i + 2];
+	for(int i = 0; i < 27; i += 3) {
+		SIValue a = truth_table[i];
+		SIValue b = truth_table[i + 1];
+		SIValue expected = truth_table[i + 2];
 
-        char *query;
-        asprintf(&query, "RETURN %s = %s", a.stringval, b.stringval);
-        AR_ExpNode *arExp = _exp_from_query(query);
-        SIValue result = AR_EXP_Evaluate(arExp, NULL);
-        AR_EXP_Free(arExp);
+		char *query;
+		asprintf(&query, "RETURN %s = %s", a.stringval, b.stringval);
+		AR_ExpNode *arExp = _exp_from_query(query);
+		SIValue result = AR_EXP_Evaluate(arExp, NULL);
+		AR_EXP_Free(arExp);
 
-        ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
-        if(SI_TYPE(result) != T_NULL) {
-            ASSERT_EQ(result.longval, expected.longval);
-        }
-    }
+		ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
+		if(SI_TYPE(result) != T_NULL) {
+			ASSERT_EQ(result.longval, expected.longval);
+		}
+	}
 }
 
-TEST_F(ArithmeticTest, NE)
-{
-    SIValue truth_table [27] = {
-        SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(false),
-        SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(true),
-        SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
-        SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(true),
-        SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(false),
-        SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
-        SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
-        SI_NullVal(), SI_NullVal(), SI_NullVal()
-    };
+TEST_F(ArithmeticTest, NE) {
+	SIValue truth_table [27] = {
+		SI_ConstStringVal("1"), SI_ConstStringVal("1"), SI_BoolVal(false),
+		SI_ConstStringVal("1"), SI_ConstStringVal("2"), SI_BoolVal(true),
+		SI_ConstStringVal("1"), SI_NullVal(), SI_NullVal(),
+		SI_ConstStringVal("2"), SI_ConstStringVal("1"), SI_BoolVal(true),
+		SI_ConstStringVal("2"), SI_ConstStringVal("2"), SI_BoolVal(false),
+		SI_ConstStringVal("2"), SI_NullVal(), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("1"), SI_NullVal(),
+		SI_NullVal(), SI_ConstStringVal("2"), SI_NullVal(),
+		SI_NullVal(), SI_NullVal(), SI_NullVal()
+	};
 
-    for(int i = 0; i < 27; i += 3) {
-        SIValue a = truth_table[i];
-        SIValue b = truth_table[i + 1];
-        SIValue expected = truth_table[i + 2];
+	for(int i = 0; i < 27; i += 3) {
+		SIValue a = truth_table[i];
+		SIValue b = truth_table[i + 1];
+		SIValue expected = truth_table[i + 2];
 
-        char *query;
-        asprintf(&query, "RETURN %s <> %s", a.stringval, b.stringval);
-        AR_ExpNode *arExp = _exp_from_query(query);
-        SIValue result = AR_EXP_Evaluate(arExp, NULL);
-        AR_EXP_Free(arExp);
+		char *query;
+		asprintf(&query, "RETURN %s <> %s", a.stringval, b.stringval);
+		AR_ExpNode *arExp = _exp_from_query(query);
+		SIValue result = AR_EXP_Evaluate(arExp, NULL);
+		AR_EXP_Free(arExp);
 
-        ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
-        if(SI_TYPE(result) != T_NULL) {
-            ASSERT_EQ(result.longval, expected.longval);
-        }
-    }
+		ASSERT_EQ(SI_TYPE(result), SI_TYPE(expected));
+		if(SI_TYPE(result) != T_NULL) {
+			ASSERT_EQ(result.longval, expected.longval);
+		}
+	}
 }

--- a/tests/unit/test_bfs.cpp
+++ b/tests/unit/test_bfs.cpp
@@ -20,130 +20,128 @@ extern "C" {
 #endif
 
 class BFSTest: public ::testing::Test {
-    public:
-    static QGNode *A;
-    static QGNode *B;
-    static QGNode *C;
-    static QGNode *D;
-    static QGEdge *AB;
-    static QGEdge *BC;
-    static QGEdge *BD;
+  public:
+	static QGNode *A;
+	static QGNode *B;
+	static QGNode *C;
+	static QGNode *D;
+	static QGEdge *AB;
+	static QGEdge *BC;
+	static QGEdge *BD;
 
-    protected:
-    static void SetUpTestCase()
-    {
-        // Use the malloc family for allocations
-        Alloc_Reset();
-    }
+  protected:
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
+	}
 
-    static QueryGraph* BuildGraph()
-    {
-        // (A)->(B)
-        // (B)->(C)
-        // (B)->(D)
-        size_t node_cap = 4;
-        size_t edge_cap = 3;
+	static QueryGraph *BuildGraph() {
+		// (A)->(B)
+		// (B)->(C)
+		// (B)->(D)
+		size_t node_cap = 4;
+		size_t edge_cap = 3;
 
-        // Create nodes.
-        const char *label = "L";
-        const char *relation = "R";
+		// Create nodes.
+		const char *label = "L";
+		const char *relation = "R";
 
-        uint id = 0;
-        A = QGNode_New(label, "A", id++);
-        B = QGNode_New(label, "B", id++);
-        C = QGNode_New(label, "C", id++);
-        D = QGNode_New(label, "D", id++);
+		uint id = 0;
+		A = QGNode_New(label, "A", id++);
+		B = QGNode_New(label, "B", id++);
+		C = QGNode_New(label, "C", id++);
+		D = QGNode_New(label, "D", id++);
 
-        AB = QGEdge_New(A, B, relation, "AB", id++);
-        BC = QGEdge_New(B, C, relation, "BC", id++);
-        BD = QGEdge_New(B, D, relation, "BD", id++);
+		AB = QGEdge_New(A, B, relation, "AB", id++);
+		BC = QGEdge_New(B, C, relation, "BC", id++);
+		BD = QGEdge_New(B, D, relation, "BD", id++);
 
-        QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
-        QueryGraph_AddNode(g, A);
-        QueryGraph_AddNode(g, B);
-        QueryGraph_AddNode(g, C);
-        QueryGraph_AddNode(g, D);
+		QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
+		QueryGraph_AddNode(g, A);
+		QueryGraph_AddNode(g, B);
+		QueryGraph_AddNode(g, C);
+		QueryGraph_AddNode(g, D);
 
-        QueryGraph_ConnectNodes(g, A, B, AB);
-        QueryGraph_ConnectNodes(g, B, C, BC);
-        QueryGraph_ConnectNodes(g, B, D, BD);
+		QueryGraph_ConnectNodes(g, A, B, AB);
+		QueryGraph_ConnectNodes(g, B, C, BC);
+		QueryGraph_ConnectNodes(g, B, D, BD);
 
-        return g;
-    }
+		return g;
+	}
 };
 
 TEST_F(BFSTest, BFSLevels) {
-    QGNode *S;                  // BFS starts here.
-    QGNode **nodes;             // Nodes reached by BFS.
-    QueryGraph *g;              // Graph traversed.
-    int level = 0;              // BFS stops when reach level depth.
+	QGNode *S;                  // BFS starts here.
+	QGNode **nodes;             // Nodes reached by BFS.
+	QueryGraph *g;              // Graph traversed.
+	int level = 0;              // BFS stops when reach level depth.
 
-    g = BuildGraph();
-    // S = QueryGraph_GetNodeByID(g, A->id);
-    S = A;
+	g = BuildGraph();
+	// S = QueryGraph_GetNodeByID(g, A->id);
+	S = A;
 
-    QGNode *expected_level_0[1] = {A};
-    QGNode *expected_level_1[1] = {B};
-    QGNode *expected_level_2[2] = {C, D};
-    QGNode *expected_level_3[0];
-    QGNode *expected_level_deepest[2] = {C, D};
-    
-    QGNode **expected[4] = {
-        expected_level_0,
-        expected_level_1,
-        expected_level_2,
-        expected_level_3
-    };
+	QGNode *expected_level_0[1] = {A};
+	QGNode *expected_level_1[1] = {B};
+	QGNode *expected_level_2[2] = {C, D};
+	QGNode *expected_level_3[0];
+	QGNode *expected_level_deepest[2] = {C, D};
 
-    //------------------------------------------------------------------------------
-    // BFS depth 0 - 3
-    //------------------------------------------------------------------------------
-    
+	QGNode **expected[4] = {
+		expected_level_0,
+		expected_level_1,
+		expected_level_2,
+		expected_level_3
+	};
 
-    for(; level < 4; level++) {
-        nodes = BFS(S, &level);
-        QGNode **expectation = expected[level];
+	//------------------------------------------------------------------------------
+	// BFS depth 0 - 3
+	//------------------------------------------------------------------------------
 
-        int node_count = array_len(nodes);
-        for(int i = 0; i < node_count; i++) {
-            bool found = false;
-            for(int j = 0; j < node_count; j++) {
-                if(nodes[i] == expectation[j]) {
-                    found = true;
-                    break;
-                }
-            }
-            ASSERT_TRUE(found);
-        }
 
-        array_free(nodes); 
-    }
-   
-    //------------------------------------------------------------------------------
-    // BFS depth BFS_LOWEST_LEVEL
-    //------------------------------------------------------------------------------
+	for(; level < 4; level++) {
+		nodes = BFS(S, &level);
+		QGNode **expectation = expected[level];
 
-    level = BFS_LOWEST_LEVEL;
-    nodes = BFS(S, &level);
+		int node_count = array_len(nodes);
+		for(int i = 0; i < node_count; i++) {
+			bool found = false;
+			for(int j = 0; j < node_count; j++) {
+				if(nodes[i] == expectation[j]) {
+					found = true;
+					break;
+				}
+			}
+			ASSERT_TRUE(found);
+		}
 
-    // Determine number of expected nodes.
-    int expected_node_count = sizeof(expected_level_deepest) / sizeof(expected_level_deepest[0]);
-    ASSERT_EQ(expected_node_count, array_len(nodes));
+		array_free(nodes);
+	}
 
-    for(int i = 0; i < expected_node_count; i++) {
-        bool found = false;
-        for(int j = 0; j < expected_node_count; j++) {
-            if(nodes[i] == expected_level_deepest[j]) {
-                found = true;
-                break;
-            }
-        }
-        ASSERT_TRUE(found);
-    }
+	//------------------------------------------------------------------------------
+	// BFS depth BFS_LOWEST_LEVEL
+	//------------------------------------------------------------------------------
 
-    // Clean up.
-    array_free(nodes);    
-    QueryGraph_Free(g);
+	level = BFS_LOWEST_LEVEL;
+	nodes = BFS(S, &level);
+
+	// Determine number of expected nodes.
+	int expected_node_count = sizeof(expected_level_deepest) / sizeof(expected_level_deepest[0]);
+	ASSERT_EQ(expected_node_count, array_len(nodes));
+
+	for(int i = 0; i < expected_node_count; i++) {
+		bool found = false;
+		for(int j = 0; j < expected_node_count; j++) {
+			if(nodes[i] == expected_level_deepest[j]) {
+				found = true;
+				break;
+			}
+		}
+		ASSERT_TRUE(found);
+	}
+
+	// Clean up.
+	array_free(nodes);
+	QueryGraph_Free(g);
 }
 
 // Static function declarations

--- a/tests/unit/test_datablock.cpp
+++ b/tests/unit/test_datablock.cpp
@@ -22,167 +22,167 @@ extern "C" {
 
 class DataBlockTest: public ::testing::Test {
   protected:
-    static void SetUpTestCase() {
-        // Use the malloc family for allocations
-        Alloc_Reset();
-    }
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
+	}
 };
 
 
 TEST_F(DataBlockTest, New) {
-    // Create a new data block, which can hold at least 1024 items
-    // each item is an integer.
-    size_t itemSize = sizeof(int);
-    DataBlock *dataBlock = DataBlock_New(1024, itemSize, NULL);
+	// Create a new data block, which can hold at least 1024 items
+	// each item is an integer.
+	size_t itemSize = sizeof(int);
+	DataBlock *dataBlock = DataBlock_New(1024, itemSize, NULL);
 
-    ASSERT_EQ(dataBlock->itemCount, 0);     // No items were added. 
-    ASSERT_GE(dataBlock->itemCap, 1024);
-    ASSERT_EQ(dataBlock->itemSize, itemSize);      
-    ASSERT_GE(dataBlock->blockCount, 1024/BLOCK_CAP);
+	ASSERT_EQ(dataBlock->itemCount, 0);     // No items were added.
+	ASSERT_GE(dataBlock->itemCap, 1024);
+	ASSERT_EQ(dataBlock->itemSize, itemSize);
+	ASSERT_GE(dataBlock->blockCount, 1024 / BLOCK_CAP);
 
-    for(int i = 0; i < dataBlock->blockCount; i++) {
-        Block *block = dataBlock->blocks[i];
-        ASSERT_EQ(block->itemSize, dataBlock->itemSize);
-        ASSERT_TRUE(block->data != NULL);
-        if(i > 0) {
-            ASSERT_TRUE(dataBlock->blocks[i-1]->next == dataBlock->blocks[i]);
-        }
-    }
+	for(int i = 0; i < dataBlock->blockCount; i++) {
+		Block *block = dataBlock->blocks[i];
+		ASSERT_EQ(block->itemSize, dataBlock->itemSize);
+		ASSERT_TRUE(block->data != NULL);
+		if(i > 0) {
+			ASSERT_TRUE(dataBlock->blocks[i - 1]->next == dataBlock->blocks[i]);
+		}
+	}
 
-    DataBlock_Free(dataBlock);
+	DataBlock_Free(dataBlock);
 }
 
 TEST_F(DataBlockTest, AddItem) {
-    DataBlock *dataBlock = DataBlock_New(1024, sizeof(int), NULL);
-    size_t itemCount = 512;
-    DataBlock_Accommodate(dataBlock, itemCount);
-    ASSERT_GE(dataBlock->itemCap, itemCount);
+	DataBlock *dataBlock = DataBlock_New(1024, sizeof(int), NULL);
+	size_t itemCount = 512;
+	DataBlock_Accommodate(dataBlock, itemCount);
+	ASSERT_GE(dataBlock->itemCap, itemCount);
 
-    // Set items.
-    for(int i = 0 ; i < itemCount; i++) {
-        int *value = (int*)DataBlock_AllocateItem(dataBlock, NULL);
-        *value = i;
-    }
+	// Set items.
+	for(int i = 0 ; i < itemCount; i++) {
+		int *value = (int *)DataBlock_AllocateItem(dataBlock, NULL);
+		*value = i;
+	}
 
-    // Read items.
-    for(int i = 0 ; i < itemCount; i++) {
-        int *value = (int*)DataBlock_GetItem(dataBlock, i);
-        ASSERT_EQ(*value, i);
-    }
+	// Read items.
+	for(int i = 0 ; i < itemCount; i++) {
+		int *value = (int *)DataBlock_GetItem(dataBlock, i);
+		ASSERT_EQ(*value, i);
+	}
 
-    // Add enough item to cause datablock to re-allocate.
-    size_t prevItemCount = dataBlock->itemCount;
-    itemCount*=64;
-    DataBlock_Accommodate(dataBlock, itemCount);
-    ASSERT_GE(dataBlock->itemCap, prevItemCount+itemCount);
-    
-    // Set items.
-    for(int i = 0 ; i < itemCount; i++) {
-        int *value = (int*)DataBlock_AllocateItem(dataBlock, NULL);
-        *value = prevItemCount + i;
-    }
+	// Add enough item to cause datablock to re-allocate.
+	size_t prevItemCount = dataBlock->itemCount;
+	itemCount *= 64;
+	DataBlock_Accommodate(dataBlock, itemCount);
+	ASSERT_GE(dataBlock->itemCap, prevItemCount + itemCount);
 
-    // Read items.
-    for(int i = 0 ; i < dataBlock->itemCount; i++) {
-        int *value = (int*)DataBlock_GetItem(dataBlock, i);
-        ASSERT_EQ(*value, i);
-    }
+	// Set items.
+	for(int i = 0 ; i < itemCount; i++) {
+		int *value = (int *)DataBlock_AllocateItem(dataBlock, NULL);
+		*value = prevItemCount + i;
+	}
 
-    DataBlock_Free(dataBlock);
+	// Read items.
+	for(int i = 0 ; i < dataBlock->itemCount; i++) {
+		int *value = (int *)DataBlock_GetItem(dataBlock, i);
+		ASSERT_EQ(*value, i);
+	}
+
+	DataBlock_Free(dataBlock);
 }
 
 TEST_F(DataBlockTest, Scan) {
-    DataBlock *dataBlock = DataBlock_New(1024, sizeof(int), NULL);
-    size_t itemCount = 2048;
-    DataBlock_Accommodate(dataBlock, itemCount);
+	DataBlock *dataBlock = DataBlock_New(1024, sizeof(int), NULL);
+	size_t itemCount = 2048;
+	DataBlock_Accommodate(dataBlock, itemCount);
 
-    // Set items.
-    for(int i = 0 ; i < itemCount; i++) {
-        int *item = (int *)DataBlock_AllocateItem(dataBlock, NULL);
-        *item = i;
-    }
+	// Set items.
+	for(int i = 0 ; i < itemCount; i++) {
+		int *item = (int *)DataBlock_AllocateItem(dataBlock, NULL);
+		*item = i;
+	}
 
-    // Scan through items.
-    int count = 0;
-    int *item = NULL;
-    DataBlockIterator *it = DataBlock_Scan(dataBlock);
-    while((item = (int*)DataBlockIterator_Next(it))) {
-        ASSERT_EQ(*item, count);
-        count++;
-    }
-    ASSERT_EQ(count, itemCount);
+	// Scan through items.
+	int count = 0;
+	int *item = NULL;
+	DataBlockIterator *it = DataBlock_Scan(dataBlock);
+	while((item = (int *)DataBlockIterator_Next(it))) {
+		ASSERT_EQ(*item, count);
+		count++;
+	}
+	ASSERT_EQ(count, itemCount);
 
-    item = (int*)DataBlockIterator_Next(it);
-    ASSERT_TRUE(item == NULL);
+	item = (int *)DataBlockIterator_Next(it);
+	ASSERT_TRUE(item == NULL);
 
-    DataBlockIterator_Reset(it);
+	DataBlockIterator_Reset(it);
 
-    // Re-scan through items.
-    count = 0;
-    item = NULL;
-    while((item = (int*)DataBlockIterator_Next(it))) {
-        ASSERT_EQ(*item, count);
-        count++;
-    }
-    ASSERT_EQ(count, itemCount);
+	// Re-scan through items.
+	count = 0;
+	item = NULL;
+	while((item = (int *)DataBlockIterator_Next(it))) {
+		ASSERT_EQ(*item, count);
+		count++;
+	}
+	ASSERT_EQ(count, itemCount);
 
-    item = (int*)DataBlockIterator_Next(it);
-    ASSERT_TRUE(item == NULL);
+	item = (int *)DataBlockIterator_Next(it);
+	ASSERT_TRUE(item == NULL);
 
-    DataBlock_Free(dataBlock);
-    DataBlockIterator_Free(it);
+	DataBlock_Free(dataBlock);
+	DataBlockIterator_Free(it);
 }
 
 TEST_F(DataBlockTest, RemoveItem) {
-    DataBlock *dataBlock = DataBlock_New(1024, sizeof(int), NULL);
-    uint itemCount = 32;
-    DataBlock_Accommodate(dataBlock, itemCount);
+	DataBlock *dataBlock = DataBlock_New(1024, sizeof(int), NULL);
+	uint itemCount = 32;
+	DataBlock_Accommodate(dataBlock, itemCount);
 
-    // Set items.
-    for(int i = 0 ; i < itemCount; i++) {
-        int *item = (int *)DataBlock_AllocateItem(dataBlock, NULL);
-        *item = i;
-    }
+	// Set items.
+	for(int i = 0 ; i < itemCount; i++) {
+		int *item = (int *)DataBlock_AllocateItem(dataBlock, NULL);
+		*item = i;
+	}
 
-    // Validate item at position 0.
-    int *item = (int*)DataBlock_GetItem(dataBlock, 0);
-    ASSERT_FALSE(item == NULL);
-    ASSERT_EQ(*item, 0);
+	// Validate item at position 0.
+	int *item = (int *)DataBlock_GetItem(dataBlock, 0);
+	ASSERT_FALSE(item == NULL);
+	ASSERT_EQ(*item, 0);
 
-    // Remove item at position 0 and perform validations
-    // A DELETED_MARKER should mark cell as deleted
-    // Index 0 should be added to datablock deletedIdx array.
-    DataBlock_DeleteItem(dataBlock, 0);
-    ASSERT_EQ(dataBlock->itemCount, itemCount-1);
-    ASSERT_EQ(array_len(dataBlock->deletedIdx), 1);
-    ASSERT_TRUE((char)dataBlock->blocks[0]->data[0] && (char)DELETED_MARKER);
+	// Remove item at position 0 and perform validations
+	// A DELETED_MARKER should mark cell as deleted
+	// Index 0 should be added to datablock deletedIdx array.
+	DataBlock_DeleteItem(dataBlock, 0);
+	ASSERT_EQ(dataBlock->itemCount, itemCount - 1);
+	ASSERT_EQ(array_len(dataBlock->deletedIdx), 1);
+	ASSERT_TRUE((char)dataBlock->blocks[0]->data[0] && (char)DELETED_MARKER);
 
-    // Try to get item from deleted cell.
-    item = (int*)DataBlock_GetItem(dataBlock, 0);
-    ASSERT_TRUE(item == NULL);
+	// Try to get item from deleted cell.
+	item = (int *)DataBlock_GetItem(dataBlock, 0);
+	ASSERT_TRUE(item == NULL);
 
-    // Iterate over datablock, deleted item should be skipped.
-    DataBlockIterator *it = DataBlock_Scan(dataBlock);
-    uint counter = 0;
-    while(DataBlockIterator_Next(it)) counter++;
-    ASSERT_EQ(counter, itemCount-1);
-    DataBlockIterator_Free(it);
+	// Iterate over datablock, deleted item should be skipped.
+	DataBlockIterator *it = DataBlock_Scan(dataBlock);
+	uint counter = 0;
+	while(DataBlockIterator_Next(it)) counter++;
+	ASSERT_EQ(counter, itemCount - 1);
+	DataBlockIterator_Free(it);
 
-    // There's no harm in deleting a deleted item.
-    DataBlock_DeleteItem(dataBlock, 0);
+	// There's no harm in deleting a deleted item.
+	DataBlock_DeleteItem(dataBlock, 0);
 
-    // Add a new item, expecting deleted cell to be reused.
-    int *newItem = (int *)DataBlock_AllocateItem(dataBlock, NULL);
-    ASSERT_EQ(dataBlock->itemCount, itemCount);
-    ASSERT_EQ(array_len(dataBlock->deletedIdx), 0);
-    ASSERT_TRUE((void*)newItem == (void*)(&dataBlock->blocks[0]->data));
+	// Add a new item, expecting deleted cell to be reused.
+	int *newItem = (int *)DataBlock_AllocateItem(dataBlock, NULL);
+	ASSERT_EQ(dataBlock->itemCount, itemCount);
+	ASSERT_EQ(array_len(dataBlock->deletedIdx), 0);
+	ASSERT_TRUE((void *)newItem == (void *)(&dataBlock->blocks[0]->data));
 
-    it = DataBlock_Scan(dataBlock);
-    counter = 0;
-    while(DataBlockIterator_Next(it)) counter++;
-    ASSERT_EQ(counter, itemCount);
-    DataBlockIterator_Free(it);
+	it = DataBlock_Scan(dataBlock);
+	counter = 0;
+	while(DataBlockIterator_Next(it)) counter++;
+	ASSERT_EQ(counter, itemCount);
+	DataBlockIterator_Free(it);
 
-    // Cleanup.
-    DataBlock_Free(dataBlock);
+	// Cleanup.
+	DataBlock_Free(dataBlock);
 }

--- a/tests/unit/test_dfs.cpp
+++ b/tests/unit/test_dfs.cpp
@@ -21,104 +21,102 @@ extern "C" {
 
 class DFSTest: public ::testing::Test {
 
-    public:
-        static QGNode *A;
-        static QGNode *B;
-        static QGNode *C;
-        static QGNode *D;
-        static QGEdge *AB;
-        static QGEdge *BC;
-        static QGEdge *CD;
+  public:
+	static QGNode *A;
+	static QGNode *B;
+	static QGNode *C;
+	static QGNode *D;
+	static QGEdge *AB;
+	static QGEdge *BC;
+	static QGEdge *CD;
 
-    protected:
-    static void SetUpTestCase()
-    {
-        // Use the malloc family for allocations
-        Alloc_Reset();
-    }
+  protected:
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
+	}
 
-    static QueryGraph* BuildGraph()
-    {
-        // (A)->(B)
-        // (B)->(C)
-        // (C)->(D)
-        size_t node_cap = 4;
-        size_t edge_cap = 3;
+	static QueryGraph *BuildGraph() {
+		// (A)->(B)
+		// (B)->(C)
+		// (C)->(D)
+		size_t node_cap = 4;
+		size_t edge_cap = 3;
 
-        // Create nodes.
-        const char *label = "L";
-        const char *relation = "R";
+		// Create nodes.
+		const char *label = "L";
+		const char *relation = "R";
 
-        uint id = 0;
-        A = QGNode_New(label, "A", id++);
-        B = QGNode_New(label, "B", id++);
-        C = QGNode_New(label, "C", id++);
-        D = QGNode_New(label, "D", id++);
+		uint id = 0;
+		A = QGNode_New(label, "A", id++);
+		B = QGNode_New(label, "B", id++);
+		C = QGNode_New(label, "C", id++);
+		D = QGNode_New(label, "D", id++);
 
-        AB = QGEdge_New(A, B, relation, "AB", id++);
-        BC = QGEdge_New(B, C, relation, "BC", id++);
-        CD = QGEdge_New(C, D, relation, "CD", id++);
+		AB = QGEdge_New(A, B, relation, "AB", id++);
+		BC = QGEdge_New(B, C, relation, "BC", id++);
+		CD = QGEdge_New(C, D, relation, "CD", id++);
 
-        QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
-        QueryGraph_AddNode(g, A);
-        QueryGraph_AddNode(g, B);
-        QueryGraph_AddNode(g, C);
-        QueryGraph_AddNode(g, D);
+		QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
+		QueryGraph_AddNode(g, A);
+		QueryGraph_AddNode(g, B);
+		QueryGraph_AddNode(g, C);
+		QueryGraph_AddNode(g, D);
 
-        QueryGraph_ConnectNodes(g, A, B, AB);
-        QueryGraph_ConnectNodes(g, B, C, BC);
-        QueryGraph_ConnectNodes(g, C, D, CD);
+		QueryGraph_ConnectNodes(g, A, B, AB);
+		QueryGraph_ConnectNodes(g, B, C, BC);
+		QueryGraph_ConnectNodes(g, C, D, CD);
 
-        return g;
-    }
+		return g;
+	}
 };
 
 TEST_F(DFSTest, DFSLevels) {
-    QGNode *S;        // DFS starts here.
-    QGEdge **path;    // Path reached by DFS.
-    QueryGraph *g;  // Graph traversed.
+	QGNode *S;        // DFS starts here.
+	QGEdge **path;    // Path reached by DFS.
+	QueryGraph *g;  // Graph traversed.
 
-    g = BuildGraph();
-    S = QueryGraph_GetNodeByID(g, A->id);
+	g = BuildGraph();
+	S = QueryGraph_GetNodeByID(g, A->id);
 
-    QGEdge *expected_level_0[0] = {};
-    QGEdge *expected_level_1[1] = {AB};
-    QGEdge *expected_level_2[2] = {AB, BC};
-    QGEdge *expected_level_3[3] = {AB, BC, CD};
-    QGEdge *expected_level_4[0] = {};
-    
-    QGEdge **expected[5] = {
-        expected_level_0,
-        expected_level_1,
-        expected_level_2,
-        expected_level_3,
-        expected_level_4
-    };
+	QGEdge *expected_level_0[0] = {};
+	QGEdge *expected_level_1[1] = {AB};
+	QGEdge *expected_level_2[2] = {AB, BC};
+	QGEdge *expected_level_3[3] = {AB, BC, CD};
+	QGEdge *expected_level_4[0] = {};
 
-    //------------------------------------------------------------------------------
-    // DFS depth 0 - 4
-    //------------------------------------------------------------------------------
+	QGEdge **expected[5] = {
+		expected_level_0,
+		expected_level_1,
+		expected_level_2,
+		expected_level_3,
+		expected_level_4
+	};
 
-    for(int level = 0; level < 5; level++) {
-        path = DFS(S, level);
-        QGEdge **expectation = expected[level];
+	//------------------------------------------------------------------------------
+	// DFS depth 0 - 4
+	//------------------------------------------------------------------------------
 
-        int edge_count = array_len(path);
-        for(int i = 0; i < edge_count; i++) {
-            bool found = false;
-            for(int j = 0; j < edge_count; j++) {
-                if(path[i] == expectation[j]) {
-                    found = true;
-                    break;
-                }
-            }
-            ASSERT_TRUE(found);
-        }
-        array_free(path); 
-    }
+	for(int level = 0; level < 5; level++) {
+		path = DFS(S, level);
+		QGEdge **expectation = expected[level];
 
-    // Clean up.
-    QueryGraph_Free(g);
+		int edge_count = array_len(path);
+		for(int i = 0; i < edge_count; i++) {
+			bool found = false;
+			for(int j = 0; j < edge_count; j++) {
+				if(path[i] == expectation[j]) {
+					found = true;
+					break;
+				}
+			}
+			ASSERT_TRUE(found);
+		}
+		array_free(path);
+	}
+
+	// Clean up.
+	QueryGraph_Free(g);
 }
 
 // Static function declarations

--- a/tests/unit/test_filter_tree.cpp
+++ b/tests/unit/test_filter_tree.cpp
@@ -26,239 +26,239 @@ pthread_key_t _tlsGCKey;    // Thread local storage graph context key.
 pthread_key_t _tlsASTKey;  // Thread local storage AST key.
 
 class FilterTreeTest: public ::testing::Test {
-    protected:
+  protected:
 
-    static void SetUpTestCase() {
-      // Use the malloc family for allocations
-      Alloc_Reset();
-      _fake_graph_context();
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
+		_fake_graph_context();
 
-      int error = pthread_key_create(&_tlsASTKey, NULL);
-      ASSERT_EQ(error, 0);
-    }
+		int error = pthread_key_create(&_tlsASTKey, NULL);
+		ASSERT_EQ(error, 0);
+	}
 
-    static void TearDownTestCase()
-    {
-        // Free fake graph context.
-        GraphContext *gc = GraphContext_GetFromTLS();
-        free(gc);
-    }
+	static void TearDownTestCase() {
+		// Free fake graph context.
+		GraphContext *gc = GraphContext_GetFromTLS();
+		free(gc);
+	}
 
-    static void _fake_graph_context() {
-        /* Filter tree construction requires access to schemas, 
-         * those inturn resides within graph context 
-         * accessible via thread local storage, as such we're creating a 
-         * fake graph context and placing it within thread local storage. */
-        GraphContext *gc = (GraphContext*)malloc(sizeof(GraphContext));
+	static void _fake_graph_context() {
+		/* Filter tree construction requires access to schemas,
+		 * those inturn resides within graph context
+		 * accessible via thread local storage, as such we're creating a
+		 * fake graph context and placing it within thread local storage. */
+		GraphContext *gc = (GraphContext *)malloc(sizeof(GraphContext));
 
-        // No indicies.
-        gc->index_count = 0;
-        
-        int error = pthread_key_create(&_tlsGCKey, NULL);
-        ASSERT_EQ(error, 0);
-        pthread_setspecific(_tlsGCKey, gc);
+		// No indicies.
+		gc->index_count = 0;
 
-    }
+		int error = pthread_key_create(&_tlsGCKey, NULL);
+		ASSERT_EQ(error, 0);
+		pthread_setspecific(_tlsGCKey, gc);
 
-    AST* _build_ast(const char *query) {
-        cypher_parse_result_t *parse_result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
-        AST *ast = AST_Build(parse_result);
-        return ast;
-    }
+	}
 
-    FT_FilterNode* build_tree_from_query(const char *q) {
-        AST *ast = _build_ast(q);
-        RecordMap *map = RecordMap_New();
-        FT_FilterNode *tree = AST_BuildFilterTree(ast, map);
-        return tree;
-    }
+	AST *_build_ast(const char *query) {
+		cypher_parse_result_t *parse_result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
+		AST *ast = AST_Build(parse_result);
+		return ast;
+	}
 
-    FT_FilterNode* _build_simple_const_tree() {
-        const char *q = "MATCH (me) WHERE me.age = 34 RETURN me";
-        return build_tree_from_query(q);
-    }
+	FT_FilterNode *build_tree_from_query(const char *q) {
+		AST *ast = _build_ast(q);
+		RecordMap *map = RecordMap_New();
+		FT_FilterNode *tree = AST_BuildFilterTree(ast, map);
+		return tree;
+	}
 
-    FT_FilterNode* _build_simple_varying_tree() {
-        const char *q = "MATCH (me),(him) WHERE me.age > him.age RETURN me, him";
-        return build_tree_from_query(q);
-    }
+	FT_FilterNode *_build_simple_const_tree() {
+		const char *q = "MATCH (me) WHERE me.age = 34 RETURN me";
+		return build_tree_from_query(q);
+	}
 
-    FT_FilterNode* _build_cond_tree(int cond) {
-        const char *q;
-        if(cond == OP_AND) q = "MATCH (me) WHERE me.age > 34 AND me.height <= 188 RETURN me";
-        else q = "MATCH (me) WHERE me.age > 34 OR me.height <= 188 RETURN me";
-        return build_tree_from_query(q);
-    }
+	FT_FilterNode *_build_simple_varying_tree() {
+		const char *q = "MATCH (me),(him) WHERE me.age > him.age RETURN me, him";
+		return build_tree_from_query(q);
+	}
 
-    FT_FilterNode* _build_AND_cond_tree() {
-        return _build_cond_tree(OP_AND);
-    }
+	FT_FilterNode *_build_cond_tree(int cond) {
+		const char *q;
+		if(cond == OP_AND) q = "MATCH (me) WHERE me.age > 34 AND me.height <= 188 RETURN me";
+		else q = "MATCH (me) WHERE me.age > 34 OR me.height <= 188 RETURN me";
+		return build_tree_from_query(q);
+	}
 
-    FT_FilterNode* _build_OR_cond_tree() {
-        return _build_cond_tree(OP_OR);
-    }
+	FT_FilterNode *_build_AND_cond_tree() {
+		return _build_cond_tree(OP_AND);
+	}
 
-    FT_FilterNode* _build_deep_tree() {
-        /* Build a tree with an OP_AND at the root
-        * OP_AND as a left child
-        * OP_OR as a right child */
-        const char *q = "MATCH (me),(he),(she),(theirs) WHERE (me.age > 34 AND he.height <= 188) AND (she.age > 34 OR theirs.height <= 188) RETURN me, he, she, theirs";
-        return build_tree_from_query(q);
-    }
+	FT_FilterNode *_build_OR_cond_tree() {
+		return _build_cond_tree(OP_OR);
+	}
 
-    void _compareFilterTreePredicateNode(const FT_FilterNode *a, const FT_FilterNode *b) {
-        ASSERT_EQ(a->t, b->t);
-        ASSERT_EQ(a->t, FT_N_PRED);
-        ASSERT_EQ(a->pred.op, b->pred.op);
+	FT_FilterNode *_build_deep_tree() {
+		/* Build a tree with an OP_AND at the root
+		* OP_AND as a left child
+		* OP_OR as a right child */
+		const char *q =
+			"MATCH (me),(he),(she),(theirs) WHERE (me.age > 34 AND he.height <= 188) AND (she.age > 34 OR theirs.height <= 188) RETURN me, he, she, theirs";
+		return build_tree_from_query(q);
+	}
 
-        char *a_variable;
-        char *b_variable;
-        AR_EXP_ToString(a->pred.lhs, &a_variable);
-        AR_EXP_ToString(b->pred.lhs, &b_variable);
-        ASSERT_STREQ(a_variable, b_variable);
+	void _compareFilterTreePredicateNode(const FT_FilterNode *a, const FT_FilterNode *b) {
+		ASSERT_EQ(a->t, b->t);
+		ASSERT_EQ(a->t, FT_N_PRED);
+		ASSERT_EQ(a->pred.op, b->pred.op);
 
-        free(a_variable);
-        free(b_variable);
+		char *a_variable;
+		char *b_variable;
+		AR_EXP_ToString(a->pred.lhs, &a_variable);
+		AR_EXP_ToString(b->pred.lhs, &b_variable);
+		ASSERT_STREQ(a_variable, b_variable);
 
-        AR_EXP_ToString(a->pred.rhs, &a_variable);
-        AR_EXP_ToString(b->pred.rhs, &b_variable);
-        ASSERT_STREQ(a_variable, b_variable);
+		free(a_variable);
+		free(b_variable);
 
-        free(a_variable);
-        free(b_variable);
-    }
+		AR_EXP_ToString(a->pred.rhs, &a_variable);
+		AR_EXP_ToString(b->pred.rhs, &b_variable);
+		ASSERT_STREQ(a_variable, b_variable);
 
-    void compareFilterTrees(const FT_FilterNode *a, const FT_FilterNode *b) {
-        ASSERT_EQ(a->t, b->t);
-        
-        if(a->t == FT_N_PRED) {
-            _compareFilterTreePredicateNode(a, b);
-        } else {
-            ASSERT_EQ(a->cond.op, b->cond.op);
-            compareFilterTrees(a->cond.left, b->cond.left);
-            compareFilterTrees(a->cond.right, b->cond.right);
-        }
-    }
+		free(a_variable);
+		free(b_variable);
+	}
+
+	void compareFilterTrees(const FT_FilterNode *a, const FT_FilterNode *b) {
+		ASSERT_EQ(a->t, b->t);
+
+		if(a->t == FT_N_PRED) {
+			_compareFilterTreePredicateNode(a, b);
+		} else {
+			ASSERT_EQ(a->cond.op, b->cond.op);
+			compareFilterTrees(a->cond.left, b->cond.left);
+			compareFilterTrees(a->cond.right, b->cond.right);
+		}
+	}
 };
 
 TEST_F(FilterTreeTest, SubTrees) {
-    FT_FilterNode *tree = _build_simple_const_tree();
-    Vector *sub_trees = FilterTree_SubTrees(tree);
-    ASSERT_EQ(Vector_Size(sub_trees), 1);
+	FT_FilterNode *tree = _build_simple_const_tree();
+	Vector *sub_trees = FilterTree_SubTrees(tree);
+	ASSERT_EQ(Vector_Size(sub_trees), 1);
 
-    FT_FilterNode *sub_tree;
-    Vector_Get(sub_trees, 0, &sub_tree);
-    compareFilterTrees(tree, sub_tree);
+	FT_FilterNode *sub_tree;
+	Vector_Get(sub_trees, 0, &sub_tree);
+	compareFilterTrees(tree, sub_tree);
 
-    Vector_Free(sub_trees);
-    FilterTree_Free(tree);
+	Vector_Free(sub_trees);
+	FilterTree_Free(tree);
 
-    //------------------------------------------------------------------------------
+	//------------------------------------------------------------------------------
 
-    tree = _build_simple_varying_tree();
-    sub_trees = FilterTree_SubTrees(tree);
-    ASSERT_EQ(Vector_Size(sub_trees), 1);
+	tree = _build_simple_varying_tree();
+	sub_trees = FilterTree_SubTrees(tree);
+	ASSERT_EQ(Vector_Size(sub_trees), 1);
 
-    Vector_Get(sub_trees, 0, &sub_tree);
-    compareFilterTrees(tree, sub_tree);
+	Vector_Get(sub_trees, 0, &sub_tree);
+	compareFilterTrees(tree, sub_tree);
 
-    Vector_Free(sub_trees);
-    FilterTree_Free(tree);
+	Vector_Free(sub_trees);
+	FilterTree_Free(tree);
 
-    //------------------------------------------------------------------------------
+	//------------------------------------------------------------------------------
 
-    FT_FilterNode *original_tree = _build_AND_cond_tree();
-    tree = _build_AND_cond_tree(); // TODO memory leak
-    sub_trees = FilterTree_SubTrees(tree);
-    ASSERT_EQ(Vector_Size(sub_trees), 2);
+	FT_FilterNode *original_tree = _build_AND_cond_tree();
+	tree = _build_AND_cond_tree(); // TODO memory leak
+	sub_trees = FilterTree_SubTrees(tree);
+	ASSERT_EQ(Vector_Size(sub_trees), 2);
 
-    Vector_Get(sub_trees, 0, &sub_tree);    
-    compareFilterTrees(original_tree->cond.left, sub_tree);
-    
-    Vector_Get(sub_trees, 1, &sub_tree);
-    compareFilterTrees(original_tree->cond.right, sub_tree);
+	Vector_Get(sub_trees, 0, &sub_tree);
+	compareFilterTrees(original_tree->cond.left, sub_tree);
 
-    Vector_Free(sub_trees);
-    // FilterTree_Free(tree);
-    FilterTree_Free(original_tree);
+	Vector_Get(sub_trees, 1, &sub_tree);
+	compareFilterTrees(original_tree->cond.right, sub_tree);
 
-    //------------------------------------------------------------------------------
-    
-    tree = _build_OR_cond_tree();
-    sub_trees = FilterTree_SubTrees(tree);
-    ASSERT_EQ(Vector_Size(sub_trees), 1);
+	Vector_Free(sub_trees);
+	// FilterTree_Free(tree);
+	FilterTree_Free(original_tree);
 
-    Vector_Get(sub_trees, 0, &sub_tree);
-    compareFilterTrees(tree, sub_tree);
+	//------------------------------------------------------------------------------
 
-    Vector_Free(sub_trees);
-    FilterTree_Free(tree);
+	tree = _build_OR_cond_tree();
+	sub_trees = FilterTree_SubTrees(tree);
+	ASSERT_EQ(Vector_Size(sub_trees), 1);
 
-    //------------------------------------------------------------------------------
+	Vector_Get(sub_trees, 0, &sub_tree);
+	compareFilterTrees(tree, sub_tree);
 
-    original_tree = _build_deep_tree();
-    tree = _build_deep_tree(); // TODO memory leak
-    sub_trees = FilterTree_SubTrees(tree);
-    ASSERT_EQ(Vector_Size(sub_trees), 3);
+	Vector_Free(sub_trees);
+	FilterTree_Free(tree);
 
-    Vector_Get(sub_trees, 0, &sub_tree);
-    compareFilterTrees(original_tree->cond.left->cond.left, sub_tree);
+	//------------------------------------------------------------------------------
 
-    Vector_Get(sub_trees, 1, &sub_tree);
-    compareFilterTrees(original_tree->cond.left->cond.right, sub_tree);
+	original_tree = _build_deep_tree();
+	tree = _build_deep_tree(); // TODO memory leak
+	sub_trees = FilterTree_SubTrees(tree);
+	ASSERT_EQ(Vector_Size(sub_trees), 3);
 
-    Vector_Get(sub_trees, 2, &sub_tree);
-    compareFilterTrees(original_tree->cond.right, sub_tree);
+	Vector_Get(sub_trees, 0, &sub_tree);
+	compareFilterTrees(original_tree->cond.left->cond.left, sub_tree);
 
-    Vector_Free(sub_trees);
-    FilterTree_Free(original_tree);
+	Vector_Get(sub_trees, 1, &sub_tree);
+	compareFilterTrees(original_tree->cond.left->cond.right, sub_tree);
+
+	Vector_Get(sub_trees, 2, &sub_tree);
+	compareFilterTrees(original_tree->cond.right, sub_tree);
+
+	Vector_Free(sub_trees);
+	FilterTree_Free(original_tree);
 }
 
 TEST_F(FilterTreeTest, CollectModified) {
-    FT_FilterNode *tree = _build_deep_tree();
-    rax *aliases = FilterTree_CollectModified(tree);
-    ASSERT_EQ(raxSize(aliases), 4);
+	FT_FilterNode *tree = _build_deep_tree();
+	rax *aliases = FilterTree_CollectModified(tree);
+	ASSERT_EQ(raxSize(aliases), 4);
 
-    uint expectation[4] = {0, 1, 2, 3};
-    for(int i = 0; i < 4; i++) {
-        uint expected = expectation[i];
-        ASSERT_NE(raxFind(aliases, (unsigned char*)&expected, sizeof(expected)), raxNotFound);
-    }
+	uint expectation[4] = {0, 1, 2, 3};
+	for(int i = 0; i < 4; i++) {
+		uint expected = expectation[i];
+		ASSERT_NE(raxFind(aliases, (unsigned char *)&expected, sizeof(expected)), raxNotFound);
+	}
 
-    /* Clean up. */    
-    raxFree(aliases);
-    FilterTree_Free(tree);
+	/* Clean up. */
+	raxFree(aliases);
+	FilterTree_Free(tree);
 }
 
 TEST_F(FilterTreeTest, NOTReduction) {
-    const char *filters[6] {
-        "MATCH (n) WHERE NOT n.v = 1 RETURN n",
-        "MATCH (n) WHERE NOT NOT n.v = 1 RETURN n",
-        "MATCH (n) WHERE NOT (n.v > 5 AND n.v < 20) RETURN n",
-        "MATCH (n) WHERE NOT (n.v <= 5 OR n.v <> 20) RETURN n",        
-        "MATCH (n) WHERE NOT( NOT( NOT( n.v >= 1 AND (n.v < 5 OR n.v <> 3) ) ) ) RETURN n",
-        "MATCH (n) WHERE n.v = 2 AND NOT n.x > 4 RETURN n",
-    };
+	const char *filters[6] {
+		"MATCH (n) WHERE NOT n.v = 1 RETURN n",
+		"MATCH (n) WHERE NOT NOT n.v = 1 RETURN n",
+		"MATCH (n) WHERE NOT (n.v > 5 AND n.v < 20) RETURN n",
+		"MATCH (n) WHERE NOT (n.v <= 5 OR n.v <> 20) RETURN n",
+		"MATCH (n) WHERE NOT( NOT( NOT( n.v >= 1 AND (n.v < 5 OR n.v <> 3) ) ) ) RETURN n",
+		"MATCH (n) WHERE n.v = 2 AND NOT n.x > 4 RETURN n",
+	};
 
-    const char *expected[6] {
-        "MATCH (n) WHERE n.v <> 1 RETURN n",
-        "MATCH (n) WHERE n.v = 1 RETURN n",
-        "MATCH (n) WHERE n.v <= 5 OR n.v >= 20 RETURN n",
-        "MATCH (n) WHERE n.v > 5 AND n.v = 20 RETURN n",
-        "MATCH (n) WHERE (n.v < 1 OR (n.v >= 5 AND n.v = 3)) RETURN n",
-        "MATCH (n) WHERE n.v = 2 AND n.x <= 4 RETURN n",
-    };
+	const char *expected[6] {
+		"MATCH (n) WHERE n.v <> 1 RETURN n",
+		"MATCH (n) WHERE n.v = 1 RETURN n",
+		"MATCH (n) WHERE n.v <= 5 OR n.v >= 20 RETURN n",
+		"MATCH (n) WHERE n.v > 5 AND n.v = 20 RETURN n",
+		"MATCH (n) WHERE (n.v < 1 OR (n.v >= 5 AND n.v = 3)) RETURN n",
+		"MATCH (n) WHERE n.v = 2 AND n.x <= 4 RETURN n",
+	};
 
-    for(int i = 0; i < 6; i++) {
-        const char *actual = filters[i];
-        const char *expected_q = expected[i];
+	for(int i = 0; i < 6; i++) {
+		const char *actual = filters[i];
+		const char *expected_q = expected[i];
 
-        FT_FilterNode *actual_tree = build_tree_from_query(actual);
-        FT_FilterNode *expected_tree = build_tree_from_query(expected_q);
+		FT_FilterNode *actual_tree = build_tree_from_query(actual);
+		FT_FilterNode *expected_tree = build_tree_from_query(expected_q);
 
-        compareFilterTrees(actual_tree, expected_tree);
+		compareFilterTrees(actual_tree, expected_tree);
 
-        FilterTree_Free(actual_tree);
-        FilterTree_Free(expected_tree);
-    }
+		FilterTree_Free(actual_tree);
+		FilterTree_Free(expected_tree);
+	}
 }

--- a/tests/unit/test_graph.cpp
+++ b/tests/unit/test_graph.cpp
@@ -29,884 +29,855 @@ extern "C"
 
 // Encapsulate the essence of an edge.
 typedef struct {
-    NodeID srcId;   	// Source node ID.
-    NodeID destId;  	// Destination node ID.
-    int64_t relationId; // Relation type ID.
+	NodeID srcId;   	// Source node ID.
+	NodeID destId;  	// Destination node ID.
+	int64_t relationId; // Relation type ID.
 } EdgeDesc;
 
-class GraphTest : public ::testing::Test
-{
+class GraphTest : public ::testing::Test {
   protected:
-    static void SetUpTestCase()
-    {
-        // Use the malloc family for allocations
-        Alloc_Reset();
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
 
-        // Initialize GraphBLAS.
-        GrB_init(GrB_NONBLOCKING);
+		// Initialize GraphBLAS.
+		GrB_init(GrB_NONBLOCKING);
 
-        GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW); // all matrices in CSR format
-        GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
-        srand(time(NULL));
-    }
+		GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW); // all matrices in CSR format
+		GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
+		srand(time(NULL));
+	}
 
-    static void TearDownTestCase()
-    {
-        GrB_finalize();
-    }    
+	static void TearDownTestCase() {
+		GrB_finalize();
+	}
 
-    void _test_node_creation(Graph *g, size_t node_count)
-    {
-        GrB_Index ncols, nrows, nvals;
+	void _test_node_creation(Graph *g, size_t node_count) {
+		GrB_Index ncols, nrows, nvals;
 
-        // Create nodes.
-        Node n;
-        for(uint i = 0; i < node_count; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
+		// Create nodes.
+		Node n;
+		for(uint i = 0; i < node_count; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
 
-        // Validate nodes creation.
-        GrB_Matrix adj = Graph_GetAdjacencyMatrix(g);
-        ASSERT_EQ(GrB_Matrix_nrows(&nrows, adj), GrB_SUCCESS);
-        ASSERT_EQ(GrB_Matrix_ncols(&ncols, adj), GrB_SUCCESS);
-        ASSERT_EQ(GrB_Matrix_nvals(&nvals, adj), GrB_SUCCESS);
+		// Validate nodes creation.
+		GrB_Matrix adj = Graph_GetAdjacencyMatrix(g);
+		ASSERT_EQ(GrB_Matrix_nrows(&nrows, adj), GrB_SUCCESS);
+		ASSERT_EQ(GrB_Matrix_ncols(&ncols, adj), GrB_SUCCESS);
+		ASSERT_EQ(GrB_Matrix_nvals(&nvals, adj), GrB_SUCCESS);
 
-        ASSERT_EQ(nvals, 0);                  // No connection were formed.
-        ASSERT_GE(ncols, Graph_NodeCount(g)); // Graph's adjacency matrix dimensions.
-        ASSERT_GE(nrows, Graph_NodeCount(g));
-        ASSERT_EQ(Graph_NodeCount(g), node_count);
-    }
+		ASSERT_EQ(nvals, 0);                  // No connection were formed.
+		ASSERT_GE(ncols, Graph_NodeCount(g)); // Graph's adjacency matrix dimensions.
+		ASSERT_GE(nrows, Graph_NodeCount(g));
+		ASSERT_EQ(Graph_NodeCount(g), node_count);
+	}
 
-    void _test_edge_creation(Graph *g, size_t node_count)
-    {
-        // Form connections.
-        int relationCount = 3;
-        size_t edge_count = (node_count - 1);
-        EdgeDesc connections[edge_count];
+	void _test_edge_creation(Graph *g, size_t node_count) {
+		// Form connections.
+		int relationCount = 3;
+		size_t edge_count = (node_count - 1);
+		EdgeDesc connections[edge_count];
 
-        // Introduce relations types.
-        for (int i = 0; i < relationCount; i++)
-            Graph_AddRelationType(g);
+		// Introduce relations types.
+		for(int i = 0; i < relationCount; i++)
+			Graph_AddRelationType(g);
 
-        // Describe connections;
-        // Node I is connected to Node I+1,
-        // Connection type is relationships[I%4].
-        Edge e;
-        for (unsigned int i = 0; i < edge_count; i++)
-        {
-            connections[i].srcId = i;                           // Source node id.
-            connections[i].destId = i + 1;                      // Destination node id.
-            connections[i].relationId = (i % relationCount);    // Relation.
-            Graph_ConnectNodes(g, connections[i].srcId, connections[i].destId, connections[i].relationId, &e);
-        }
+		// Describe connections;
+		// Node I is connected to Node I+1,
+		// Connection type is relationships[I%4].
+		Edge e;
+		for(unsigned int i = 0; i < edge_count; i++) {
+			connections[i].srcId = i;                           // Source node id.
+			connections[i].destId = i + 1;                      // Destination node id.
+			connections[i].relationId = (i % relationCount);    // Relation.
+			Graph_ConnectNodes(g, connections[i].srcId, connections[i].destId, connections[i].relationId, &e);
+		}
 
-        // Validate edges creation,
-        // expecting number of none zero entries to be edge_count.
-        GrB_Index nvals;
-        GrB_Matrix adj = Graph_GetAdjacencyMatrix(g);
-        ASSERT_EQ(GrB_Matrix_nvals(&nvals, adj), GrB_SUCCESS);
-        ASSERT_EQ(nvals, edge_count);
+		// Validate edges creation,
+		// expecting number of none zero entries to be edge_count.
+		GrB_Index nvals;
+		GrB_Matrix adj = Graph_GetAdjacencyMatrix(g);
+		ASSERT_EQ(GrB_Matrix_nvals(&nvals, adj), GrB_SUCCESS);
+		ASSERT_EQ(nvals, edge_count);
 
-        // Inspect graph matrices;
-        // Graph's adjacency matrix should include all connections,
-        // relation matrices should include edges of a certain relation.
-        for (unsigned int i = 0; i < edge_count; i++)
-        {
-            int src_id = connections[i].srcId;
-            int dest_id = connections[i].destId;
-            int r = connections[i].relationId;
-            bool v = false;
+		// Inspect graph matrices;
+		// Graph's adjacency matrix should include all connections,
+		// relation matrices should include edges of a certain relation.
+		for(unsigned int i = 0; i < edge_count; i++) {
+			int src_id = connections[i].srcId;
+			int dest_id = connections[i].destId;
+			int r = connections[i].relationId;
+			bool v = false;
 
-            // src_id connected to dest_id.
-            ASSERT_EQ(GrB_Matrix_extractElement_BOOL(&v, adj, dest_id, src_id), GrB_SUCCESS);
-            ASSERT_TRUE(v);
+			// src_id connected to dest_id.
+			ASSERT_EQ(GrB_Matrix_extractElement_BOOL(&v, adj, dest_id, src_id), GrB_SUCCESS);
+			ASSERT_TRUE(v);
 
-            // Test relation matrix.
-            v = false;
-            GrB_Matrix mat = Graph_GetRelationMatrix(g, r);
-            ASSERT_EQ(GrB_Matrix_extractElement_BOOL(&v, mat, dest_id, src_id), GrB_SUCCESS);
-            ASSERT_TRUE(v);
-        }
-    }
+			// Test relation matrix.
+			v = false;
+			GrB_Matrix mat = Graph_GetRelationMatrix(g, r);
+			ASSERT_EQ(GrB_Matrix_extractElement_BOOL(&v, mat, dest_id, src_id), GrB_SUCCESS);
+			ASSERT_TRUE(v);
+		}
+	}
 
-    void _test_graph_resize(Graph *g)
-    {
-        GrB_Index ncols, nrows;
-        size_t prev_node_count = Graph_NodeCount(g);
-        size_t additional_node_count = prev_node_count * 16;
+	void _test_graph_resize(Graph *g) {
+		GrB_Index ncols, nrows;
+		size_t prev_node_count = Graph_NodeCount(g);
+		size_t additional_node_count = prev_node_count * 16;
 
-        Graph_AllocateNodes(g, prev_node_count + additional_node_count);
-        for(uint i = 0; i < additional_node_count; i++) {
-            Node n;
-            Graph_CreateNode(g, 0, &n);
-        }
+		Graph_AllocateNodes(g, prev_node_count + additional_node_count);
+		for(uint i = 0; i < additional_node_count; i++) {
+			Node n;
+			Graph_CreateNode(g, 0, &n);
+		}
 
-        // Validate nodes creation.
-        ASSERT_EQ(Graph_NodeCount(g), prev_node_count + additional_node_count);
-        // Graph's adjacency matrix dimensions.
-        GrB_Matrix adj = Graph_GetAdjacencyMatrix(g);
-        ASSERT_EQ(GrB_Matrix_nrows(&nrows, adj), GrB_SUCCESS);
-        ASSERT_EQ(GrB_Matrix_ncols(&ncols, adj), GrB_SUCCESS);
-        ASSERT_GE(ncols, Graph_NodeCount(g));
-        ASSERT_GE(nrows, Graph_NodeCount(g));
+		// Validate nodes creation.
+		ASSERT_EQ(Graph_NodeCount(g), prev_node_count + additional_node_count);
+		// Graph's adjacency matrix dimensions.
+		GrB_Matrix adj = Graph_GetAdjacencyMatrix(g);
+		ASSERT_EQ(GrB_Matrix_nrows(&nrows, adj), GrB_SUCCESS);
+		ASSERT_EQ(GrB_Matrix_ncols(&ncols, adj), GrB_SUCCESS);
+		ASSERT_GE(ncols, Graph_NodeCount(g));
+		ASSERT_GE(nrows, Graph_NodeCount(g));
 
-        // Verify number of created nodes.
-        Node *n;
-        unsigned int new_node_count = 0;
-        DataBlockIterator *it = Graph_ScanNodes(g);
-        while ((n = (Node *)DataBlockIterator_Next(it)) != NULL) new_node_count++;
-        ASSERT_EQ(new_node_count, prev_node_count + additional_node_count);
-        DataBlockIterator_Free(it);
+		// Verify number of created nodes.
+		Node *n;
+		unsigned int new_node_count = 0;
+		DataBlockIterator *it = Graph_ScanNodes(g);
+		while((n = (Node *)DataBlockIterator_Next(it)) != NULL) new_node_count++;
+		ASSERT_EQ(new_node_count, prev_node_count + additional_node_count);
+		DataBlockIterator_Free(it);
 
-        // Relation matrices get resize lazily,
-        // Try to fetch one of the specific relation matrices and verify its dimenstions.
-        uint relation_count = Graph_RelationTypeCount(g);
-        ASSERT_GT(relation_count, 0);
-        for (unsigned int i = 0; i < relation_count; i++)
-        {
-            GrB_Matrix r = Graph_GetRelationMatrix(g, i);
-            ASSERT_EQ(GrB_Matrix_nrows(&nrows, r), GrB_SUCCESS);
-            ASSERT_EQ(GrB_Matrix_ncols(&ncols, r), GrB_SUCCESS);
-            ASSERT_GE(ncols, Graph_NodeCount(g));
-            ASSERT_GE(nrows, Graph_NodeCount(g));
-        }
-    }
+		// Relation matrices get resize lazily,
+		// Try to fetch one of the specific relation matrices and verify its dimenstions.
+		uint relation_count = Graph_RelationTypeCount(g);
+		ASSERT_GT(relation_count, 0);
+		for(unsigned int i = 0; i < relation_count; i++) {
+			GrB_Matrix r = Graph_GetRelationMatrix(g, i);
+			ASSERT_EQ(GrB_Matrix_nrows(&nrows, r), GrB_SUCCESS);
+			ASSERT_EQ(GrB_Matrix_ncols(&ncols, r), GrB_SUCCESS);
+			ASSERT_GE(ncols, Graph_NodeCount(g));
+			ASSERT_GE(nrows, Graph_NodeCount(g));
+		}
+	}
 };
 
 /* TODO benchmark functions are currently not invoked */
-void benchmark_node_creation_with_labels()
-{
-    printf("benchmark_node_creation_with_labels\n");
-    double tic[2];
-    int samples = 64;
-    int label_count = 3;
-    double timings[samples];
-    int outliers = 0;
-    float threshold = 0.0018;
-    // size_t n = GRAPH_DEFAULT_NODE_CAP;
-    size_t n = 1000000;
-    Graph *g = Graph_New(n,n);
-    Graph_AcquireWriteLock(g);
+void benchmark_node_creation_with_labels() {
+	printf("benchmark_node_creation_with_labels\n");
+	double tic[2];
+	int samples = 64;
+	int label_count = 3;
+	double timings[samples];
+	int outliers = 0;
+	float threshold = 0.0018;
+	// size_t n = GRAPH_DEFAULT_NODE_CAP;
+	size_t n = 1000000;
+	Graph *g = Graph_New(n, n);
+	Graph_AcquireWriteLock(g);
 
-    // Introduce labels and relations to graph.
-    for (int i = 0; i < label_count; i++)
-    {
-        Graph_AddRelationType(g); // Typed relation.
-        Graph_AddLabel(g);    // Typed node.
-    }
+	// Introduce labels and relations to graph.
+	for(int i = 0; i < label_count; i++) {
+		Graph_AddRelationType(g); // Typed relation.
+		Graph_AddLabel(g);    // Typed node.
+	}
 
-    Node node;
+	Node node;
 
-    int labels[n];
-    // Create N nodes with labels.
-    for (int i = 0; i < samples; i++)
-    {
-        // Associate nodes to labels.
-        for (unsigned int j = 0; j < n; j++) labels[j] = (rand() % label_count) - 1;
+	int labels[n];
+	// Create N nodes with labels.
+	for(int i = 0; i < samples; i++) {
+		// Associate nodes to labels.
+		for(unsigned int j = 0; j < n; j++) labels[j] = (rand() % label_count) - 1;
 
-        simple_tic(tic);
-        for (unsigned int j = 0; j < n; j++) Graph_CreateNode(g, labels[j], &node);
-        timings[i] = simple_toc(tic);
+		simple_tic(tic);
+		for(unsigned int j = 0; j < n; j++) Graph_CreateNode(g, labels[j], &node);
+		timings[i] = simple_toc(tic);
 
-        printf("%zu Nodes created, time: %.6f sec\n", n, timings[i]);
-        if (timings[i] > threshold)
-            outliers++;
-    }
+		printf("%zu Nodes created, time: %.6f sec\n", n, timings[i]);
+		if(timings[i] > threshold)
+			outliers++;
+	}
 
-    if (outliers > samples * 0.1)
-    {
-        printf("Node creation took too long\n");
-        for (int i = 0; i < samples; i++)
-        {
-            printf("%zu Nodes created, time: %.6f sec\n", n, timings[i]);
-        }
-        // assert(false);
-    }
+	if(outliers > samples * 0.1) {
+		printf("Node creation took too long\n");
+		for(int i = 0; i < samples; i++) {
+			printf("%zu Nodes created, time: %.6f sec\n", n, timings[i]);
+		}
+		// assert(false);
+	}
 
-    Graph_ReleaseLock(g);
-    Graph_Free(g);
+	Graph_ReleaseLock(g);
+	Graph_Free(g);
 }
 
 // Test graph creation time.
-void benchmark_node_creation_no_labels()
-{
-    printf("benchmark_node_creation_no_labels\n");
-    double tic[2];
-    int samples = 64;
-    double timings[samples];
-    int outliers = 0;
-    float threshold = 0.000006;
-    // size_t n = GRAPH_DEFAULT_NODE_CAP;
-    Node node;
-    size_t n = 1000000;
-    Graph *g = Graph_New(n,n);
-    Graph_AcquireWriteLock(g);
+void benchmark_node_creation_no_labels() {
+	printf("benchmark_node_creation_no_labels\n");
+	double tic[2];
+	int samples = 64;
+	double timings[samples];
+	int outliers = 0;
+	float threshold = 0.000006;
+	// size_t n = GRAPH_DEFAULT_NODE_CAP;
+	Node node;
+	size_t n = 1000000;
+	Graph *g = Graph_New(n, n);
+	Graph_AcquireWriteLock(g);
 
-    for (int i = 0; i < samples; i++)
-    {
-        // Create N nodes, don't use labels.
-        simple_tic(tic);
-        for(int j = 0; j < n; j++) Graph_CreateNode(g, GRAPH_NO_LABEL, &node);
-        timings[i] = simple_toc(tic);
-        printf("%zu Nodes created, time: %.6f sec\n", n, timings[i]);
-        if (timings[i] > threshold) outliers++;
-    }
+	for(int i = 0; i < samples; i++) {
+		// Create N nodes, don't use labels.
+		simple_tic(tic);
+		for(int j = 0; j < n; j++) Graph_CreateNode(g, GRAPH_NO_LABEL, &node);
+		timings[i] = simple_toc(tic);
+		printf("%zu Nodes created, time: %.6f sec\n", n, timings[i]);
+		if(timings[i] > threshold) outliers++;
+	}
 
-    if (outliers > samples * 0.1)
-    {
-        printf("Node creation took too long\n");
-        for (int i = 0; i < samples; i++)
-        {
-            printf("%zu Nodes created, time: %.6f sec\n", n, timings[i]);
-        }
-        // assert(false);
-    }
+	if(outliers > samples * 0.1) {
+		printf("Node creation took too long\n");
+		for(int i = 0; i < samples; i++) {
+			printf("%zu Nodes created, time: %.6f sec\n", n, timings[i]);
+		}
+		// assert(false);
+	}
 
-    Graph_ReleaseLock(g);
-    Graph_Free(g);
+	Graph_ReleaseLock(g);
+	Graph_Free(g);
 }
 
-void benchmark_edge_creation_with_relationships()
-{
-    printf("benchmark_edge_creation_with_relationships\n");
-    double tic[2];
-    int samples = 64;
-    double timings[samples];
-    int outliers = 0;
-    float threshold = 0.002;
-    int edge_count = 1000000 * 1.10;
-    int node_count = 1000000;
-    int relation_count = 3;
-    EdgeDesc connections[edge_count];
-    Node node;
-    Edge edge;
-    Graph *g = Graph_New(GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
-    Graph_AcquireWriteLock(g);
+void benchmark_edge_creation_with_relationships() {
+	printf("benchmark_edge_creation_with_relationships\n");
+	double tic[2];
+	int samples = 64;
+	double timings[samples];
+	int outliers = 0;
+	float threshold = 0.002;
+	int edge_count = 1000000 * 1.10;
+	int node_count = 1000000;
+	int relation_count = 3;
+	EdgeDesc connections[edge_count];
+	Node node;
+	Edge edge;
+	Graph *g = Graph_New(GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
+	Graph_AcquireWriteLock(g);
 
-    // Introduce relations types.
-    for (int i = 0; i < relation_count; i++) Graph_AddRelationType(g);
-    for (int i = 0; i < node_count; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &node);
-    for (int i = 0; i < samples; i++) {
-        // Describe connections;
-        // Node I is connected to Node I+1,
-        // Connection type is relationships[I%4].
-        for (int j = 0; j < edge_count; j++) {
-            connections[j].srcId = rand() % node_count;     // Source node id.
-            connections[j].destId = rand() % node_count;    // Destination node id.
-            connections[j].relationId = i % relation_count; // Relation.
-        }
+	// Introduce relations types.
+	for(int i = 0; i < relation_count; i++) Graph_AddRelationType(g);
+	for(int i = 0; i < node_count; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &node);
+	for(int i = 0; i < samples; i++) {
+		// Describe connections;
+		// Node I is connected to Node I+1,
+		// Connection type is relationships[I%4].
+		for(int j = 0; j < edge_count; j++) {
+			connections[j].srcId = rand() % node_count;     // Source node id.
+			connections[j].destId = rand() % node_count;    // Destination node id.
+			connections[j].relationId = i % relation_count; // Relation.
+		}
 
-        simple_tic(tic);
-        for (int j = 0; j < edge_count; j++) {
-            Graph_ConnectNodes(g, connections[j].srcId, connections[j].destId, connections[j].relationId, &edge);
-        }
-        timings[i] = simple_toc(tic);
-        printf("%d Formed connections, time: %.6f sec\n", edge_count, timings[i]);
-        if (timings[i] > threshold)
-            outliers++;
-    }
+		simple_tic(tic);
+		for(int j = 0; j < edge_count; j++) {
+			Graph_ConnectNodes(g, connections[j].srcId, connections[j].destId, connections[j].relationId,
+							   &edge);
+		}
+		timings[i] = simple_toc(tic);
+		printf("%d Formed connections, time: %.6f sec\n", edge_count, timings[i]);
+		if(timings[i] > threshold)
+			outliers++;
+	}
 
-    if (outliers > samples * 0.1)
-    {
-        printf("Node creation took too long\n");
-        for (int i = 0; i < samples; i++)
-        {
-            printf("%d Formed connections, time: %.6f sec\n", edge_count, timings[i]);
-        }
-        // assert(false);
-    }
+	if(outliers > samples * 0.1) {
+		printf("Node creation took too long\n");
+		for(int i = 0; i < samples; i++) {
+			printf("%d Formed connections, time: %.6f sec\n", edge_count, timings[i]);
+		}
+		// assert(false);
+	}
 
-    Graph_ReleaseLock(g);
-    Graph_Free(g);
+	Graph_ReleaseLock(g);
+	Graph_Free(g);
 }
 
-void benchmark_graph()
-{
-    benchmark_node_creation_no_labels();
-    benchmark_node_creation_with_labels();
-    benchmark_edge_creation_with_relationships();
-    printf("%sgraph benchmark - PASS!%s\n", KGRN, KNRM);
+void benchmark_graph() {
+	benchmark_node_creation_no_labels();
+	benchmark_node_creation_with_labels();
+	benchmark_edge_creation_with_relationships();
+	printf("%sgraph benchmark - PASS!%s\n", KGRN, KNRM);
 }
 
 // Validate the creation of a graph,
 // Make sure graph's defaults are applied.
-TEST_F(GraphTest, NewGraph)
-{
-    GrB_Index ncols, nrows, nvals;
-    Graph *g = Graph_New(GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
-    Graph_AcquireWriteLock(g);
+TEST_F(GraphTest, NewGraph) {
+	GrB_Index ncols, nrows, nvals;
+	Graph *g = Graph_New(GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
+	Graph_AcquireWriteLock(g);
 
-    ASSERT_EQ(GrB_Matrix_ncols(&ncols, g->adjacency_matrix), GrB_SUCCESS);
-    ASSERT_EQ(GrB_Matrix_nrows(&nrows, g->adjacency_matrix), GrB_SUCCESS);
-    ASSERT_EQ(GrB_Matrix_nvals(&nvals, g->adjacency_matrix), GrB_SUCCESS);
+	ASSERT_EQ(GrB_Matrix_ncols(&ncols, g->adjacency_matrix), GrB_SUCCESS);
+	ASSERT_EQ(GrB_Matrix_nrows(&nrows, g->adjacency_matrix), GrB_SUCCESS);
+	ASSERT_EQ(GrB_Matrix_nvals(&nvals, g->adjacency_matrix), GrB_SUCCESS);
 
-    ASSERT_TRUE(g->nodes != NULL);
-    ASSERT_TRUE(g->relations != NULL);
-    ASSERT_TRUE(g->labels != NULL);
-    ASSERT_TRUE(g->adjacency_matrix != NULL);
-    ASSERT_EQ(Graph_NodeCount(g), 0);
-    ASSERT_EQ(nrows, GRAPH_DEFAULT_NODE_CAP);
-    ASSERT_EQ(ncols, GRAPH_DEFAULT_NODE_CAP);
-    ASSERT_EQ(nvals, 0);
+	ASSERT_TRUE(g->nodes != NULL);
+	ASSERT_TRUE(g->relations != NULL);
+	ASSERT_TRUE(g->labels != NULL);
+	ASSERT_TRUE(g->adjacency_matrix != NULL);
+	ASSERT_EQ(Graph_NodeCount(g), 0);
+	ASSERT_EQ(nrows, GRAPH_DEFAULT_NODE_CAP);
+	ASSERT_EQ(ncols, GRAPH_DEFAULT_NODE_CAP);
+	ASSERT_EQ(nvals, 0);
 
-    Graph_ReleaseLock(g);
-    Graph_Free(g);
+	Graph_ReleaseLock(g);
+	Graph_Free(g);
 }
 
 // Tests node and edge creation.
-TEST_F(GraphTest, GraphConstruction)
-{
-    size_t node_count = GRAPH_DEFAULT_NODE_CAP / 2;
-    Graph *g = Graph_New(node_count, node_count);
-    Graph_AcquireWriteLock(g);
-    _test_node_creation(g, node_count);
-    // _test_edge_creation(g, node_count);
+TEST_F(GraphTest, GraphConstruction) {
+	size_t node_count = GRAPH_DEFAULT_NODE_CAP / 2;
+	Graph *g = Graph_New(node_count, node_count);
+	Graph_AcquireWriteLock(g);
+	_test_node_creation(g, node_count);
+	// _test_edge_creation(g, node_count);
 
-    // Introduce additional nodes which will cause graph to resize.
-    // _test_graph_resize(g);
+	// Introduce additional nodes which will cause graph to resize.
+	// _test_graph_resize(g);
 
-    Graph_ReleaseLock(g);
-    Graph_Free(g);
+	Graph_ReleaseLock(g);
+	Graph_Free(g);
 }
 
-TEST_F(GraphTest, RemoveNodes)
-{
-    // Construct graph.
-    GrB_Matrix M;
-    GrB_Index nnz;
-    Graph *g = Graph_New(32, 32);
-    Graph_AcquireWriteLock(g);
+TEST_F(GraphTest, RemoveNodes) {
+	// Construct graph.
+	GrB_Matrix M;
+	GrB_Index nnz;
+	Graph *g = Graph_New(32, 32);
+	Graph_AcquireWriteLock(g);
 
-    // Create 3 nodes.
-    Node node;
-    Edge edge;
+	// Create 3 nodes.
+	Node node;
+	Edge edge;
 
-    for(int i = 0; i < 3; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &node);
-    int r = Graph_AddRelationType(g);
+	for(int i = 0; i < 3; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &node);
+	int r = Graph_AddRelationType(g);
 
-    /* Connections:
-     * 0 connected to 1. 
-     * 1 connected to 0.
-     * 1 connected to 2. */
+	/* Connections:
+	 * 0 connected to 1.
+	 * 1 connected to 0.
+	 * 1 connected to 2. */
 
-    // connect 0 to 1.
-    Graph_ConnectNodes(g, 0, 1, r, &edge);
+	// connect 0 to 1.
+	Graph_ConnectNodes(g, 0, 1, r, &edge);
 
-    // Connect 1 to 0.
-    Graph_ConnectNodes(g, 1, 0, r, &edge);
+	// Connect 1 to 0.
+	Graph_ConnectNodes(g, 1, 0, r, &edge);
 
-    // Connect 1 to 2.
-    Graph_ConnectNodes(g, 1, 2, r, &edge);
-    
-    // Validate graph creation.
-    ASSERT_EQ(Graph_NodeCount(g), 3);
-    M = Graph_GetRelationMatrix(g, r);
-    GrB_Matrix_nvals(&nnz, M);
-    ASSERT_EQ(nnz, 3);
+	// Connect 1 to 2.
+	Graph_ConnectNodes(g, 1, 2, r, &edge);
 
-    M = Graph_GetAdjacencyMatrix(g);
-    GrB_Matrix_nvals(&nnz, M);
-    ASSERT_EQ(nnz, 3);
+	// Validate graph creation.
+	ASSERT_EQ(Graph_NodeCount(g), 3);
+	M = Graph_GetRelationMatrix(g, r);
+	GrB_Matrix_nvals(&nnz, M);
+	ASSERT_EQ(nnz, 3);
 
-    Edge *edges = (Edge*)array_new(Edge, 3);
-    //==============================================================================
-    //=== Delete node 0 ============================================================
-    //==============================================================================
+	M = Graph_GetAdjacencyMatrix(g);
+	GrB_Matrix_nvals(&nnz, M);
+	ASSERT_EQ(nnz, 3);
 
-    // First node should have 2 edges.
-    Graph_GetNode(g, 0, &node);
-    Graph_GetNodeEdges(g, &node, GRAPH_EDGE_DIR_BOTH, GRAPH_NO_RELATION, &edges);
-    uint edge_count = array_len(edges);
-    ASSERT_EQ(edge_count, 2);
+	Edge *edges = (Edge *)array_new(Edge, 3);
+	//==============================================================================
+	//=== Delete node 0 ============================================================
+	//==============================================================================
 
-    // Delete the edges on the first node manually, as Graph_DeleteNode expects
-    // it to be detached.
-    // Both 0 -> 1 edge and 1 -> 0 edge should be removed.
-    for (uint i = 0; i < edge_count; i ++) Graph_DeleteEdge(g, &edges[i]);
+	// First node should have 2 edges.
+	Graph_GetNode(g, 0, &node);
+	Graph_GetNodeEdges(g, &node, GRAPH_EDGE_DIR_BOTH, GRAPH_NO_RELATION, &edges);
+	uint edge_count = array_len(edges);
+	ASSERT_EQ(edge_count, 2);
 
-    array_free(edges);
+	// Delete the edges on the first node manually, as Graph_DeleteNode expects
+	// it to be detached.
+	// Both 0 -> 1 edge and 1 -> 0 edge should be removed.
+	for(uint i = 0; i < edge_count; i ++) Graph_DeleteEdge(g, &edges[i]);
 
-    Graph_GetNode(g, 0, &node);
-    Graph_DeleteNode(g, &node);
+	array_free(edges);
 
-    ASSERT_EQ(Graph_NodeCount(g), 2);
-    ASSERT_EQ(Graph_EdgeCount(g), 1);
+	Graph_GetNode(g, 0, &node);
+	Graph_DeleteNode(g, &node);
+
+	ASSERT_EQ(Graph_NodeCount(g), 2);
+	ASSERT_EQ(Graph_EdgeCount(g), 1);
 }
 
-TEST_F(GraphTest, RemoveMultipleNodes)
-{
-    // Delete two node.
-    // One which is the latest node introduced to the graph
-    // and the very first node.
+TEST_F(GraphTest, RemoveMultipleNodes) {
+	// Delete two node.
+	// One which is the latest node introduced to the graph
+	// and the very first node.
 
-    // Expecting ...
-    double tic[2];
+	// Expecting ...
+	double tic[2];
 
-    Node n;
-    Edge e;
-    Graph *g = Graph_New(32, 32);
-    Graph_AcquireWriteLock(g);
-    int relation = Graph_AddRelationType(g);
-    for(int i = 0; i < 8; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
+	Node n;
+	Edge e;
+	Graph *g = Graph_New(32, 32);
+	Graph_AcquireWriteLock(g);
+	int relation = Graph_AddRelationType(g);
+	for(int i = 0; i < 8; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
 
-    // First node.
-    Graph_ConnectNodes(g, 0, 2, relation, &e);
-    Graph_ConnectNodes(g, 0, 6, relation, &e);
-    Graph_ConnectNodes(g, 0, 7, relation, &e);
+	// First node.
+	Graph_ConnectNodes(g, 0, 2, relation, &e);
+	Graph_ConnectNodes(g, 0, 6, relation, &e);
+	Graph_ConnectNodes(g, 0, 7, relation, &e);
 
-    // Right before last node.
-    Graph_ConnectNodes(g, 6, 0, relation, &e);
-    Graph_ConnectNodes(g, 6, 1, relation, &e);
-    Graph_ConnectNodes(g, 6, 7, relation, &e);
+	// Right before last node.
+	Graph_ConnectNodes(g, 6, 0, relation, &e);
+	Graph_ConnectNodes(g, 6, 1, relation, &e);
+	Graph_ConnectNodes(g, 6, 7, relation, &e);
 
-    // Last node.
-    Graph_ConnectNodes(g, 7, 0, relation, &e);
-    Graph_ConnectNodes(g, 7, 1, relation, &e);
-    Graph_ConnectNodes(g, 7, 6, relation, &e);
+	// Last node.
+	Graph_ConnectNodes(g, 7, 0, relation, &e);
+	Graph_ConnectNodes(g, 7, 1, relation, &e);
+	Graph_ConnectNodes(g, 7, 6, relation, &e);
 
-    // Delete first and last nodes.
-    simple_tic(tic);
-    Graph_GetNode(g, 0, &n);
-    Graph_DeleteNode(g, &n);
-    Graph_GetNode(g, 7, &n);
-    Graph_DeleteNode(g, &n);
+	// Delete first and last nodes.
+	simple_tic(tic);
+	Graph_GetNode(g, 0, &n);
+	Graph_DeleteNode(g, &n);
+	Graph_GetNode(g, 7, &n);
+	Graph_DeleteNode(g, &n);
 
-    ASSERT_EQ(Graph_NodeCount(g), 8 - 2);
+	ASSERT_EQ(Graph_NodeCount(g), 8 - 2);
 
-    GrB_Descriptor desc;
-    GrB_Descriptor_new(&desc);
-    GrB_Descriptor_set(desc, GrB_INP0, GrB_TRAN);
+	GrB_Descriptor desc;
+	GrB_Descriptor_new(&desc);
+	GrB_Descriptor_set(desc, GrB_INP0, GrB_TRAN);
 
-    // Validation.
-    GrB_Vector row;
-    GrB_Vector col;
-    GrB_Index rowNvals;
-    GrB_Index colNvals;
+	// Validation.
+	GrB_Vector row;
+	GrB_Vector col;
+	GrB_Index rowNvals;
+	GrB_Index colNvals;
 
-    GrB_Vector_new(&row, GrB_BOOL, Graph_NodeCount(g));
-    GrB_Vector_new(&col, GrB_BOOL, Graph_NodeCount(g));
+	GrB_Vector_new(&row, GrB_BOOL, Graph_NodeCount(g));
+	GrB_Vector_new(&col, GrB_BOOL, Graph_NodeCount(g));
 
-    // Make sure last and first rows and column are zeroed out.
-    GrB_Matrix adj = Graph_GetAdjacencyMatrix(g);
+	// Make sure last and first rows and column are zeroed out.
+	GrB_Matrix adj = Graph_GetAdjacencyMatrix(g);
 
-    GrB_Col_extract(row, NULL, NULL, adj, GrB_ALL, Graph_NodeCount(g), 7, desc);
-    GrB_Col_extract(col, NULL, NULL, adj, GrB_ALL, Graph_NodeCount(g), 7, NULL);
-    GrB_Vector_nvals(&rowNvals, row);
-    GrB_Vector_nvals(&colNvals, col);
-    ASSERT_EQ(rowNvals, 0);
-    ASSERT_EQ(colNvals, 0);
+	GrB_Col_extract(row, NULL, NULL, adj, GrB_ALL, Graph_NodeCount(g), 7, desc);
+	GrB_Col_extract(col, NULL, NULL, adj, GrB_ALL, Graph_NodeCount(g), 7, NULL);
+	GrB_Vector_nvals(&rowNvals, row);
+	GrB_Vector_nvals(&colNvals, col);
+	ASSERT_EQ(rowNvals, 0);
+	ASSERT_EQ(colNvals, 0);
 
-    GrB_Col_extract(row, NULL, NULL, adj, GrB_ALL, Graph_NodeCount(g), 0, desc);
-    GrB_Col_extract(col, NULL, NULL, adj, GrB_ALL, Graph_NodeCount(g), 0, NULL);
-    GrB_Vector_nvals(&rowNvals, row);
-    GrB_Vector_nvals(&colNvals, col);
-    ASSERT_EQ(rowNvals, 0);
-    ASSERT_EQ(colNvals, 0);
+	GrB_Col_extract(row, NULL, NULL, adj, GrB_ALL, Graph_NodeCount(g), 0, desc);
+	GrB_Col_extract(col, NULL, NULL, adj, GrB_ALL, Graph_NodeCount(g), 0, NULL);
+	GrB_Vector_nvals(&rowNvals, row);
+	GrB_Vector_nvals(&colNvals, col);
+	ASSERT_EQ(rowNvals, 0);
+	ASSERT_EQ(colNvals, 0);
 
-    // Clean up.
-    GrB_Descriptor_free(&desc);
-    GrB_Vector_free(&row);
-    GrB_Vector_free(&col);
+	// Clean up.
+	GrB_Descriptor_free(&desc);
+	GrB_Vector_free(&row);
+	GrB_Vector_free(&col);
 
-    Graph_ReleaseLock(g);
-    Graph_Free(g);
+	Graph_ReleaseLock(g);
+	Graph_Free(g);
 }
 
-TEST_F(GraphTest, RemoveEdges)
-{
-    // Construct graph.
-    Edge e;
-    Node n;
-    GrB_Matrix M;
-    GrB_Index nnz;
-    Graph *g = Graph_New(32, 32);
-    Graph_AcquireWriteLock(g);
-    for(int i = 0; i < 3; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
-    int r = Graph_AddRelationType(g);
+TEST_F(GraphTest, RemoveEdges) {
+	// Construct graph.
+	Edge e;
+	Node n;
+	GrB_Matrix M;
+	GrB_Index nnz;
+	Graph *g = Graph_New(32, 32);
+	Graph_AcquireWriteLock(g);
+	for(int i = 0; i < 3; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
+	int r = Graph_AddRelationType(g);
 
-    /* Connections:
-     * 0 connected to 1. 
-     * 0 connected to 2.
-     * 1 connected to 2. */
+	/* Connections:
+	 * 0 connected to 1.
+	 * 0 connected to 2.
+	 * 1 connected to 2. */
 
-    // connect 0 to 1.
-    Graph_ConnectNodes(g, 0, 1, r, &e);
-    // Connect 0 to 2.
-    Graph_ConnectNodes(g, 0, 2, r, &e);
-    // Connect 1 to 2.
-    Graph_ConnectNodes(g, 1, 2, r, &e);
+	// connect 0 to 1.
+	Graph_ConnectNodes(g, 0, 1, r, &e);
+	// Connect 0 to 2.
+	Graph_ConnectNodes(g, 0, 2, r, &e);
+	// Connect 1 to 2.
+	Graph_ConnectNodes(g, 1, 2, r, &e);
 
-    // Validate graph creation.
-    ASSERT_EQ(Graph_EdgeCount(g), 3);
+	// Validate graph creation.
+	ASSERT_EQ(Graph_EdgeCount(g), 3);
 
-    M = Graph_GetRelationMatrix(g, r);
-    GrB_Matrix_nvals(&nnz, M);
-    ASSERT_EQ(nnz, 3);
+	M = Graph_GetRelationMatrix(g, r);
+	GrB_Matrix_nvals(&nnz, M);
+	ASSERT_EQ(nnz, 3);
 
-    M = Graph_GetAdjacencyMatrix(g);
-    GrB_Matrix_nvals(&nnz, M);
-    ASSERT_EQ(nnz, 3);
+	M = Graph_GetAdjacencyMatrix(g);
+	GrB_Matrix_nvals(&nnz, M);
+	ASSERT_EQ(nnz, 3);
 
-    //==============================================================================
-    //=== Delete first edge ========================================================
-    //==============================================================================
-    Edge *edges = (Edge *)array_new(Edge, 3);
-    Graph_GetEdgesConnectingNodes(g, 0, 1, GRAPH_NO_RELATION, &edges);
-    ASSERT_EQ(array_len(edges), 1);
-    
-    e = edges[0];
-    NodeID srcID = Edge_GetSrcNodeID(&e);
-    NodeID destID = Edge_GetDestNodeID(&e);
-    
-    // Delete edge.
-    Graph_DeleteEdge(g, &e);
+	//==============================================================================
+	//=== Delete first edge ========================================================
+	//==============================================================================
+	Edge *edges = (Edge *)array_new(Edge, 3);
+	Graph_GetEdgesConnectingNodes(g, 0, 1, GRAPH_NO_RELATION, &edges);
+	ASSERT_EQ(array_len(edges), 1);
 
-    // Validate edge deletion.
-    ASSERT_EQ(Graph_EdgeCount(g), 2);
-    array_clear(edges);
-    Graph_GetEdgesConnectingNodes(g, 0, 1, GRAPH_NO_RELATION, &edges);
-    ASSERT_EQ(array_len(edges), 0);
-    
-    // Validate matrix update.
-    M = Graph_GetRelationMatrix(g, r);
-    // Relation matrix at [destID, srcID] should be empty.
-    bool x = false;
-    GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
-    ASSERT_FALSE(x);
-    GrB_Matrix_nvals(&nnz, M);
-    ASSERT_EQ(nnz, 2);
+	e = edges[0];
+	NodeID srcID = Edge_GetSrcNodeID(&e);
+	NodeID destID = Edge_GetDestNodeID(&e);
 
-    // Adjacency matrix at [destID, srcID] should be empty.
-    x = false;
-    M = Graph_GetAdjacencyMatrix(g);
-    GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
-    ASSERT_FALSE(x);
-    GrB_Matrix_nvals(&nnz, M);
-    ASSERT_EQ(nnz, 2);
+	// Delete edge.
+	Graph_DeleteEdge(g, &e);
 
-    //==============================================================================
-    //=== Delete second edge =======================================================
-    //==============================================================================
+	// Validate edge deletion.
+	ASSERT_EQ(Graph_EdgeCount(g), 2);
+	array_clear(edges);
+	Graph_GetEdgesConnectingNodes(g, 0, 1, GRAPH_NO_RELATION, &edges);
+	ASSERT_EQ(array_len(edges), 0);
 
-    array_clear(edges); 
-    Graph_GetNode(g, 2, &n);
-    Graph_GetNodeEdges(g, &n, GRAPH_EDGE_DIR_BOTH, GRAPH_NO_RELATION, &edges);
+	// Validate matrix update.
+	M = Graph_GetRelationMatrix(g, r);
+	// Relation matrix at [destID, srcID] should be empty.
+	bool x = false;
+	GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
+	ASSERT_FALSE(x);
+	GrB_Matrix_nvals(&nnz, M);
+	ASSERT_EQ(nnz, 2);
 
-    ASSERT_EQ(array_len(edges), 2);
-    
-    // Delete edge.
-    e = edges[0];
-    srcID = Edge_GetSrcNodeID(&e);
-    destID = Edge_GetDestNodeID(&e);
-    Graph_DeleteEdge(g, &e);
+	// Adjacency matrix at [destID, srcID] should be empty.
+	x = false;
+	M = Graph_GetAdjacencyMatrix(g);
+	GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
+	ASSERT_FALSE(x);
+	GrB_Matrix_nvals(&nnz, M);
+	ASSERT_EQ(nnz, 2);
 
-    // Validate edge deletion.
-    ASSERT_EQ(Graph_EdgeCount(g), 1);
-    
-    // Validate matrix update.
-    M = Graph_GetRelationMatrix(g, r);
-    // Relation matrix at [destID, srcID] should be empty.
-    x = false;
-    GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
-    ASSERT_FALSE(x);
-    GrB_Matrix_nvals(&nnz, M);
-    ASSERT_EQ(nnz, 1);
+	//==============================================================================
+	//=== Delete second edge =======================================================
+	//==============================================================================
 
-    // Adjacency matrix at [destID, srcID] should be empty.
-    x = false;
-    M = Graph_GetAdjacencyMatrix(g);
-    GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
-    ASSERT_FALSE(x);
-    GrB_Matrix_nvals(&nnz, M);
-    ASSERT_EQ(nnz, 1);
+	array_clear(edges);
+	Graph_GetNode(g, 2, &n);
+	Graph_GetNodeEdges(g, &n, GRAPH_EDGE_DIR_BOTH, GRAPH_NO_RELATION, &edges);
 
-    //==============================================================================
-    //=== Delete third edge ========================================================
-    //==============================================================================
+	ASSERT_EQ(array_len(edges), 2);
 
-    // Delete edge.
-    e = edges[1];
-    srcID = Edge_GetSrcNodeID(&e);
-    destID = Edge_GetDestNodeID(&e);
-    Graph_DeleteEdge(g, &e);
+	// Delete edge.
+	e = edges[0];
+	srcID = Edge_GetSrcNodeID(&e);
+	destID = Edge_GetDestNodeID(&e);
+	Graph_DeleteEdge(g, &e);
 
-    // Validate edge deletion.
-    ASSERT_EQ(Graph_EdgeCount(g), 0);
-    
-    // Validate matrix update.
-    M = Graph_GetRelationMatrix(g, r);
-    // Relation matrix at [destID, srcID] should be empty.
-    x = false;
-    GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
-    ASSERT_FALSE(x);
-    GrB_Matrix_nvals(&nnz, M);
-    ASSERT_EQ(nnz, 0);
+	// Validate edge deletion.
+	ASSERT_EQ(Graph_EdgeCount(g), 1);
 
-    // Adjacency matrix at [destID, srcID] should be empty.
-    x = false;
-    M = Graph_GetAdjacencyMatrix(g);
-    GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
-    ASSERT_FALSE(x);
-    GrB_Matrix_nvals(&nnz, M);
-    ASSERT_EQ(nnz, 0);
+	// Validate matrix update.
+	M = Graph_GetRelationMatrix(g, r);
+	// Relation matrix at [destID, srcID] should be empty.
+	x = false;
+	GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
+	ASSERT_FALSE(x);
+	GrB_Matrix_nvals(&nnz, M);
+	ASSERT_EQ(nnz, 1);
 
-    // Cleanup.
-    Graph_ReleaseLock(g);
-    Graph_Free(g);
+	// Adjacency matrix at [destID, srcID] should be empty.
+	x = false;
+	M = Graph_GetAdjacencyMatrix(g);
+	GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
+	ASSERT_FALSE(x);
+	GrB_Matrix_nvals(&nnz, M);
+	ASSERT_EQ(nnz, 1);
+
+	//==============================================================================
+	//=== Delete third edge ========================================================
+	//==============================================================================
+
+	// Delete edge.
+	e = edges[1];
+	srcID = Edge_GetSrcNodeID(&e);
+	destID = Edge_GetDestNodeID(&e);
+	Graph_DeleteEdge(g, &e);
+
+	// Validate edge deletion.
+	ASSERT_EQ(Graph_EdgeCount(g), 0);
+
+	// Validate matrix update.
+	M = Graph_GetRelationMatrix(g, r);
+	// Relation matrix at [destID, srcID] should be empty.
+	x = false;
+	GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
+	ASSERT_FALSE(x);
+	GrB_Matrix_nvals(&nnz, M);
+	ASSERT_EQ(nnz, 0);
+
+	// Adjacency matrix at [destID, srcID] should be empty.
+	x = false;
+	M = Graph_GetAdjacencyMatrix(g);
+	GrB_Matrix_extractElement_BOOL(&x, M, destID, srcID);
+	ASSERT_FALSE(x);
+	GrB_Matrix_nvals(&nnz, M);
+	ASSERT_EQ(nnz, 0);
+
+	// Cleanup.
+	Graph_ReleaseLock(g);
+	Graph_Free(g);
 }
 
-TEST_F(GraphTest, GetNode)
-{
-    /* Create a graph with nodeCount nodes,
-     * Make sure node retrival works as expected:
-     * 1. try to get nodes (0 - nodeCount)
-     * 2. try to get node with ID >= nodeCount. */
+TEST_F(GraphTest, GetNode) {
+	/* Create a graph with nodeCount nodes,
+	 * Make sure node retrival works as expected:
+	 * 1. try to get nodes (0 - nodeCount)
+	 * 2. try to get node with ID >= nodeCount. */
 
-    Node n;
-    size_t nodeCount = 16;
-    Graph *g = Graph_New(nodeCount, nodeCount);
-    Graph_AcquireWriteLock(g);
-    for(int i = 0 ; i < nodeCount; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
-    
-    // Get nodes 0 - nodeCount.
-    NodeID i = 0;
-    for(; i < nodeCount; i++) {
-        Graph_GetNode(g, i, &n);
-        ASSERT_TRUE(n.entity != NULL);
-    }
+	Node n;
+	size_t nodeCount = 16;
+	Graph *g = Graph_New(nodeCount, nodeCount);
+	Graph_AcquireWriteLock(g);
+	for(int i = 0 ; i < nodeCount; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
 
-    // Get a none existing node.
-    ASSERT_EQ(Graph_GetNode(g, i, &n), 0);
-    ASSERT_TRUE(n.entity == NULL);
+	// Get nodes 0 - nodeCount.
+	NodeID i = 0;
+	for(; i < nodeCount; i++) {
+		Graph_GetNode(g, i, &n);
+		ASSERT_TRUE(n.entity != NULL);
+	}
 
-    Graph_ReleaseLock(g);
-    Graph_Free(g);
+	// Get a none existing node.
+	ASSERT_EQ(Graph_GetNode(g, i, &n), 0);
+	ASSERT_TRUE(n.entity == NULL);
+
+	Graph_ReleaseLock(g);
+	Graph_Free(g);
 }
 
-TEST_F(GraphTest, GetEdge)
-{
-    /* Create a graph with both nodes and edges.
-     * Make sure edge retrival works as expected: 
-     * 1. try to get edges by ID 
-     * 2. try to get edges connecting source to destination node 
-     * 3. try to get none existing edges. */
+TEST_F(GraphTest, GetEdge) {
+	/* Create a graph with both nodes and edges.
+	 * Make sure edge retrival works as expected:
+	 * 1. try to get edges by ID
+	 * 2. try to get edges connecting source to destination node
+	 * 3. try to get none existing edges. */
 
-    Node n;
-    Edge e;
-    int relationCount = 4;
-    size_t nodeCount = 5;
-    size_t edgeCount = 5;
-    int relations[relationCount];
+	Node n;
+	Edge e;
+	int relationCount = 4;
+	size_t nodeCount = 5;
+	size_t edgeCount = 5;
+	int relations[relationCount];
 
-    Graph *g = Graph_New(nodeCount, nodeCount);
-    Graph_AcquireWriteLock(g);
-    for(int i = 0; i < nodeCount; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
-    for(int i = 0; i < relationCount; i++) relations[i] = Graph_AddRelationType(g);
+	Graph *g = Graph_New(nodeCount, nodeCount);
+	Graph_AcquireWriteLock(g);
+	for(int i = 0; i < nodeCount; i++) Graph_CreateNode(g, GRAPH_NO_LABEL, &n);
+	for(int i = 0; i < relationCount; i++) relations[i] = Graph_AddRelationType(g);
 
-    /* Connect nodes:
-     * 1. nodes (0-1) will be connected by relation 0. 
-     * 2. nodes (0-1) will be connected by relation 1.
-     * 3. nodes (1-2) will be connected by relation 1.
-     * 4. nodes (2-3) will be connected by relation 2.
-     * 5. nodes (3-4) will be connected by relation 3. */
+	/* Connect nodes:
+	 * 1. nodes (0-1) will be connected by relation 0.
+	 * 2. nodes (0-1) will be connected by relation 1.
+	 * 3. nodes (1-2) will be connected by relation 1.
+	 * 4. nodes (2-3) will be connected by relation 2.
+	 * 5. nodes (3-4) will be connected by relation 3. */
 
-    Graph_ConnectNodes(g, 0, 1, relations[0], &e);
-    Graph_ConnectNodes(g, 0, 1, relations[1], &e);
-    Graph_ConnectNodes(g, 1, 2, relations[1], &e);
-    Graph_ConnectNodes(g, 2, 3, relations[2], &e);
-    Graph_ConnectNodes(g, 3, 4, relations[3], &e);
+	Graph_ConnectNodes(g, 0, 1, relations[0], &e);
+	Graph_ConnectNodes(g, 0, 1, relations[1], &e);
+	Graph_ConnectNodes(g, 1, 2, relations[1], &e);
+	Graph_ConnectNodes(g, 2, 3, relations[2], &e);
+	Graph_ConnectNodes(g, 3, 4, relations[3], &e);
 
-    // Validations
-    // Try to get edges by ID
-    for(EdgeID i = 0; i < edgeCount; i++) {
-        Graph_GetEdge(g, i, &e);
-        ASSERT_TRUE(e.entity != NULL);
-        ASSERT_EQ(e.entity->id, i);
-    }
+	// Validations
+	// Try to get edges by ID
+	for(EdgeID i = 0; i < edgeCount; i++) {
+		Graph_GetEdge(g, i, &e);
+		ASSERT_TRUE(e.entity != NULL);
+		ASSERT_EQ(e.entity->id, i);
+	}
 
-    // Try to get edges connecting source to destination node.
-    NodeID src;
-    NodeID dest;
-    int relation;
-    Edge *edges = (Edge*)array_new(Edge, 4);
+	// Try to get edges connecting source to destination node.
+	NodeID src;
+	NodeID dest;
+	int relation;
+	Edge *edges = (Edge *)array_new(Edge, 4);
 
-    /* Get all edges connecting node 0 to node 1,
-     * expecting 2 edges. */
-    src = 0;
-    dest = 1;
-    relation = GRAPH_NO_RELATION;   // Relation agnostic.
-    Graph_GetEdgesConnectingNodes(g, src, dest, relation, &edges);
-    ASSERT_EQ(array_len(edges), 2);
-    for(int i = 0; i < 2; i++) {
-        e = edges[i];
-        relation = relations[i];
-        ASSERT_TRUE(e.entity != NULL);
-        ASSERT_EQ(Edge_GetSrcNodeID(&e), src);
-        ASSERT_EQ(Edge_GetDestNodeID(&e), dest);
-        ASSERT_EQ(Edge_GetRelationID(&e), relation);
-    }
-    array_clear(edges);
+	/* Get all edges connecting node 0 to node 1,
+	 * expecting 2 edges. */
+	src = 0;
+	dest = 1;
+	relation = GRAPH_NO_RELATION;   // Relation agnostic.
+	Graph_GetEdgesConnectingNodes(g, src, dest, relation, &edges);
+	ASSERT_EQ(array_len(edges), 2);
+	for(int i = 0; i < 2; i++) {
+		e = edges[i];
+		relation = relations[i];
+		ASSERT_TRUE(e.entity != NULL);
+		ASSERT_EQ(Edge_GetSrcNodeID(&e), src);
+		ASSERT_EQ(Edge_GetDestNodeID(&e), dest);
+		ASSERT_EQ(Edge_GetRelationID(&e), relation);
+	}
+	array_clear(edges);
 
-    // Try to get none existing edges:
+	// Try to get none existing edges:
 
-    // Node 0 is not connected to 2.
-    src = 0;
-    dest = 2;
-    relation = GRAPH_NO_RELATION;
-    Graph_GetEdgesConnectingNodes(g, src, dest, relation, &edges);
-    ASSERT_EQ(array_len(edges), 0);
-    array_clear(edges);
+	// Node 0 is not connected to 2.
+	src = 0;
+	dest = 2;
+	relation = GRAPH_NO_RELATION;
+	Graph_GetEdgesConnectingNodes(g, src, dest, relation, &edges);
+	ASSERT_EQ(array_len(edges), 0);
+	array_clear(edges);
 
-    // Node 0 is not connected to 1 via relation 2.
-    src = 0;
-    dest = 1;
-    relation = relations[2];
-    Graph_GetEdgesConnectingNodes(g, src, dest, relation, &edges);
-    ASSERT_EQ(array_len(edges), 0);
-    array_clear(edges);
+	// Node 0 is not connected to 1 via relation 2.
+	src = 0;
+	dest = 1;
+	relation = relations[2];
+	Graph_GetEdgesConnectingNodes(g, src, dest, relation, &edges);
+	ASSERT_EQ(array_len(edges), 0);
+	array_clear(edges);
 
-    // Node 1 is not connected to 0 via relation 0.
-    src = 1;
-    dest = 0;
-    relation = relations[0];
-    Graph_GetEdgesConnectingNodes(g, src, dest, relation, &edges);
-    ASSERT_EQ(array_len(edges), 0);
-    array_clear(edges);
+	// Node 1 is not connected to 0 via relation 0.
+	src = 1;
+	dest = 0;
+	relation = relations[0];
+	Graph_GetEdgesConnectingNodes(g, src, dest, relation, &edges);
+	ASSERT_EQ(array_len(edges), 0);
+	array_clear(edges);
 
-    // No node connects to itself.
-    for(NodeID i = 0; i < nodeCount; i++) {
-        for(int j = 0; j < relationCount; j++) {
-            src = i;
-            relation = relations[j];
-            Graph_GetEdgesConnectingNodes(g, src, src, relation, &edges);
-            ASSERT_EQ(array_len(edges), 0);
-            array_clear(edges); // Reset edge count.
-        }
-        relation = GRAPH_NO_RELATION;
-        Graph_GetEdgesConnectingNodes(g, src, src, relation, &edges);
-        ASSERT_EQ(array_len(edges), 0);
-        array_clear(edges); // Reset edge count.
-    }
+	// No node connects to itself.
+	for(NodeID i = 0; i < nodeCount; i++) {
+		for(int j = 0; j < relationCount; j++) {
+			src = i;
+			relation = relations[j];
+			Graph_GetEdgesConnectingNodes(g, src, src, relation, &edges);
+			ASSERT_EQ(array_len(edges), 0);
+			array_clear(edges); // Reset edge count.
+		}
+		relation = GRAPH_NO_RELATION;
+		Graph_GetEdgesConnectingNodes(g, src, src, relation, &edges);
+		ASSERT_EQ(array_len(edges), 0);
+		array_clear(edges); // Reset edge count.
+	}
 
-    array_free(edges);
-    Graph_ReleaseLock(g);
-    Graph_Free(g);
+	array_free(edges);
+	Graph_ReleaseLock(g);
+	Graph_Free(g);
 }
 
 
-TEST_F(GraphTest, BulkDelete)
-{
-    // Create graph.
-    int node_count = 5;
-    int edge_count = 13;
-    Node n[node_count];
-    Edge e[edge_count];
-    Graph *g = Graph_New(16, 16);
+TEST_F(GraphTest, BulkDelete) {
+	// Create graph.
+	int node_count = 5;
+	int edge_count = 13;
+	Node n[node_count];
+	Edge e[edge_count];
+	Graph *g = Graph_New(16, 16);
 
-    Graph_AcquireWriteLock(g);
-    
-    int l = Graph_AddLabel(g);
-    int r0 = Graph_AddRelationType(g);
-    int r1 = Graph_AddRelationType(g);
+	Graph_AcquireWriteLock(g);
 
-    for(int i = 0; i < node_count; i++) Graph_CreateNode(g, l, &n[i]);
+	int l = Graph_AddLabel(g);
+	int r0 = Graph_AddRelationType(g);
+	int r1 = Graph_AddRelationType(g);
 
-    /* Connect nodes:
-     * (0)-[r0]->(1)
-     * (0)-[r0]->(1)
-     * (0)-[r1]->(1)
-     * (0)-[r1]->(1)
-     * 
-     * (1)-[r0]->(0)
-     * (1)-[r0]->(0)
-     * (1)-[r1]->(0)
-     * 
-     * (2)-[r0]->(0)
-     * (2)-[r1]->(1)
-     * (2)-[r1]->(3)
-     * 
-     * (3)-[r1]->(4)
-     * (3)-[r1]->(4)
-     * 
-     * (4)-[r0]->(3) */
-    
-    // Node 0 is connected to node 1 with multiple edges.
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[0]), ENTITY_GET_ID(&n[1]), r0, &e[0]);
-    Edge_SetRelationID(&e[0], r0);
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[0]), ENTITY_GET_ID(&n[1]), r0, &e[1]);
-    Edge_SetRelationID(&e[1], r0);
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[0]), ENTITY_GET_ID(&n[1]), r1, &e[2]);
-    Edge_SetRelationID(&e[2], r1);
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[0]), ENTITY_GET_ID(&n[1]), r1, &e[3]);
-    Edge_SetRelationID(&e[3], r1);
-    
-    // Node 1 is connected to node 0 with multiple edges.
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[1]), ENTITY_GET_ID(&n[0]), r0, &e[4]);
-    Edge_SetRelationID(&e[4], r0);
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[1]), ENTITY_GET_ID(&n[0]), r0, &e[5]);
-    Edge_SetRelationID(&e[5], r0);
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[1]), ENTITY_GET_ID(&n[0]), r1, &e[6]);
-    Edge_SetRelationID(&e[6], r1);
+	for(int i = 0; i < node_count; i++) Graph_CreateNode(g, l, &n[i]);
 
-    // Node 2 is connected to nodes 0,1 and 3.
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[2]), ENTITY_GET_ID(&n[0]), r0, &e[7]);
-    Edge_SetRelationID(&e[7], r0);
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[2]), ENTITY_GET_ID(&n[1]), r1, &e[8]);
-    Edge_SetRelationID(&e[8], r1);
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[2]), ENTITY_GET_ID(&n[3]), r1, &e[9]);
-    Edge_SetRelationID(&e[9], r1);
+	/* Connect nodes:
+	 * (0)-[r0]->(1)
+	 * (0)-[r0]->(1)
+	 * (0)-[r1]->(1)
+	 * (0)-[r1]->(1)
+	 *
+	 * (1)-[r0]->(0)
+	 * (1)-[r0]->(0)
+	 * (1)-[r1]->(0)
+	 *
+	 * (2)-[r0]->(0)
+	 * (2)-[r1]->(1)
+	 * (2)-[r1]->(3)
+	 *
+	 * (3)-[r1]->(4)
+	 * (3)-[r1]->(4)
+	 *
+	 * (4)-[r0]->(3) */
 
-    // Node 3 is connected to node 4 with multiple edges.
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[3]), ENTITY_GET_ID(&n[4]), r1, &e[10]);
-    Edge_SetRelationID(&e[10], r1);
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[3]), ENTITY_GET_ID(&n[4]), r1, &e[11]);
-    Edge_SetRelationID(&e[11], r1);
+	// Node 0 is connected to node 1 with multiple edges.
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[0]), ENTITY_GET_ID(&n[1]), r0, &e[0]);
+	Edge_SetRelationID(&e[0], r0);
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[0]), ENTITY_GET_ID(&n[1]), r0, &e[1]);
+	Edge_SetRelationID(&e[1], r0);
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[0]), ENTITY_GET_ID(&n[1]), r1, &e[2]);
+	Edge_SetRelationID(&e[2], r1);
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[0]), ENTITY_GET_ID(&n[1]), r1, &e[3]);
+	Edge_SetRelationID(&e[3], r1);
 
-    // Node 4 is connected to node 3.
-    Graph_ConnectNodes(g, ENTITY_GET_ID(&n[4]), ENTITY_GET_ID(&n[3]), r0, &e[12]);
-    Edge_SetRelationID(&e[12], r0);
+	// Node 1 is connected to node 0 with multiple edges.
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[1]), ENTITY_GET_ID(&n[0]), r0, &e[4]);
+	Edge_SetRelationID(&e[4], r0);
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[1]), ENTITY_GET_ID(&n[0]), r0, &e[5]);
+	Edge_SetRelationID(&e[5], r0);
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[1]), ENTITY_GET_ID(&n[0]), r1, &e[6]);
+	Edge_SetRelationID(&e[6], r1);
 
-    Graph_ReleaseLock(g);
-    /* Delete nodes 0,1.
-     * Implicit deleted edges:
-     * 0 (0)-[r0]->(1)
-     * 1 (0)-[r0]->(1)
-     * 2 (0)-[r1]->(1)
-     * 3 (0)-[r1]->(1)
-     *
-     * 4 (1)-[r0]->(0)
-     * 5 (1)-[r0]->(0)
-     * 6 (1)-[r1]->(0)
-     *
-     * 7 (2)-[r0]->(0)
-     * 8 (2)-[r1]->(1) */
+	// Node 2 is connected to nodes 0,1 and 3.
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[2]), ENTITY_GET_ID(&n[0]), r0, &e[7]);
+	Edge_SetRelationID(&e[7], r0);
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[2]), ENTITY_GET_ID(&n[1]), r1, &e[8]);
+	Edge_SetRelationID(&e[8], r1);
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[2]), ENTITY_GET_ID(&n[3]), r1, &e[9]);
+	Edge_SetRelationID(&e[9], r1);
 
-    Node nodes[4] = {n[0], n[1], n[0], n[1]};
+	// Node 3 is connected to node 4 with multiple edges.
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[3]), ENTITY_GET_ID(&n[4]), r1, &e[10]);
+	Edge_SetRelationID(&e[10], r1);
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[3]), ENTITY_GET_ID(&n[4]), r1, &e[11]);
+	Edge_SetRelationID(&e[11], r1);
 
-    /* Delete edges 1,5 and 11.
-     * 0  (0)-[r0]->(1) - Duplicate
-     * 4  (1)-[r0]->(0) - Duplicate
-     * 10 (3)-[r1]->(4) */
-    Edge edges[6] = {e[0], e[0], e[4], e[4], e[10], e[10]};
-    uint node_deleted = 0;
-    uint edge_deleted = 0;
-    
-    Graph_AcquireWriteLock(g);
-    Graph_BulkDelete(g, nodes, 4, edges, 6, &node_deleted, &edge_deleted);
-    Graph_ReleaseLock(g);
+	// Node 4 is connected to node 3.
+	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[4]), ENTITY_GET_ID(&n[3]), r0, &e[12]);
+	Edge_SetRelationID(&e[12], r0);
 
-    ASSERT_EQ(node_deleted, 2);
-    // Statistics do not count for multi edge deletions.
-    // ASSERT_EQ(edge_deleted, 10);
+	Graph_ReleaseLock(g);
+	/* Delete nodes 0,1.
+	 * Implicit deleted edges:
+	 * 0 (0)-[r0]->(1)
+	 * 1 (0)-[r0]->(1)
+	 * 2 (0)-[r1]->(1)
+	 * 3 (0)-[r1]->(1)
+	 *
+	 * 4 (1)-[r0]->(0)
+	 * 5 (1)-[r0]->(0)
+	 * 6 (1)-[r1]->(0)
+	 *
+	 * 7 (2)-[r0]->(0)
+	 * 8 (2)-[r1]->(1) */
 
-    /* Verification, updated graph:
-     * (2)-[r1]->(3)
-     * 
-     * (3)-[r1]->(4)
-     * 
-     * (4)-[r0]->(3) */
+	Node nodes[4] = {n[0], n[1], n[0], n[1]};
 
-    ASSERT_EQ(Graph_NodeCount(g), 3);
-    ASSERT_EQ(Graph_EdgeCount(g), 3);
+	/* Delete edges 1,5 and 11.
+	 * 0  (0)-[r0]->(1) - Duplicate
+	 * 4  (1)-[r0]->(0) - Duplicate
+	 * 10 (3)-[r1]->(4) */
+	Edge edges[6] = {e[0], e[0], e[4], e[4], e[10], e[10]};
+	uint node_deleted = 0;
+	uint edge_deleted = 0;
 
-    // Clean up.
-    Graph_Free(g);
+	Graph_AcquireWriteLock(g);
+	Graph_BulkDelete(g, nodes, 4, edges, 6, &node_deleted, &edge_deleted);
+	Graph_ReleaseLock(g);
+
+	ASSERT_EQ(node_deleted, 2);
+	// Statistics do not count for multi edge deletions.
+	// ASSERT_EQ(edge_deleted, 10);
+
+	/* Verification, updated graph:
+	 * (2)-[r1]->(3)
+	 *
+	 * (3)-[r1]->(4)
+	 *
+	 * (4)-[r0]->(3) */
+
+	ASSERT_EQ(Graph_NodeCount(g), 3);
+	ASSERT_EQ(Graph_EdgeCount(g), 3);
+
+	// Clean up.
+	Graph_Free(g);
 }

--- a/tests/unit/test_gxb_matrix_del.cpp
+++ b/tests/unit/test_gxb_matrix_del.cpp
@@ -17,42 +17,41 @@ extern "C" {
 
 class GxB_DeleteTest: public ::testing::Test {
   protected:
-    static void SetUpTestCase() {
-        // Use the malloc family for allocations
-        Alloc_Reset();
-        ASSERT_EQ(GrB_init(GrB_NONBLOCKING), GrB_SUCCESS);
-        GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW); // all matrices in CSR format
-        GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
-    }
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
+		ASSERT_EQ(GrB_init(GrB_NONBLOCKING), GrB_SUCCESS);
+		GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW); // all matrices in CSR format
+		GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
+	}
 
-    static void TearDownTestCase()
-    {
-        GrB_finalize();
-    }
+	static void TearDownTestCase() {
+		GrB_finalize();
+	}
 };
 
 TEST_F(GxB_DeleteTest, GxB_Delete) {
-    // Create a 10X10 diagonal matrix.
-    GrB_Matrix M;
-    GrB_Matrix_new(&M, GrB_BOOL, 10, 10);
-    
-    // 1's along the diagonal.
-    for(GrB_Index i = 0; i < 10; i++) {
-        GrB_Matrix_setElement_BOOL(M, true, i, i);
-    }
+	// Create a 10X10 diagonal matrix.
+	GrB_Matrix M;
+	GrB_Matrix_new(&M, GrB_BOOL, 10, 10);
 
-    GrB_Index nvals;
-    GrB_Matrix_nvals(&nvals, M);
-    ASSERT_EQ(nvals, 10);
+	// 1's along the diagonal.
+	for(GrB_Index i = 0; i < 10; i++) {
+		GrB_Matrix_setElement_BOOL(M, true, i, i);
+	}
 
-    // Clear diagonal.
-    for(GrB_Index i = 0; i < 10; i++) {
-        GxB_Matrix_Delete(M, i, i);
-        GrB_Matrix_nvals(&nvals, M);
-        ASSERT_EQ(nvals, 10-1-i);
-    }
+	GrB_Index nvals;
+	GrB_Matrix_nvals(&nvals, M);
+	ASSERT_EQ(nvals, 10);
 
-    // Expecting an empty matrix.
-    GrB_Matrix_nvals(&nvals, M);
-    ASSERT_EQ(nvals, 0);
+	// Clear diagonal.
+	for(GrB_Index i = 0; i < 10; i++) {
+		GxB_Matrix_Delete(M, i, i);
+		GrB_Matrix_nvals(&nvals, M);
+		ASSERT_EQ(nvals, 10 - 1 - i);
+	}
+
+	// Expecting an empty matrix.
+	GrB_Matrix_nvals(&nvals, M);
+	ASSERT_EQ(nvals, 0);
 }

--- a/tests/unit/test_index.cpp
+++ b/tests/unit/test_index.cpp
@@ -24,97 +24,97 @@ extern pthread_key_t _tlsGCKey;    // Thread local storage graph context key.
 
 class IndexTest: public ::testing::Test {
   protected:
-    static void SetUpTestCase() {
-      // Use the malloc family for allocations
-      Alloc_Reset();
-      ASSERT_EQ(GrB_init(GrB_NONBLOCKING), GrB_SUCCESS);
-      GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW); // all matrices in CSR format
-      GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
+		ASSERT_EQ(GrB_init(GrB_NONBLOCKING), GrB_SUCCESS);
+		GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW); // all matrices in CSR format
+		GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
 
-      _fake_graph_context();
-    }
+		_fake_graph_context();
+	}
 
-    static void TearDownTestCase() {
-        _free_fake_graph_context();
-        GrB_finalize();
-    }
+	static void TearDownTestCase() {
+		_free_fake_graph_context();
+		GrB_finalize();
+	}
 
-    static void _fake_graph_context() {
-        GraphContext *gc = (GraphContext*)malloc(sizeof(GraphContext));
+	static void _fake_graph_context() {
+		GraphContext *gc = (GraphContext *)malloc(sizeof(GraphContext));
 
-        gc->g = _build_test_graph();
-        gc->index_count = 0;
-        gc->graph_name = strdup("G");
-        gc->attributes = raxNew();
-        gc->string_mapping = (char**)array_new(char*, 64);
-        gc->node_schemas = (Schema**)array_new(Schema*, GRAPH_DEFAULT_LABEL_CAP);
-        gc->relation_schemas = (Schema**)array_new(Schema*, GRAPH_DEFAULT_RELATION_TYPE_CAP);
+		gc->g = _build_test_graph();
+		gc->index_count = 0;
+		gc->graph_name = strdup("G");
+		gc->attributes = raxNew();
+		gc->string_mapping = (char **)array_new(char *, 64);
+		gc->node_schemas = (Schema **)array_new(Schema *, GRAPH_DEFAULT_LABEL_CAP);
+		gc->relation_schemas = (Schema **)array_new(Schema *, GRAPH_DEFAULT_RELATION_TYPE_CAP);
 
-        GraphContext_AddSchema(gc, "Person", SCHEMA_NODE);
+		GraphContext_AddSchema(gc, "Person", SCHEMA_NODE);
 
-        int error = pthread_key_create(&_tlsGCKey, NULL);
-        ASSERT_EQ(error, 0);
-        pthread_setspecific(_tlsGCKey, gc);
-    }
+		int error = pthread_key_create(&_tlsGCKey, NULL);
+		ASSERT_EQ(error, 0);
+		pthread_setspecific(_tlsGCKey, gc);
+	}
 
-    static void _free_fake_graph_context() {
-        GraphContext *gc = GraphContext_GetFromTLS();
-        GraphContext_Free(gc);
-    }
+	static void _free_fake_graph_context() {
+		GraphContext *gc = GraphContext_GetFromTLS();
+		GraphContext_Free(gc);
+	}
 
-    static Graph* _build_test_graph() {
-        // Allocate graph
-        size_t n = 16;
-        Graph *g = Graph_New(n, n);
-        Graph_AcquireWriteLock(g);
+	static Graph *_build_test_graph() {
+		// Allocate graph
+		size_t n = 16;
+		Graph *g = Graph_New(n, n);
+		Graph_AcquireWriteLock(g);
 
-        // Build a label matrix and add to graph
-        // (this does not need to be associated with an actual label string)
-        Graph_AddLabel(g);
+		// Build a label matrix and add to graph
+		// (this does not need to be associated with an actual label string)
+		Graph_AddLabel(g);
 
-        Graph_ReleaseLock(g);
-        return g;
-    }
+		Graph_ReleaseLock(g);
+		return g;
+	}
 };
 
 TEST_F(IndexTest, Index_New) {
-    const char *l = "Person";
-    Index *idx = Index_New(l, IDX_EXACT_MATCH);
+	const char *l = "Person";
+	Index *idx = Index_New(l, IDX_EXACT_MATCH);
 
-    // Return indexed label.
-    const char *label = Index_GetLabel(idx);
-    ASSERT_STREQ(label, l);
+	// Return indexed label.
+	const char *label = Index_GetLabel(idx);
+	ASSERT_STREQ(label, l);
 
-    const char *field = "name";
-    ASSERT_FALSE(Index_ContainsField(idx, field));
-    Index_AddField(idx, field);
-    Index_AddField(idx, field);
-    ASSERT_TRUE(Index_ContainsField(idx, field));
+	const char *field = "name";
+	ASSERT_FALSE(Index_ContainsField(idx, field));
+	Index_AddField(idx, field);
+	Index_AddField(idx, field);
+	ASSERT_TRUE(Index_ContainsField(idx, field));
 
-    field = "age";
-    ASSERT_FALSE(Index_ContainsField(idx, field));
-    Index_AddField(idx, field);
-    Index_AddField(idx, field);
-    ASSERT_TRUE(Index_ContainsField(idx, field));
+	field = "age";
+	ASSERT_FALSE(Index_ContainsField(idx, field));
+	Index_AddField(idx, field);
+	Index_AddField(idx, field);
+	ASSERT_TRUE(Index_ContainsField(idx, field));
 
-    // Returns number of fields indexed.
-    uint field_count = Index_FieldsCount(idx);
-    ASSERT_EQ(field_count, 2);
+	// Returns number of fields indexed.
+	uint field_count = Index_FieldsCount(idx);
+	ASSERT_EQ(field_count, 2);
 
-    // Returns indexed fields.
-    const char **fields = Index_GetFields(idx);
-    ASSERT_STREQ(fields[0], "name");
-    ASSERT_STREQ(fields[1], "age");
+	// Returns indexed fields.
+	const char **fields = Index_GetFields(idx);
+	ASSERT_STREQ(fields[0], "name");
+	ASSERT_STREQ(fields[1], "age");
 
-    Index_RemoveField(idx, "age");
-    Index_RemoveField(idx, "age");
-    ASSERT_FALSE(Index_ContainsField(idx, "age"));
-    ASSERT_TRUE(Index_ContainsField(idx, "name"));
+	Index_RemoveField(idx, "age");
+	Index_RemoveField(idx, "age");
+	ASSERT_FALSE(Index_ContainsField(idx, "age"));
+	ASSERT_TRUE(Index_ContainsField(idx, "name"));
 
-    Index_RemoveField(idx, "name");
-    Index_RemoveField(idx, "name");
-    ASSERT_FALSE(Index_ContainsField(idx, "age"));
-    ASSERT_FALSE(Index_ContainsField(idx, "name"));
+	Index_RemoveField(idx, "name");
+	Index_RemoveField(idx, "name");
+	ASSERT_FALSE(Index_ContainsField(idx, "age"));
+	ASSERT_FALSE(Index_ContainsField(idx, "name"));
 
-    Index_Free(idx);
+	Index_Free(idx);
 }

--- a/tests/unit/test_query_graph.cpp
+++ b/tests/unit/test_query_graph.cpp
@@ -17,333 +17,333 @@ extern "C" {
 #endif
 
 class QueryGraphTest: public ::testing::Test {
-    protected:
-        static void SetUpTestCase() {
-            // Use the malloc family for allocations
-            Alloc_Reset();
-    }
+  protected:
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
+	}
 
-    void compare_nodes(const QGNode *a, const QGNode *b) {
-        ASSERT_STREQ(a->alias, b->alias);
-        ASSERT_STREQ(a->label, b->label);
-        ASSERT_EQ(a->labelID, b->labelID);
-        ASSERT_EQ(array_len(a->incoming_edges), array_len(b->incoming_edges));
-        ASSERT_EQ(array_len(a->outgoing_edges), array_len(b->outgoing_edges));
-    }
+	void compare_nodes(const QGNode *a, const QGNode *b) {
+		ASSERT_STREQ(a->alias, b->alias);
+		ASSERT_STREQ(a->label, b->label);
+		ASSERT_EQ(a->labelID, b->labelID);
+		ASSERT_EQ(array_len(a->incoming_edges), array_len(b->incoming_edges));
+		ASSERT_EQ(array_len(a->outgoing_edges), array_len(b->outgoing_edges));
+	}
 
-    void compare_edges(const QGEdge *a, const QGEdge *b) {
-        ASSERT_STREQ(a->alias, b->alias);
-        uint relcount = array_len(a->reltypes);
-        ASSERT_EQ(relcount, array_len(b->reltypes));
-        for (uint i = 0; i < relcount; i ++) {
-            ASSERT_STREQ(a->reltypes[i], b->reltypes[i]);
-            ASSERT_EQ(a->reltypeIDs[i], b->reltypeIDs[i]);
-        }
+	void compare_edges(const QGEdge *a, const QGEdge *b) {
+		ASSERT_STREQ(a->alias, b->alias);
+		uint relcount = array_len(a->reltypes);
+		ASSERT_EQ(relcount, array_len(b->reltypes));
+		for(uint i = 0; i < relcount; i ++) {
+			ASSERT_STREQ(a->reltypes[i], b->reltypes[i]);
+			ASSERT_EQ(a->reltypeIDs[i], b->reltypeIDs[i]);
+		}
 
-        compare_nodes(a->src, b->src);
-        compare_nodes(a->dest, b->dest);
-    }
+		compare_nodes(a->src, b->src);
+		compare_nodes(a->dest, b->dest);
+	}
 
-    bool contains_node(const QueryGraph *qg, const QGNode *n) {
-        uint count = QueryGraph_NodeCount(qg);
-        for (uint i = 0; i < count; i ++) {
-            if (qg->nodes[i] == n) return true;
-        }
-        return false;
-    }
+	bool contains_node(const QueryGraph *qg, const QGNode *n) {
+		uint count = QueryGraph_NodeCount(qg);
+		for(uint i = 0; i < count; i ++) {
+			if(qg->nodes[i] == n) return true;
+		}
+		return false;
+	}
 
-    bool contains_edge(const QueryGraph *qg, const QGEdge *e) {
-        uint count = QueryGraph_EdgeCount(qg);
-        for (uint i = 0; i < count; i ++) {
-            if (qg->edges[i] == e) return true;
-        }
-        return false;
-    }
+	bool contains_edge(const QueryGraph *qg, const QGEdge *e) {
+		uint count = QueryGraph_EdgeCount(qg);
+		for(uint i = 0; i < count; i ++) {
+			if(qg->edges[i] == e) return true;
+		}
+		return false;
+	}
 
-    QueryGraph* SingleNodeGraph() {
-        // Create a single node graph
-        // (A)
-        size_t node_cap = 1;
-        size_t edge_cap = 0;
+	QueryGraph *SingleNodeGraph() {
+		// Create a single node graph
+		// (A)
+		size_t node_cap = 1;
+		size_t edge_cap = 0;
 
-        // Create nodes.
-        const char *label = "L";
+		// Create nodes.
+		const char *label = "L";
 
-        QGNode *A = QGNode_New(label, "A", 0);
-        QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
-        QueryGraph_AddNode(g, A);
-        
-        return g;
-    }
+		QGNode *A = QGNode_New(label, "A", 0);
+		QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
+		QueryGraph_AddNode(g, A);
 
-    QueryGraph* TriangleGraph() {
-        // Create a triangle graph
-        // (A)->(B)->(C)->(A)
-        size_t node_cap = 3;
-        size_t edge_cap = 3;
+		return g;
+	}
 
-        // Create nodes.
-        const char *label = "L";
-        const char *relation = "R";
+	QueryGraph *TriangleGraph() {
+		// Create a triangle graph
+		// (A)->(B)->(C)->(A)
+		size_t node_cap = 3;
+		size_t edge_cap = 3;
 
-        uint id = 0;
-        QGNode *A = QGNode_New(label, "A", id++);
-        QGNode *B = QGNode_New(label, "B", id++);
-        QGNode *C = QGNode_New(label, "C", id++);
+		// Create nodes.
+		const char *label = "L";
+		const char *relation = "R";
 
-        QGEdge *AB = QGEdge_New(A, B, relation, "AB", id++);
-        QGEdge *BC = QGEdge_New(B, C, relation, "BC", id++);
-        QGEdge *CA = QGEdge_New(C, A, relation, "CA", id++);
+		uint id = 0;
+		QGNode *A = QGNode_New(label, "A", id++);
+		QGNode *B = QGNode_New(label, "B", id++);
+		QGNode *C = QGNode_New(label, "C", id++);
 
-        QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
-        QueryGraph_AddNode(g, A);
-        QueryGraph_AddNode(g, B);
-        QueryGraph_AddNode(g, C);
+		QGEdge *AB = QGEdge_New(A, B, relation, "AB", id++);
+		QGEdge *BC = QGEdge_New(B, C, relation, "BC", id++);
+		QGEdge *CA = QGEdge_New(C, A, relation, "CA", id++);
 
-        QueryGraph_ConnectNodes(g, A, B, AB);
-        QueryGraph_ConnectNodes(g, B, C, BC);
-        QueryGraph_ConnectNodes(g, C, A, CA);
-        
-        return g;
-    }
+		QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
+		QueryGraph_AddNode(g, A);
+		QueryGraph_AddNode(g, B);
+		QueryGraph_AddNode(g, C);
 
-    QueryGraph* DisjointGraph() {
-        // Create a disjoint graph
-        // (A)->(B) (C)
-        size_t node_cap = 3;
-        size_t edge_cap = 1;
+		QueryGraph_ConnectNodes(g, A, B, AB);
+		QueryGraph_ConnectNodes(g, B, C, BC);
+		QueryGraph_ConnectNodes(g, C, A, CA);
 
-        // Create nodes.
-        const char *label = "L";
-        const char *relation = "R";
+		return g;
+	}
 
-        uint id = 0;
-        QGNode *A = QGNode_New(label, "A", id++);
-        QGNode *B = QGNode_New(label, "B", id++);
-        QGNode *C = QGNode_New(label, "C", id++);
+	QueryGraph *DisjointGraph() {
+		// Create a disjoint graph
+		// (A)->(B) (C)
+		size_t node_cap = 3;
+		size_t edge_cap = 1;
 
-        QGEdge *AB = QGEdge_New(A, B, relation, "AB", id++);
+		// Create nodes.
+		const char *label = "L";
+		const char *relation = "R";
 
-        QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
-        QueryGraph_AddNode(g, A);
-        QueryGraph_AddNode(g, B);
-        QueryGraph_AddNode(g, C);
+		uint id = 0;
+		QGNode *A = QGNode_New(label, "A", id++);
+		QGNode *B = QGNode_New(label, "B", id++);
+		QGNode *C = QGNode_New(label, "C", id++);
 
-        QueryGraph_ConnectNodes(g, A, B, AB);
+		QGEdge *AB = QGEdge_New(A, B, relation, "AB", id++);
 
-        return g;
-    }
+		QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
+		QueryGraph_AddNode(g, A);
+		QueryGraph_AddNode(g, B);
+		QueryGraph_AddNode(g, C);
 
-    QueryGraph* SingleNodeCycleGraph() {
-        // Create a disjoint graph
-        // (A)->(A)
-        size_t node_cap = 1;
-        size_t edge_cap = 1;
+		QueryGraph_ConnectNodes(g, A, B, AB);
 
-        // Create nodes.
-        const char *label = "L";
-        const char *relation = "R";
+		return g;
+	}
 
-        uint id = 0;
-        QGNode *A = QGNode_New(label, "A", id++);
-        QGEdge *AA = QGEdge_New(A, A, relation, "AA", id++);
+	QueryGraph *SingleNodeCycleGraph() {
+		// Create a disjoint graph
+		// (A)->(A)
+		size_t node_cap = 1;
+		size_t edge_cap = 1;
 
-        QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
-        QueryGraph_AddNode(g, A);
-        QueryGraph_ConnectNodes(g, A, A, AA);
+		// Create nodes.
+		const char *label = "L";
+		const char *relation = "R";
 
-        return g;
-    }
+		uint id = 0;
+		QGNode *A = QGNode_New(label, "A", id++);
+		QGEdge *AA = QGEdge_New(A, A, relation, "AA", id++);
+
+		QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
+		QueryGraph_AddNode(g, A);
+		QueryGraph_ConnectNodes(g, A, A, AA);
+
+		return g;
+	}
 
 };
 
 TEST_F(QueryGraphTest, QueryGraphClone) {
-    // Create a triangle graph
-    // (A)->(B)->(C)->(A)
-    size_t node_cap = 3;
-    size_t edge_cap = 3;
+	// Create a triangle graph
+	// (A)->(B)->(C)->(A)
+	size_t node_cap = 3;
+	size_t edge_cap = 3;
 
-    // Create nodes.
-    const char *label = "L";
-    const char *relation = "R";
+	// Create nodes.
+	const char *label = "L";
+	const char *relation = "R";
 
-    uint id = 0;
-    QGNode *A = QGNode_New(label, "A", id++);
-    QGNode *B = QGNode_New(label, "B", id++);
-    QGNode *C = QGNode_New(label, "C", id++);
+	uint id = 0;
+	QGNode *A = QGNode_New(label, "A", id++);
+	QGNode *B = QGNode_New(label, "B", id++);
+	QGNode *C = QGNode_New(label, "C", id++);
 
-    QGEdge *AB = QGEdge_New(A, B, relation, "AB", id++);
-    QGEdge *BC = QGEdge_New(B, C, relation, "BC", id++);
-    QGEdge *CA = QGEdge_New(C, A, relation, "CA", id++);
+	QGEdge *AB = QGEdge_New(A, B, relation, "AB", id++);
+	QGEdge *BC = QGEdge_New(B, C, relation, "BC", id++);
+	QGEdge *CA = QGEdge_New(C, A, relation, "CA", id++);
 
-    QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
-    QueryGraph_AddNode(g, A);
-    QueryGraph_AddNode(g, B);
-    QueryGraph_AddNode(g, C);
+	QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
+	QueryGraph_AddNode(g, A);
+	QueryGraph_AddNode(g, B);
+	QueryGraph_AddNode(g, C);
 
-    QueryGraph_ConnectNodes(g, A, B, AB);
-    QueryGraph_ConnectNodes(g, B, C, BC);
-    QueryGraph_ConnectNodes(g, C, A, CA);
+	QueryGraph_ConnectNodes(g, A, B, AB);
+	QueryGraph_ConnectNodes(g, B, C, BC);
+	QueryGraph_ConnectNodes(g, C, A, CA);
 
-    QueryGraph *clone = QueryGraph_Clone(g);
+	QueryGraph *clone = QueryGraph_Clone(g);
 
-    // Validations.
-    ASSERT_EQ(QueryGraph_NodeCount(g), QueryGraph_NodeCount(clone));
-    ASSERT_EQ(QueryGraph_EdgeCount(g), QueryGraph_EdgeCount(clone));
+	// Validations.
+	ASSERT_EQ(QueryGraph_NodeCount(g), QueryGraph_NodeCount(clone));
+	ASSERT_EQ(QueryGraph_EdgeCount(g), QueryGraph_EdgeCount(clone));
 
-    // Validate nodes.
-    for(int i = 0; i < QueryGraph_NodeCount(g); i++) {
-        QGNode *a = g->nodes[i];
-        QGNode *b = clone->nodes[i];
-        compare_nodes(a, b);
-    }
+	// Validate nodes.
+	for(int i = 0; i < QueryGraph_NodeCount(g); i++) {
+		QGNode *a = g->nodes[i];
+		QGNode *b = clone->nodes[i];
+		compare_nodes(a, b);
+	}
 
-    // Validate edges.
-    for(int i = 0; i < QueryGraph_EdgeCount(g); i++) {
-        QGEdge *a = g->edges[i];
-        QGEdge *b = clone->edges[i];
-        compare_edges(a, b);  
-    }
+	// Validate edges.
+	for(int i = 0; i < QueryGraph_EdgeCount(g); i++) {
+		QGEdge *a = g->edges[i];
+		QGEdge *b = clone->edges[i];
+		compare_edges(a, b);
+	}
 
-    // Clean up.
-    QueryGraph_Free(g);
-    QueryGraph_Free(clone);
+	// Clean up.
+	QueryGraph_Free(g);
+	QueryGraph_Free(clone);
 }
 
 
 TEST_F(QueryGraphTest, QueryGraphRemoveEntities) {
-    // Create a triangle graph
-    // (A)->(B)->(C)->(A)
-    size_t node_cap = 3;
-    size_t edge_cap = 3;
+	// Create a triangle graph
+	// (A)->(B)->(C)->(A)
+	size_t node_cap = 3;
+	size_t edge_cap = 3;
 
-    // Create nodes.
-    const char *label = "L";
-    const char *relation = "R";
+	// Create nodes.
+	const char *label = "L";
+	const char *relation = "R";
 
-    uint id = 0;
-    QGNode *A = QGNode_New(label, "A", id++);
-    QGNode *B = QGNode_New(label, "B", id++);
-    QGNode *C = QGNode_New(label, "C", id++);
+	uint id = 0;
+	QGNode *A = QGNode_New(label, "A", id++);
+	QGNode *B = QGNode_New(label, "B", id++);
+	QGNode *C = QGNode_New(label, "C", id++);
 
-    QGEdge *AB = QGEdge_New(A, B, relation, "AB", id++);
-    QGEdge *BC = QGEdge_New(B, C, relation, "BC", id++);
-    QGEdge *CA = QGEdge_New(C, A, relation, "CA", id++);
+	QGEdge *AB = QGEdge_New(A, B, relation, "AB", id++);
+	QGEdge *BC = QGEdge_New(B, C, relation, "BC", id++);
+	QGEdge *CA = QGEdge_New(C, A, relation, "CA", id++);
 
-    QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
-    QueryGraph_AddNode(g, A);
-    QueryGraph_AddNode(g, B);
-    QueryGraph_AddNode(g, C);
+	QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
+	QueryGraph_AddNode(g, A);
+	QueryGraph_AddNode(g, B);
+	QueryGraph_AddNode(g, C);
 
-    QueryGraph_ConnectNodes(g, A, B, AB);
-    QueryGraph_ConnectNodes(g, B, C, BC);
-    QueryGraph_ConnectNodes(g, C, A, CA);
+	QueryGraph_ConnectNodes(g, A, B, AB);
+	QueryGraph_ConnectNodes(g, B, C, BC);
+	QueryGraph_ConnectNodes(g, C, A, CA);
 
-    // Remove an edge.
-    ASSERT_TRUE(contains_edge(g, AB));
-    ASSERT_TRUE(QueryGraph_GetEdgeByID(g, AB->id) != NULL);
-    
-    QueryGraph_RemoveEdge(g, AB);
+	// Remove an edge.
+	ASSERT_TRUE(contains_edge(g, AB));
+	ASSERT_TRUE(QueryGraph_GetEdgeByID(g, AB->id) != NULL);
 
-    ASSERT_FALSE(contains_edge(g, AB));
-    ASSERT_FALSE(QueryGraph_GetEdgeByID(g, AB->id) != NULL);
-    
-    // Remove node.
-    ASSERT_TRUE(contains_node(g, C));
-    ASSERT_TRUE(QueryGraph_GetNodeByID(g, C->id) != NULL);
+	QueryGraph_RemoveEdge(g, AB);
 
-    QueryGraph_RemoveNode(g, C);
-    
-    ASSERT_FALSE(contains_node(g, C));
-    ASSERT_FALSE(QueryGraph_GetNodeByID(g, C->id) != NULL);
+	ASSERT_FALSE(contains_edge(g, AB));
+	ASSERT_FALSE(QueryGraph_GetEdgeByID(g, AB->id) != NULL);
 
-    // Both CA BC edges should be removed.
-    ASSERT_FALSE(contains_edge(g, CA));
-    ASSERT_FALSE(QueryGraph_GetEdgeByID(g, CA->id) != NULL);
-    
-    ASSERT_FALSE(contains_edge(g, BC));
-    ASSERT_FALSE(QueryGraph_GetEdgeByID(g, BC->id) != NULL);
+	// Remove node.
+	ASSERT_TRUE(contains_node(g, C));
+	ASSERT_TRUE(QueryGraph_GetNodeByID(g, C->id) != NULL);
 
-    /* Assert entity count:
-     * Nodes - A was removed.
-     * Edges - AB explicitly removed, BC and CA implicitly removed. */
-    ASSERT_EQ(QueryGraph_NodeCount(g), 2);    
-    ASSERT_EQ(QueryGraph_EdgeCount(g), 0);
+	QueryGraph_RemoveNode(g, C);
 
-    // Assert remaining entities, 
-    ASSERT_TRUE(contains_node(g, A));
-    ASSERT_TRUE(QueryGraph_GetNodeByID(g, A->id) != NULL);
-    ASSERT_TRUE(contains_node(g, B));
-    ASSERT_TRUE(QueryGraph_GetNodeByID(g, B->id) != NULL);
+	ASSERT_FALSE(contains_node(g, C));
+	ASSERT_FALSE(QueryGraph_GetNodeByID(g, C->id) != NULL);
 
-    // Clean up.
-    QueryGraph_Free(g);
+	// Both CA BC edges should be removed.
+	ASSERT_FALSE(contains_edge(g, CA));
+	ASSERT_FALSE(QueryGraph_GetEdgeByID(g, CA->id) != NULL);
+
+	ASSERT_FALSE(contains_edge(g, BC));
+	ASSERT_FALSE(QueryGraph_GetEdgeByID(g, BC->id) != NULL);
+
+	/* Assert entity count:
+	 * Nodes - A was removed.
+	 * Edges - AB explicitly removed, BC and CA implicitly removed. */
+	ASSERT_EQ(QueryGraph_NodeCount(g), 2);
+	ASSERT_EQ(QueryGraph_EdgeCount(g), 0);
+
+	// Assert remaining entities,
+	ASSERT_TRUE(contains_node(g, A));
+	ASSERT_TRUE(QueryGraph_GetNodeByID(g, A->id) != NULL);
+	ASSERT_TRUE(contains_node(g, B));
+	ASSERT_TRUE(QueryGraph_GetNodeByID(g, B->id) != NULL);
+
+	// Clean up.
+	QueryGraph_Free(g);
 }
 
 TEST_F(QueryGraphTest, QueryGraphConnectedComponents) {
-    QueryGraph *g;
-    QueryGraph **connected_components;
+	QueryGraph *g;
+	QueryGraph **connected_components;
 
-    //------------------------------------------------------------------------------
-    // Single node graph
-    //------------------------------------------------------------------------------
-    g = SingleNodeGraph();
-    connected_components = QueryGraph_ConnectedComponents(g);
+	//------------------------------------------------------------------------------
+	// Single node graph
+	//------------------------------------------------------------------------------
+	g = SingleNodeGraph();
+	connected_components = QueryGraph_ConnectedComponents(g);
 
-    ASSERT_EQ(array_len(connected_components), 1);
+	ASSERT_EQ(array_len(connected_components), 1);
 
-    // Clean up.
-    QueryGraph_Free(g);
-    for(int i = 0; i < array_len(connected_components); i++) {
-        QueryGraph_Free(connected_components[i]);
-    }
-    array_free(connected_components);
-    
-    //------------------------------------------------------------------------------
-    // Triangle graph
-    //------------------------------------------------------------------------------
+	// Clean up.
+	QueryGraph_Free(g);
+	for(int i = 0; i < array_len(connected_components); i++) {
+		QueryGraph_Free(connected_components[i]);
+	}
+	array_free(connected_components);
 
-    g = TriangleGraph();
-    connected_components = QueryGraph_ConnectedComponents(g);
+	//------------------------------------------------------------------------------
+	// Triangle graph
+	//------------------------------------------------------------------------------
 
-    ASSERT_EQ(array_len(connected_components), 1);
+	g = TriangleGraph();
+	connected_components = QueryGraph_ConnectedComponents(g);
 
-    // Clean up.
-    QueryGraph_Free(g);
-    for(int i = 0; i < array_len(connected_components); i++) {
-        QueryGraph_Free(connected_components[i]);
-    }
-    array_free(connected_components);
+	ASSERT_EQ(array_len(connected_components), 1);
 
-    //------------------------------------------------------------------------------
-    // Disjoint graph
-    //------------------------------------------------------------------------------
-    
-    g = DisjointGraph();
-    connected_components = QueryGraph_ConnectedComponents(g);
+	// Clean up.
+	QueryGraph_Free(g);
+	for(int i = 0; i < array_len(connected_components); i++) {
+		QueryGraph_Free(connected_components[i]);
+	}
+	array_free(connected_components);
 
-    ASSERT_EQ(array_len(connected_components), 2);
+	//------------------------------------------------------------------------------
+	// Disjoint graph
+	//------------------------------------------------------------------------------
 
-    // Clean up.
-    QueryGraph_Free(g);
-    for(int i = 0; i < array_len(connected_components); i++) {
-        QueryGraph_Free(connected_components[i]);
-    }
-    array_free(connected_components);
+	g = DisjointGraph();
+	connected_components = QueryGraph_ConnectedComponents(g);
 
-    //------------------------------------------------------------------------------
-    // Single node cycle graph
-    //------------------------------------------------------------------------------
-    
-    g = SingleNodeCycleGraph();
-    connected_components = QueryGraph_ConnectedComponents(g);
+	ASSERT_EQ(array_len(connected_components), 2);
 
-    ASSERT_EQ(array_len(connected_components), 1);
+	// Clean up.
+	QueryGraph_Free(g);
+	for(int i = 0; i < array_len(connected_components); i++) {
+		QueryGraph_Free(connected_components[i]);
+	}
+	array_free(connected_components);
 
-    // Clean up.
-    QueryGraph_Free(g);
-    for(int i = 0; i < array_len(connected_components); i++) {
-        QueryGraph_Free(connected_components[i]);
-    }
-    array_free(connected_components);
+	//------------------------------------------------------------------------------
+	// Single node cycle graph
+	//------------------------------------------------------------------------------
+
+	g = SingleNodeCycleGraph();
+	connected_components = QueryGraph_ConnectedComponents(g);
+
+	ASSERT_EQ(array_len(connected_components), 1);
+
+	// Clean up.
+	QueryGraph_Free(g);
+	for(int i = 0; i < array_len(connected_components); i++) {
+		QueryGraph_Free(connected_components[i]);
+	}
+	array_free(connected_components);
 }

--- a/tests/unit/test_range.cpp
+++ b/tests/unit/test_range.cpp
@@ -19,11 +19,11 @@ extern "C" {
 #endif
 
 class RangeTest: public ::testing::Test {
-    protected:
-    static void SetUpTestCase() {
-        // Use the malloc family for allocations
-        Alloc_Reset();
-    }
+  protected:
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -31,140 +31,140 @@ class RangeTest: public ::testing::Test {
 //------------------------------------------------------------------------------
 
 TEST_F(RangeTest, NumericRangeNew) {
-    NumericRange *r = NumericRange_New();
-    
-    ASSERT_TRUE(r->valid);
-    ASSERT_EQ(r->max, INFINITY);
-    ASSERT_EQ(r->min, -INFINITY);
-    ASSERT_FALSE(r->include_max);
-    ASSERT_FALSE(r->include_min);
+	NumericRange *r = NumericRange_New();
 
-    NumericRange_Free(r);
+	ASSERT_TRUE(r->valid);
+	ASSERT_EQ(r->max, INFINITY);
+	ASSERT_EQ(r->min, -INFINITY);
+	ASSERT_FALSE(r->include_max);
+	ASSERT_FALSE(r->include_min);
+
+	NumericRange_Free(r);
 }
 
 TEST_F(RangeTest, NumericRangeValidation) {
-    NumericRange *r = NumericRange_New();
+	NumericRange *r = NumericRange_New();
 
-    // X > 5 AND X < 5
-    r->max = 5;
-    r->min = 5;
-    r->include_max = false;
-    r->include_min = false;
-    ASSERT_FALSE(NumericRange_IsValid(r));
+	// X > 5 AND X < 5
+	r->max = 5;
+	r->min = 5;
+	r->include_max = false;
+	r->include_min = false;
+	ASSERT_FALSE(NumericRange_IsValid(r));
 
-    // X >= 5 AND X < 5
-    r->max = 5;
-    r->min = 5;
-    r->include_max = false;
-    r->include_min = true;
-    ASSERT_FALSE(NumericRange_IsValid(r));
-    
-    // X >= 5 AND X <= 5
-    r->max = 5;
-    r->min = 5;
-    r->include_max = true;
-    r->include_min = true;
-    ASSERT_TRUE(NumericRange_IsValid(r));
+	// X >= 5 AND X < 5
+	r->max = 5;
+	r->min = 5;
+	r->include_max = false;
+	r->include_min = true;
+	ASSERT_FALSE(NumericRange_IsValid(r));
 
-    // X > 5 AND X <= 5
-    r->max = 5;
-    r->min = 5;
-    r->include_max = true;
-    r->include_min = false;
-    ASSERT_FALSE(NumericRange_IsValid(r));
+	// X >= 5 AND X <= 5
+	r->max = 5;
+	r->min = 5;
+	r->include_max = true;
+	r->include_min = true;
+	ASSERT_TRUE(NumericRange_IsValid(r));
 
-    // (5, 10)  X > 5 AND x < 10.
-    r->max = 10;
-    r->min = 5;
-    r->include_max = false;
-    r->include_min = false;
-    ASSERT_TRUE(NumericRange_IsValid(r));
+	// X > 5 AND X <= 5
+	r->max = 5;
+	r->min = 5;
+	r->include_max = true;
+	r->include_min = false;
+	ASSERT_FALSE(NumericRange_IsValid(r));
 
-    // (5, 10]  X > 5 AND x <= 10.
-    r->max = 10;
-    r->min = 5;
-    r->include_max = true;
-    r->include_min = false;
-    ASSERT_TRUE(NumericRange_IsValid(r));
+	// (5, 10)  X > 5 AND x < 10.
+	r->max = 10;
+	r->min = 5;
+	r->include_max = false;
+	r->include_min = false;
+	ASSERT_TRUE(NumericRange_IsValid(r));
 
-    // [5, 10)  X >= 5 AND x < 10.
-    r->max = 10;
-    r->min = 5;
-    r->include_max = false;
-    r->include_min = true;
-    ASSERT_TRUE(NumericRange_IsValid(r));
+	// (5, 10]  X > 5 AND x <= 10.
+	r->max = 10;
+	r->min = 5;
+	r->include_max = true;
+	r->include_min = false;
+	ASSERT_TRUE(NumericRange_IsValid(r));
 
-    // [5, 10]  X >= 5 AND x =< 10.
-    r->max = 10;
-    r->min = 5;
-    r->include_max = true;
-    r->include_min = true;
-    ASSERT_TRUE(NumericRange_IsValid(r));
+	// [5, 10)  X >= 5 AND x < 10.
+	r->max = 10;
+	r->min = 5;
+	r->include_max = false;
+	r->include_min = true;
+	ASSERT_TRUE(NumericRange_IsValid(r));
 
-    NumericRange_Free(r);
+	// [5, 10]  X >= 5 AND x =< 10.
+	r->max = 10;
+	r->min = 5;
+	r->include_max = true;
+	r->include_min = true;
+	ASSERT_TRUE(NumericRange_IsValid(r));
+
+	NumericRange_Free(r);
 }
 
 TEST_F(RangeTest, NumericTightenRange) {
-    NumericRange *r = NumericRange_New();
+	NumericRange *r = NumericRange_New();
 
-    // X < 100
-    NumericRange_TightenRange(r, OP_LT, 100);
-    ASSERT_EQ(r->max, 100);
-    ASSERT_FALSE(r->include_max);
+	// X < 100
+	NumericRange_TightenRange(r, OP_LT, 100);
+	ASSERT_EQ(r->max, 100);
+	ASSERT_FALSE(r->include_max);
 
-    // X <= 100
-    NumericRange_TightenRange(r, OP_LE, 100);
-    ASSERT_EQ(r->max, 100);
-    ASSERT_FALSE(r->include_max);
+	// X <= 100
+	NumericRange_TightenRange(r, OP_LE, 100);
+	ASSERT_EQ(r->max, 100);
+	ASSERT_FALSE(r->include_max);
 
-    // X >= 50
-    NumericRange_TightenRange(r, OP_GE, 50);
-    ASSERT_EQ(r->min, 50);
-    ASSERT_TRUE(r->include_min);
+	// X >= 50
+	NumericRange_TightenRange(r, OP_GE, 50);
+	ASSERT_EQ(r->min, 50);
+	ASSERT_TRUE(r->include_min);
 
-    // X > 50
-    NumericRange_TightenRange(r, OP_GT, 50);
-    ASSERT_EQ(r->min, 50);
-    ASSERT_FALSE(r->include_min);
+	// X > 50
+	NumericRange_TightenRange(r, OP_GT, 50);
+	ASSERT_EQ(r->min, 50);
+	ASSERT_FALSE(r->include_min);
 
-    // 75 <= X >= 75
-    NumericRange_TightenRange(r, OP_EQUAL, 75);
-    ASSERT_EQ(r->min, 75);
-    ASSERT_TRUE(r->include_min);
-    ASSERT_EQ(r->max, 75);
-    ASSERT_TRUE(r->include_max);
+	// 75 <= X >= 75
+	NumericRange_TightenRange(r, OP_EQUAL, 75);
+	ASSERT_EQ(r->min, 75);
+	ASSERT_TRUE(r->include_min);
+	ASSERT_EQ(r->max, 75);
+	ASSERT_TRUE(r->include_max);
 
-    ASSERT_TRUE(NumericRange_IsValid(r));
-    NumericRange_Free(r);
+	ASSERT_TRUE(NumericRange_IsValid(r));
+	NumericRange_Free(r);
 }
 
 TEST_F(RangeTest, NumericContainsValue) {
-    NumericRange *r = NumericRange_New();
-    // -INF < X < INF
-    ASSERT_TRUE(NumericRange_ContainsValue(r, 100));
+	NumericRange *r = NumericRange_New();
+	// -INF < X < INF
+	ASSERT_TRUE(NumericRange_ContainsValue(r, 100));
 
-    // X <= 100
-    NumericRange_TightenRange(r, OP_LE, 100);
-    ASSERT_FALSE(NumericRange_ContainsValue(r, 101));
-    ASSERT_TRUE(NumericRange_ContainsValue(r, 100));
-    ASSERT_TRUE(NumericRange_ContainsValue(r, -9999));
+	// X <= 100
+	NumericRange_TightenRange(r, OP_LE, 100);
+	ASSERT_FALSE(NumericRange_ContainsValue(r, 101));
+	ASSERT_TRUE(NumericRange_ContainsValue(r, 100));
+	ASSERT_TRUE(NumericRange_ContainsValue(r, -9999));
 
-    // X > -10
-    NumericRange_TightenRange(r, OP_GT, -10);
-    ASSERT_FALSE(NumericRange_ContainsValue(r, -10));
-    ASSERT_TRUE(NumericRange_ContainsValue(r, -9));
+	// X > -10
+	NumericRange_TightenRange(r, OP_GT, -10);
+	ASSERT_FALSE(NumericRange_ContainsValue(r, -10));
+	ASSERT_TRUE(NumericRange_ContainsValue(r, -9));
 
-    // X >= 0 AND X <= 0
-    NumericRange_TightenRange(r, OP_EQUAL, 0);
-    ASSERT_FALSE(NumericRange_ContainsValue(r, 1));
-    ASSERT_FALSE(NumericRange_ContainsValue(r, -1));
-    ASSERT_TRUE(NumericRange_ContainsValue(r, 0));
+	// X >= 0 AND X <= 0
+	NumericRange_TightenRange(r, OP_EQUAL, 0);
+	ASSERT_FALSE(NumericRange_ContainsValue(r, 1));
+	ASSERT_FALSE(NumericRange_ContainsValue(r, -1));
+	ASSERT_TRUE(NumericRange_ContainsValue(r, 0));
 
-    // X > 0
-    NumericRange_TightenRange(r, OP_GT, 0);
-    ASSERT_FALSE(NumericRange_ContainsValue(r, 0));
+	// X > 0
+	NumericRange_TightenRange(r, OP_GT, 0);
+	ASSERT_FALSE(NumericRange_ContainsValue(r, 0));
 
-    NumericRange_Free(r);
+	NumericRange_Free(r);
 }
 
 //------------------------------------------------------------------------------
@@ -172,136 +172,136 @@ TEST_F(RangeTest, NumericContainsValue) {
 //------------------------------------------------------------------------------
 
 TEST_F(RangeTest, StringRangeNew) {
-    StringRange *r = StringRange_New();
-    
-    ASSERT_TRUE(r->valid);
-    ASSERT_TRUE(r->max == NULL);
-    ASSERT_TRUE(r->min == NULL);
-    ASSERT_FALSE(r->include_max);
-    ASSERT_FALSE(r->include_min);
+	StringRange *r = StringRange_New();
 
-    StringRange_Free(r);
+	ASSERT_TRUE(r->valid);
+	ASSERT_TRUE(r->max == NULL);
+	ASSERT_TRUE(r->min == NULL);
+	ASSERT_FALSE(r->include_max);
+	ASSERT_FALSE(r->include_min);
+
+	StringRange_Free(r);
 }
 
 TEST_F(RangeTest, StringRangeValidation) {
-    StringRange *r;
+	StringRange *r;
 
-    // X > "a" AND X < "a"
-    r = StringRange_New();
-    StringRange_TightenRange(r, OP_LT, "a");
-    StringRange_TightenRange(r, OP_GT, "a");
-    ASSERT_FALSE(StringRange_IsValid(r));
-    StringRange_Free(r);
+	// X > "a" AND X < "a"
+	r = StringRange_New();
+	StringRange_TightenRange(r, OP_LT, "a");
+	StringRange_TightenRange(r, OP_GT, "a");
+	ASSERT_FALSE(StringRange_IsValid(r));
+	StringRange_Free(r);
 
-    // X >= "a" AND X < "a"
-    r = StringRange_New();
-    StringRange_TightenRange(r, OP_LT, "a");
-    StringRange_TightenRange(r, OP_GE, "a");
-    ASSERT_FALSE(StringRange_IsValid(r));
-    StringRange_Free(r);
-    
-    // X >= "a" AND X <= "a"
-    r = StringRange_New();
-    StringRange_TightenRange(r, OP_LE, "a");
-    StringRange_TightenRange(r, OP_GE, "a");
-    ASSERT_TRUE(StringRange_IsValid(r));
-    StringRange_Free(r);
+	// X >= "a" AND X < "a"
+	r = StringRange_New();
+	StringRange_TightenRange(r, OP_LT, "a");
+	StringRange_TightenRange(r, OP_GE, "a");
+	ASSERT_FALSE(StringRange_IsValid(r));
+	StringRange_Free(r);
 
-    // X > "a" AND X <= "a"
-    r = StringRange_New();
-    StringRange_TightenRange(r, OP_LE, "a");
-    StringRange_TightenRange(r, OP_GT, "a");
-    ASSERT_FALSE(StringRange_IsValid(r));
-    StringRange_Free(r);
+	// X >= "a" AND X <= "a"
+	r = StringRange_New();
+	StringRange_TightenRange(r, OP_LE, "a");
+	StringRange_TightenRange(r, OP_GE, "a");
+	ASSERT_TRUE(StringRange_IsValid(r));
+	StringRange_Free(r);
 
-    // ("a", "z")  X > "a" AND x < "z".
-    r = StringRange_New();
-    StringRange_TightenRange(r, OP_LT, "z");
-    StringRange_TightenRange(r, OP_GT, "a");
-    ASSERT_TRUE(StringRange_IsValid(r));
-    StringRange_Free(r);
+	// X > "a" AND X <= "a"
+	r = StringRange_New();
+	StringRange_TightenRange(r, OP_LE, "a");
+	StringRange_TightenRange(r, OP_GT, "a");
+	ASSERT_FALSE(StringRange_IsValid(r));
+	StringRange_Free(r);
 
-    // ("a", "z"]  X > "a" AND x <= "z".
-    r = StringRange_New();
-    StringRange_TightenRange(r, OP_LE, "z");
-    StringRange_TightenRange(r, OP_GT, "a");
-    ASSERT_TRUE(StringRange_IsValid(r));
-    StringRange_Free(r);
+	// ("a", "z")  X > "a" AND x < "z".
+	r = StringRange_New();
+	StringRange_TightenRange(r, OP_LT, "z");
+	StringRange_TightenRange(r, OP_GT, "a");
+	ASSERT_TRUE(StringRange_IsValid(r));
+	StringRange_Free(r);
 
-    // ["a", "z")  X >= "a" AND x < "z".
-    r = StringRange_New();
-    StringRange_TightenRange(r, OP_LT, "z");
-    StringRange_TightenRange(r, OP_GE, "a");
-    ASSERT_TRUE(StringRange_IsValid(r));
-    StringRange_Free(r);
+	// ("a", "z"]  X > "a" AND x <= "z".
+	r = StringRange_New();
+	StringRange_TightenRange(r, OP_LE, "z");
+	StringRange_TightenRange(r, OP_GT, "a");
+	ASSERT_TRUE(StringRange_IsValid(r));
+	StringRange_Free(r);
 
-    // ["a", "z"]  X >= "a" AND x =< "z".
-    r = StringRange_New();
-    StringRange_TightenRange(r, OP_LE, "z");
-    StringRange_TightenRange(r, OP_GE, "a");
-    ASSERT_TRUE(StringRange_IsValid(r));
-    StringRange_Free(r);
+	// ["a", "z")  X >= "a" AND x < "z".
+	r = StringRange_New();
+	StringRange_TightenRange(r, OP_LT, "z");
+	StringRange_TightenRange(r, OP_GE, "a");
+	ASSERT_TRUE(StringRange_IsValid(r));
+	StringRange_Free(r);
+
+	// ["a", "z"]  X >= "a" AND x =< "z".
+	r = StringRange_New();
+	StringRange_TightenRange(r, OP_LE, "z");
+	StringRange_TightenRange(r, OP_GE, "a");
+	ASSERT_TRUE(StringRange_IsValid(r));
+	StringRange_Free(r);
 }
 
 TEST_F(RangeTest, StringTightenRange) {
-    StringRange *r = StringRange_New();
+	StringRange *r = StringRange_New();
 
-    // X < "z"
-    StringRange_TightenRange(r, OP_LT, "z");
-    ASSERT_STREQ(r->max, "z");
-    ASSERT_FALSE(r->include_max);
+	// X < "z"
+	StringRange_TightenRange(r, OP_LT, "z");
+	ASSERT_STREQ(r->max, "z");
+	ASSERT_FALSE(r->include_max);
 
-    // X <= "z"
-    StringRange_TightenRange(r, OP_LE, "z");
-    ASSERT_STREQ(r->max, "z");
-    ASSERT_FALSE(r->include_max);
+	// X <= "z"
+	StringRange_TightenRange(r, OP_LE, "z");
+	ASSERT_STREQ(r->max, "z");
+	ASSERT_FALSE(r->include_max);
 
-    // X >= "a"
-    StringRange_TightenRange(r, OP_GE, "a");
-    ASSERT_STREQ(r->min, "a");
-    ASSERT_TRUE(r->include_min);
+	// X >= "a"
+	StringRange_TightenRange(r, OP_GE, "a");
+	ASSERT_STREQ(r->min, "a");
+	ASSERT_TRUE(r->include_min);
 
-    // X > "a"
-    StringRange_TightenRange(r, OP_GT, "a");
-    ASSERT_STREQ(r->min, "a");
-    ASSERT_FALSE(r->include_min);
+	// X > "a"
+	StringRange_TightenRange(r, OP_GT, "a");
+	ASSERT_STREQ(r->min, "a");
+	ASSERT_FALSE(r->include_min);
 
-    // "g" <= X >= "g"
-    StringRange_TightenRange(r, OP_EQUAL, "g");
-    ASSERT_STREQ(r->min, "g");
-    ASSERT_TRUE(r->include_min);
-    ASSERT_STREQ(r->max, "g");
-    ASSERT_TRUE(r->include_max);
+	// "g" <= X >= "g"
+	StringRange_TightenRange(r, OP_EQUAL, "g");
+	ASSERT_STREQ(r->min, "g");
+	ASSERT_TRUE(r->include_min);
+	ASSERT_STREQ(r->max, "g");
+	ASSERT_TRUE(r->include_max);
 
-    ASSERT_TRUE(StringRange_IsValid(r));
-    StringRange_Free(r);
+	ASSERT_TRUE(StringRange_IsValid(r));
+	StringRange_Free(r);
 }
 
 TEST_F(RangeTest, StringContainsValue) {
-    StringRange *r = StringRange_New();
-    // -INF < X < INF
-    ASSERT_TRUE(StringRange_ContainsValue(r, "k"));
+	StringRange *r = StringRange_New();
+	// -INF < X < INF
+	ASSERT_TRUE(StringRange_ContainsValue(r, "k"));
 
-    // X <= "y"
-    StringRange_TightenRange(r, OP_LE, "y");
-    ASSERT_FALSE(StringRange_ContainsValue(r, "z"));
-    ASSERT_TRUE(StringRange_ContainsValue(r, "y"));
-    ASSERT_TRUE(StringRange_ContainsValue(r, "a"));
+	// X <= "y"
+	StringRange_TightenRange(r, OP_LE, "y");
+	ASSERT_FALSE(StringRange_ContainsValue(r, "z"));
+	ASSERT_TRUE(StringRange_ContainsValue(r, "y"));
+	ASSERT_TRUE(StringRange_ContainsValue(r, "a"));
 
-    // X > "a"
-    StringRange_TightenRange(r, OP_GT, "a");
-    ASSERT_FALSE(StringRange_ContainsValue(r, "a"));
-    ASSERT_TRUE(StringRange_ContainsValue(r, "b"));
+	// X > "a"
+	StringRange_TightenRange(r, OP_GT, "a");
+	ASSERT_FALSE(StringRange_ContainsValue(r, "a"));
+	ASSERT_TRUE(StringRange_ContainsValue(r, "b"));
 
-    // X >= "k" AND X <= "k"
-    StringRange_TightenRange(r, OP_EQUAL, "k");
-    ASSERT_FALSE(StringRange_ContainsValue(r, "l"));
-    ASSERT_FALSE(StringRange_ContainsValue(r, "j"));
-    ASSERT_TRUE(StringRange_ContainsValue(r, "k"));
+	// X >= "k" AND X <= "k"
+	StringRange_TightenRange(r, OP_EQUAL, "k");
+	ASSERT_FALSE(StringRange_ContainsValue(r, "l"));
+	ASSERT_FALSE(StringRange_ContainsValue(r, "j"));
+	ASSERT_TRUE(StringRange_ContainsValue(r, "k"));
 
-    // X > "k"
-    StringRange_TightenRange(r, OP_GT, "k");
-    ASSERT_FALSE(StringRange_ContainsValue(r, "k"));
+	// X > "k"
+	StringRange_TightenRange(r, OP_GT, "k");
+	ASSERT_FALSE(StringRange_ContainsValue(r, "k"));
 
-    StringRange_Free(r);
+	StringRange_Free(r);
 }

--- a/tests/unit/test_record.cpp
+++ b/tests/unit/test_record.cpp
@@ -21,34 +21,34 @@ extern "C" {
 
 class RecordTest: public ::testing::Test {
   protected:
-    static void SetUpTestCase() {// Use the malloc family for allocations
-      Alloc_Reset();
-    }
+	static void SetUpTestCase() {// Use the malloc family for allocations
+		Alloc_Reset();
+	}
 };
 
 TEST_F(RecordTest, RecordToString) {
-    Record r = Record_New(6);
-    SIValue v_string = SI_ConstStringVal("Hello");
-    SIValue v_int = SI_LongVal(-24);
-    SIValue v_uint = SI_LongVal(24);
-    SIValue v_double = SI_DoubleVal(0.314);
-    SIValue v_null = SI_NullVal();
-    SIValue v_bool = SI_BoolVal(1);
+	Record r = Record_New(6);
+	SIValue v_string = SI_ConstStringVal("Hello");
+	SIValue v_int = SI_LongVal(-24);
+	SIValue v_uint = SI_LongVal(24);
+	SIValue v_double = SI_DoubleVal(0.314);
+	SIValue v_null = SI_NullVal();
+	SIValue v_bool = SI_BoolVal(1);
 
-    Record_AddScalar(r, 0, v_string);
-    Record_AddScalar(r, 1, v_int);
-    Record_AddScalar(r, 2, v_uint);
-    Record_AddScalar(r, 3, v_double);
-    Record_AddScalar(r, 4, v_null);
-    Record_AddScalar(r, 5, v_bool);
+	Record_AddScalar(r, 0, v_string);
+	Record_AddScalar(r, 1, v_int);
+	Record_AddScalar(r, 2, v_uint);
+	Record_AddScalar(r, 3, v_double);
+	Record_AddScalar(r, 4, v_null);
+	Record_AddScalar(r, 5, v_bool);
 
-    size_t record_str_cap = 0;
-    char *record_str = NULL;
-    size_t record_str_len = Record_ToString(r, &record_str, &record_str_cap);
+	size_t record_str_cap = 0;
+	char *record_str = NULL;
+	size_t record_str_len = Record_ToString(r, &record_str, &record_str_cap);
 
-    ASSERT_EQ(strcmp(record_str, "Hello,-24,24,0.314000,NULL,true"), 0);
-    ASSERT_EQ(record_str_len, 31);
+	ASSERT_EQ(strcmp(record_str, "Hello,-24,24,0.314000,NULL,true"), 0);
+	ASSERT_EQ(record_str_len, 31);
 
-    rm_free(record_str);
-    Record_Free(r);
+	rm_free(record_str);
+	Record_Free(r);
 }

--- a/tests/unit/test_traversal_ordering.cpp
+++ b/tests/unit/test_traversal_ordering.cpp
@@ -24,266 +24,270 @@ extern "C" {
 pthread_key_t _tlsASTKey;  // Thread local storage AST key.
 
 class TraversalOrderingTest: public ::testing::Test {
-    protected:
-    static void SetUpTestCase() {
-        // Use the malloc family for allocations
-        Alloc_Reset();
+  protected:
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
 
-        int error = pthread_key_create(&_tlsASTKey, NULL);
-        ASSERT_EQ(error, 0);
-    }
+		int error = pthread_key_create(&_tlsASTKey, NULL);
+		ASSERT_EQ(error, 0);
+	}
 
-    static void TearDownTestCase() {
-    }
+	static void TearDownTestCase() {
+	}
 
-    AST* _build_ast(const char *query) {
-        cypher_parse_result_t *parse_result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
-        AST *ast = AST_Build(parse_result);
-        return ast;
-    }
+	AST *_build_ast(const char *query) {
+		cypher_parse_result_t *parse_result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
+		AST *ast = AST_Build(parse_result);
+		return ast;
+	}
 
-    FT_FilterNode* build_filter_tree_from_query(RecordMap *map, const char *query) {
-        AST *ast = _build_ast(query);
-        return AST_BuildFilterTree(ast, map);
-    }
+	FT_FilterNode *build_filter_tree_from_query(RecordMap *map, const char *query) {
+		AST *ast = _build_ast(query);
+		return AST_BuildFilterTree(ast, map);
+	}
 };
 
 TEST_F(TraversalOrderingTest, TransposeFree) {
-    RecordMap *map = RecordMap_New();
-    /* Given the ordered (left to right) set of algebraic expression:
-     * { [CD], [BC], [AB] }
-     * Which represents the traversal:
-     * (A)->(B)->(C)->(D)
-     * If we choose to start at C
-     * we can continue to D.
-     * Retract from C to B
-     * Retract from B to A.
-     * Overall we've performed 2 transposes:
-     * (A)<-(B) and (B)<-(C).
-     * 
-     * We can reorder this set in such away
-     * that we won't perform any transposes.
-     * 
-     * Here are all of the possible permutations of the set:
-     * { [AB], [BC], [CD] } (A)->(B)->(C)->(D)
-     * { [AB], [CD], [BC] } Invalid arrangement.
-     * { [BC], [AB], [CD] } (A)<-(B)->(C)->(D)
-     * { [BC], [CD], [AB] } (A)<-(B)->(C)->(D)
-     * { [CD], [AB], [BC] } Invalid arrangement.
-     * { [CD], [BC], [AB] } (A)<-(B)<-(C)->(D)
-     * 
-     * Arrangement { [AB], [BC], [CD] } 
-     * Is the only one that doesn't requires any transposes. */
+	RecordMap *map = RecordMap_New();
+	/* Given the ordered (left to right) set of algebraic expression:
+	 * { [CD], [BC], [AB] }
+	 * Which represents the traversal:
+	 * (A)->(B)->(C)->(D)
+	 * If we choose to start at C
+	 * we can continue to D.
+	 * Retract from C to B
+	 * Retract from B to A.
+	 * Overall we've performed 2 transposes:
+	 * (A)<-(B) and (B)<-(C).
+	 *
+	 * We can reorder this set in such away
+	 * that we won't perform any transposes.
+	 *
+	 * Here are all of the possible permutations of the set:
+	 * { [AB], [BC], [CD] } (A)->(B)->(C)->(D)
+	 * { [AB], [CD], [BC] } Invalid arrangement.
+	 * { [BC], [AB], [CD] } (A)<-(B)->(C)->(D)
+	 * { [BC], [CD], [AB] } (A)<-(B)->(C)->(D)
+	 * { [CD], [AB], [BC] } Invalid arrangement.
+	 * { [CD], [BC], [AB] } (A)<-(B)<-(C)->(D)
+	 *
+	 * Arrangement { [AB], [BC], [CD] }
+	 * Is the only one that doesn't requires any transposes. */
 
-    uint id = 0;
-    QGNode *A = QGNode_New(NULL, "A", id++);
-    QGNode *B = QGNode_New(NULL, "B", id++);
-    QGNode *C = QGNode_New(NULL, "C", id++);
-    QGNode *D = QGNode_New(NULL, "D", id++);
+	uint id = 0;
+	QGNode *A = QGNode_New(NULL, "A", id++);
+	QGNode *B = QGNode_New(NULL, "B", id++);
+	QGNode *C = QGNode_New(NULL, "C", id++);
+	QGNode *D = QGNode_New(NULL, "D", id++);
 
-    QGEdge *AB = QGEdge_New(A, B, "E", "AB", id++);
-    QGEdge *BC = QGEdge_New(B, C, "E", "BC", id++);
-    QGEdge *CD = QGEdge_New(C, D, "E", "CD", id++);
+	QGEdge *AB = QGEdge_New(A, B, "E", "AB", id++);
+	QGEdge *BC = QGEdge_New(B, C, "E", "BC", id++);
+	QGEdge *CD = QGEdge_New(C, D, "E", "CD", id++);
 
-    QueryGraph *qg = QueryGraph_New(4, 3);
+	QueryGraph *qg = QueryGraph_New(4, 3);
 
-    QueryGraph_AddNode(qg, A);
-    QueryGraph_AddNode(qg, B);
-    QueryGraph_AddNode(qg, C);
-    QueryGraph_AddNode(qg, D);
-    QueryGraph_ConnectNodes(qg, A, B, AB);
-    QueryGraph_ConnectNodes(qg, B, C, BC);
-    QueryGraph_ConnectNodes(qg, C, D, CD);
+	QueryGraph_AddNode(qg, A);
+	QueryGraph_AddNode(qg, B);
+	QueryGraph_AddNode(qg, C);
+	QueryGraph_AddNode(qg, D);
+	QueryGraph_ConnectNodes(qg, A, B, AB);
+	QueryGraph_ConnectNodes(qg, B, C, BC);
+	QueryGraph_ConnectNodes(qg, C, D, CD);
 
-    AlgebraicExpression *set[3];
-    AlgebraicExpression *ExpAB = AlgebraicExpression_Empty();
-    AlgebraicExpression *ExpBC = AlgebraicExpression_Empty();
-    AlgebraicExpression *ExpCD = AlgebraicExpression_Empty();
-    
-    AlgebraicExpression_AppendTerm(ExpAB, NULL, false, false, false);
-    AlgebraicExpression_AppendTerm(ExpBC, NULL, false, false, false);
-    AlgebraicExpression_AppendTerm(ExpCD, NULL, false, false, false);
+	AlgebraicExpression *set[3];
+	AlgebraicExpression *ExpAB = AlgebraicExpression_Empty();
+	AlgebraicExpression *ExpBC = AlgebraicExpression_Empty();
+	AlgebraicExpression *ExpCD = AlgebraicExpression_Empty();
 
-    ExpAB->src_node = A;
-    ExpAB->dest_node = B;
-    ExpBC->src_node = B;
-    ExpBC->dest_node = C;
-    ExpCD->src_node = C;
-    ExpCD->dest_node = D;
+	AlgebraicExpression_AppendTerm(ExpAB, NULL, false, false, false);
+	AlgebraicExpression_AppendTerm(ExpBC, NULL, false, false, false);
+	AlgebraicExpression_AppendTerm(ExpCD, NULL, false, false, false);
 
-    // { [CD], [BC], [AB] }
-    set[0] = ExpCD;
-    set[1] = ExpBC;
-    set[2] = ExpAB;
+	ExpAB->src_node = A;
+	ExpAB->dest_node = B;
+	ExpBC->src_node = B;
+	ExpBC->dest_node = C;
+	ExpCD->src_node = C;
+	ExpCD->dest_node = D;
 
-    orderExpressions(set, 3, map, NULL);
-    ASSERT_EQ(set[0], ExpAB);
-    ASSERT_EQ(set[1], ExpBC);
-    ASSERT_EQ(set[2], ExpCD);
+	// { [CD], [BC], [AB] }
+	set[0] = ExpCD;
+	set[1] = ExpBC;
+	set[2] = ExpAB;
 
-    // { [AB], [BC], [CD] }
-    set[0] = ExpAB;
-    set[1] = ExpBC;
-    set[2] = ExpCD;
-    orderExpressions(set, 3, map, NULL);
-    ASSERT_EQ(set[0], ExpAB);
-    ASSERT_EQ(set[1], ExpBC);
-    ASSERT_EQ(set[2], ExpCD);
-    
-    // { [AB], [CD], [BC] }
-    set[0] = ExpAB;
-    set[1] = ExpCD;
-    set[2] = ExpBC;
-    orderExpressions(set, 3, map, NULL);
-    ASSERT_EQ(set[0], ExpAB);
-    ASSERT_EQ(set[1], ExpBC);
-    ASSERT_EQ(set[2], ExpCD);
-    
-    // { [BC], [AB], [CD] }
-    set[0] = ExpBC;
-    set[1] = ExpAB;
-    set[2] = ExpCD;
-    orderExpressions(set, 3, map, NULL);
-    ASSERT_EQ(set[0], ExpAB);
-    ASSERT_EQ(set[1], ExpBC);
-    ASSERT_EQ(set[2], ExpCD);
-    
-    // { [BC], [CD], [AB] }
-    set[0] = ExpBC;
-    set[1] = ExpCD;
-    set[2] = ExpAB;
-    orderExpressions(set, 3, map, NULL);
-    ASSERT_EQ(set[0], ExpAB);
-    ASSERT_EQ(set[1], ExpBC);
-    ASSERT_EQ(set[2], ExpCD);
-    
-    // { [CD], [AB], [BC] }
-    set[0] = ExpCD;
-    set[1] = ExpAB;
-    set[2] = ExpBC;
-    orderExpressions(set, 3, map, NULL);
-    ASSERT_EQ(set[0], ExpAB);
-    ASSERT_EQ(set[1], ExpBC);
-    ASSERT_EQ(set[2], ExpCD);
+	orderExpressions(set, 3, map, NULL);
+	ASSERT_EQ(set[0], ExpAB);
+	ASSERT_EQ(set[1], ExpBC);
+	ASSERT_EQ(set[2], ExpCD);
 
-    // Clean up.
-    AlgebraicExpression_Free(ExpAB);
-    AlgebraicExpression_Free(ExpBC);
-    AlgebraicExpression_Free(ExpCD);
-    QueryGraph_Free(qg);
+	// { [AB], [BC], [CD] }
+	set[0] = ExpAB;
+	set[1] = ExpBC;
+	set[2] = ExpCD;
+	orderExpressions(set, 3, map, NULL);
+	ASSERT_EQ(set[0], ExpAB);
+	ASSERT_EQ(set[1], ExpBC);
+	ASSERT_EQ(set[2], ExpCD);
+
+	// { [AB], [CD], [BC] }
+	set[0] = ExpAB;
+	set[1] = ExpCD;
+	set[2] = ExpBC;
+	orderExpressions(set, 3, map, NULL);
+	ASSERT_EQ(set[0], ExpAB);
+	ASSERT_EQ(set[1], ExpBC);
+	ASSERT_EQ(set[2], ExpCD);
+
+	// { [BC], [AB], [CD] }
+	set[0] = ExpBC;
+	set[1] = ExpAB;
+	set[2] = ExpCD;
+	orderExpressions(set, 3, map, NULL);
+	ASSERT_EQ(set[0], ExpAB);
+	ASSERT_EQ(set[1], ExpBC);
+	ASSERT_EQ(set[2], ExpCD);
+
+	// { [BC], [CD], [AB] }
+	set[0] = ExpBC;
+	set[1] = ExpCD;
+	set[2] = ExpAB;
+	orderExpressions(set, 3, map, NULL);
+	ASSERT_EQ(set[0], ExpAB);
+	ASSERT_EQ(set[1], ExpBC);
+	ASSERT_EQ(set[2], ExpCD);
+
+	// { [CD], [AB], [BC] }
+	set[0] = ExpCD;
+	set[1] = ExpAB;
+	set[2] = ExpBC;
+	orderExpressions(set, 3, map, NULL);
+	ASSERT_EQ(set[0], ExpAB);
+	ASSERT_EQ(set[1], ExpBC);
+	ASSERT_EQ(set[2], ExpCD);
+
+	// Clean up.
+	AlgebraicExpression_Free(ExpAB);
+	AlgebraicExpression_Free(ExpBC);
+	AlgebraicExpression_Free(ExpCD);
+	QueryGraph_Free(qg);
 }
 
 TEST_F(TraversalOrderingTest, FilterFirst) {
-    RecordMap *map = RecordMap_New();
-    /* Given the ordered (left to right) set of algebraic expression:
-     * { [AB], [BC], [CD] }
-     * Which represents the traversal:
-     * (A)->(B)->(C)->(D)
-     * And a set of filters:
-     * C.V = X.
-     * 
-     * We can reorder this set in such away
-     * that filters are applied as early as possible.
-     * 
-     * Here are all of the possible permutations of the set
-     * in which the filter is applied at the earliest step:
-     * { [CB], [BA], [CD] } (D)<-(C)->(B)->(A) (2 transposes)
-     * { [CB], [CD], [BA] } (D)<-(C)->(B)->(A) (2 transposes)
-     * { [CD], [CB], [BA] } (A)<-(B)<-(C)->(D) (2 transposes) */
+	RecordMap *map = RecordMap_New();
+	/* Given the ordered (left to right) set of algebraic expression:
+	 * { [AB], [BC], [CD] }
+	 * Which represents the traversal:
+	 * (A)->(B)->(C)->(D)
+	 * And a set of filters:
+	 * C.V = X.
+	 *
+	 * We can reorder this set in such away
+	 * that filters are applied as early as possible.
+	 *
+	 * Here are all of the possible permutations of the set
+	 * in which the filter is applied at the earliest step:
+	 * { [CB], [BA], [CD] } (D)<-(C)->(B)->(A) (2 transposes)
+	 * { [CB], [CD], [BA] } (D)<-(C)->(B)->(A) (2 transposes)
+	 * { [CD], [CB], [BA] } (A)<-(B)<-(C)->(D) (2 transposes) */
 
-    uint id = 0;
-    FT_FilterNode *filters;
-    QGNode *A = QGNode_New(NULL, "A", id++);
-    QGNode *B = QGNode_New(NULL, "B", id++);
-    QGNode *C = QGNode_New(NULL, "C", id++);
-    QGNode *D = QGNode_New(NULL, "D", id++);
+	uint id = 0;
+	FT_FilterNode *filters;
+	QGNode *A = QGNode_New(NULL, "A", id++);
+	QGNode *B = QGNode_New(NULL, "B", id++);
+	QGNode *C = QGNode_New(NULL, "C", id++);
+	QGNode *D = QGNode_New(NULL, "D", id++);
 
-    QGEdge *AB = QGEdge_New(A, B, "E", "AB", id++);
-    QGEdge *BC = QGEdge_New(B, C, "E", "BC", id++);
-    QGEdge *CD = QGEdge_New(C, D, "E", "CD", id++);
+	QGEdge *AB = QGEdge_New(A, B, "E", "AB", id++);
+	QGEdge *BC = QGEdge_New(B, C, "E", "BC", id++);
+	QGEdge *CD = QGEdge_New(C, D, "E", "CD", id++);
 
-    QueryGraph *qg = QueryGraph_New(4, 3);
+	QueryGraph *qg = QueryGraph_New(4, 3);
 
-    QueryGraph_AddNode(qg, A);
-    QueryGraph_AddNode(qg, B);
-    QueryGraph_AddNode(qg, C);
-    QueryGraph_AddNode(qg, D);
-    QueryGraph_ConnectNodes(qg, A, B, AB);
-    QueryGraph_ConnectNodes(qg, B, C, BC);
-    QueryGraph_ConnectNodes(qg, C, D, CD);
+	QueryGraph_AddNode(qg, A);
+	QueryGraph_AddNode(qg, B);
+	QueryGraph_AddNode(qg, C);
+	QueryGraph_AddNode(qg, D);
+	QueryGraph_ConnectNodes(qg, A, B, AB);
+	QueryGraph_ConnectNodes(qg, B, C, BC);
+	QueryGraph_ConnectNodes(qg, C, D, CD);
 
-    AlgebraicExpression *set[3];
-    AlgebraicExpression *ExpAB = AlgebraicExpression_Empty();
-    AlgebraicExpression *ExpBC = AlgebraicExpression_Empty();
-    AlgebraicExpression *ExpCD = AlgebraicExpression_Empty();
-    
-    AlgebraicExpression_AppendTerm(ExpAB, NULL, false, false, false);
-    AlgebraicExpression_AppendTerm(ExpBC, NULL, false, false, false);
-    AlgebraicExpression_AppendTerm(ExpCD, NULL, false, false, false);
+	AlgebraicExpression *set[3];
+	AlgebraicExpression *ExpAB = AlgebraicExpression_Empty();
+	AlgebraicExpression *ExpBC = AlgebraicExpression_Empty();
+	AlgebraicExpression *ExpCD = AlgebraicExpression_Empty();
 
-    ExpAB->src_node = A;
-    ExpAB->dest_node = B;
-    ExpBC->src_node = B;
-    ExpBC->dest_node = C;
-    ExpCD->src_node = C;
-    ExpCD->dest_node = D;
+	AlgebraicExpression_AppendTerm(ExpAB, NULL, false, false, false);
+	AlgebraicExpression_AppendTerm(ExpBC, NULL, false, false, false);
+	AlgebraicExpression_AppendTerm(ExpCD, NULL, false, false, false);
 
-    // { [AB], [BC], [CD] }
-    set[0] = ExpAB;
-    set[1] = ExpBC;
-    set[2] = ExpCD;
+	ExpAB->src_node = A;
+	ExpAB->dest_node = B;
+	ExpBC->src_node = B;
+	ExpBC->dest_node = C;
+	ExpCD->src_node = C;
+	ExpCD->dest_node = D;
 
-    filters = build_filter_tree_from_query(map, "MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE A.val = 1 RETURN *");
+	// { [AB], [BC], [CD] }
+	set[0] = ExpAB;
+	set[1] = ExpBC;
+	set[2] = ExpCD;
 
-    orderExpressions(set, 3, map, filters);
-    ASSERT_EQ(set[0], ExpAB);
-    ASSERT_EQ(set[1], ExpBC);
-    ASSERT_EQ(set[2], ExpCD);
+	filters = build_filter_tree_from_query(map,
+										   "MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE A.val = 1 RETURN *");
 
-    FilterTree_Free(filters);
+	orderExpressions(set, 3, map, filters);
+	ASSERT_EQ(set[0], ExpAB);
+	ASSERT_EQ(set[1], ExpBC);
+	ASSERT_EQ(set[2], ExpCD);
 
-    // { [AB], [BC], [CD] }
-    set[0] = ExpAB;
-    set[1] = ExpBC;
-    set[2] = ExpCD;
+	FilterTree_Free(filters);
 
-    filters = build_filter_tree_from_query(map, "MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE B.val = 1 RETURN *");
+	// { [AB], [BC], [CD] }
+	set[0] = ExpAB;
+	set[1] = ExpBC;
+	set[2] = ExpCD;
 
-    orderExpressions(set, 3, map, filters);
-    ASSERT_TRUE (set[0] == ExpAB || set[0] == ExpBC);
+	filters = build_filter_tree_from_query(map,
+										   "MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE B.val = 1 RETURN *");
 
-    FilterTree_Free(filters);
+	orderExpressions(set, 3, map, filters);
+	ASSERT_TRUE(set[0] == ExpAB || set[0] == ExpBC);
 
-    // { [AB], [BC], [CD] }
-    set[0] = ExpAB;
-    set[1] = ExpBC;
-    set[2] = ExpCD;
+	FilterTree_Free(filters);
 
-    filters = build_filter_tree_from_query(map, "MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE C.val = 1 RETURN *");
+	// { [AB], [BC], [CD] }
+	set[0] = ExpAB;
+	set[1] = ExpBC;
+	set[2] = ExpCD;
 
-    orderExpressions(set, 3, map, filters);
-    ASSERT_TRUE(set[0] == ExpBC || set[0] == ExpCD);
+	filters = build_filter_tree_from_query(map,
+										   "MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE C.val = 1 RETURN *");
 
-    FilterTree_Free(filters);
+	orderExpressions(set, 3, map, filters);
+	ASSERT_TRUE(set[0] == ExpBC || set[0] == ExpCD);
 
-    // { [AB], [BC], [CD] }
-    set[0] = ExpAB;
-    set[1] = ExpBC;
-    set[2] = ExpCD;
+	FilterTree_Free(filters);
 
-    filters = build_filter_tree_from_query(map, "MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE D.val = 1 RETURN *");
+	// { [AB], [BC], [CD] }
+	set[0] = ExpAB;
+	set[1] = ExpBC;
+	set[2] = ExpCD;
 
-    orderExpressions(set, 3, map, filters);
+	filters = build_filter_tree_from_query(map,
+										   "MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE D.val = 1 RETURN *");
 
-    ASSERT_EQ(set[0], ExpCD);
-    ASSERT_EQ(set[1], ExpBC);
-    ASSERT_EQ(set[2], ExpAB);
+	orderExpressions(set, 3, map, filters);
 
-    // Clean up.
-    FilterTree_Free(filters);
-    RecordMap_Free(map);
-    AlgebraicExpression_Free(ExpAB);
-    AlgebraicExpression_Free(ExpBC);
-    AlgebraicExpression_Free(ExpCD);
-    QueryGraph_Free(qg);
+	ASSERT_EQ(set[0], ExpCD);
+	ASSERT_EQ(set[1], ExpBC);
+	ASSERT_EQ(set[2], ExpAB);
+
+	// Clean up.
+	FilterTree_Free(filters);
+	RecordMap_Free(map);
+	AlgebraicExpression_Free(ExpAB);
+	AlgebraicExpression_Free(ExpBC);
+	AlgebraicExpression_Free(ExpCD);
+	QueryGraph_Free(qg);
 }

--- a/tests/unit/test_tuples_iter.cpp
+++ b/tests/unit/test_tuples_iter.cpp
@@ -19,358 +19,358 @@ extern "C" {
 
 class TuplesTest: public ::testing::Test {
   protected:
-    static void SetUpTestCase() {
-      // Use the malloc family for allocations
-      Alloc_Reset();
+	static void SetUpTestCase() {
+		// Use the malloc family for allocations
+		Alloc_Reset();
 
-      GrB_init(GrB_NONBLOCKING);
-      GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW); // all matrices in CSR format
-      GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
-    }
+		GrB_init(GrB_NONBLOCKING);
+		GxB_Global_Option_set(GxB_FORMAT, GxB_BY_ROW); // all matrices in CSR format
+		GxB_Global_Option_set(GxB_HYPER, GxB_NEVER_HYPER); // matrices are never hypersparse
+	}
 
-    static void TearDownTestCase() {
-      GrB_finalize();
-    }
+	static void TearDownTestCase() {
+		GrB_finalize();
+	}
 
-    GrB_Matrix CreateSquareNByNDiagonalMatrix(GrB_Index n) {
-      GrB_Matrix A = CreateSquareNByNEmptyMatrix(n);
+	GrB_Matrix CreateSquareNByNDiagonalMatrix(GrB_Index n) {
+		GrB_Matrix A = CreateSquareNByNEmptyMatrix(n);
 
-      GrB_Index I[n];
-      GrB_Index J[n];
-      bool X[n];
+		GrB_Index I[n];
+		GrB_Index J[n];
+		bool X[n];
 
-      // Initialize.
-      for(int i = 0; i < n; i++) {
-        I[i] = i;
-        J[i] = i;
-        X[i] = i;
-      }
+		// Initialize.
+		for(int i = 0; i < n; i++) {
+			I[i] = i;
+			J[i] = i;
+			X[i] = i;
+		}
 
-      GrB_Matrix_build_BOOL(A, I, J, X, n, GrB_FIRST_BOOL);
-      
-      return A;
-    }
+		GrB_Matrix_build_BOOL(A, I, J, X, n, GrB_FIRST_BOOL);
 
-    GrB_Matrix CreateSquareNByNEmptyMatrix(GrB_Index n) {
-      GrB_Matrix A;
-      GrB_Matrix_new(&A, GrB_BOOL, n, n);
-      return A;
-    }
+		return A;
+	}
+
+	GrB_Matrix CreateSquareNByNEmptyMatrix(GrB_Index n) {
+		GrB_Matrix A;
+		GrB_Matrix_new(&A, GrB_BOOL, n, n);
+		return A;
+	}
 };
 
 TEST_F(TuplesTest, RandomVectorTest) {
-  //--------------------------------------------------------------------------
-  // Build a random vector
-  //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Build a random vector
+	//--------------------------------------------------------------------------
 
-  GrB_Vector A;
-  GrB_Index nvals = 0;
-  GrB_Index nrows = 1024;
-  GrB_Index *I = (GrB_Index *)malloc(sizeof(GrB_Index) * nrows);
-  bool *X = (bool *)malloc(sizeof(bool) * nrows);
+	GrB_Vector A;
+	GrB_Index nvals = 0;
+	GrB_Index nrows = 1024;
+	GrB_Index *I = (GrB_Index *)malloc(sizeof(GrB_Index) * nrows);
+	bool *X = (bool *)malloc(sizeof(bool) * nrows);
 
-  GrB_Vector_new(&A, GrB_BOOL, nrows);
+	GrB_Vector_new(&A, GrB_BOOL, nrows);
 
-  double mid_point = RAND_MAX/2;
-  for(int i = 0; i < nrows; i++) {
-    if(rand() > mid_point) {
-      I[nvals] = i;
-      X[nvals] = true;
-      nvals++;
-    }
-  }
+	double mid_point = RAND_MAX / 2;
+	for(int i = 0; i < nrows; i++) {
+		if(rand() > mid_point) {
+			I[nvals] = i;
+			X[nvals] = true;
+			nvals++;
+		}
+	}
 
-  GrB_Vector_build_BOOL(A, I, X, nvals, GrB_FIRST_BOOL);
+	GrB_Vector_build_BOOL(A, I, X, nvals, GrB_FIRST_BOOL);
 
-  GrB_Index I_expected[nvals];
-  GrB_Vector_extractTuples_BOOL(I_expected, NULL, &nvals, A);
+	GrB_Index I_expected[nvals];
+	GrB_Vector_extractTuples_BOOL(I_expected, NULL, &nvals, A);
 
-  //--------------------------------------------------------------------------
-  // Get an iterator over all nonzero elements.
-  //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Get an iterator over all nonzero elements.
+	//--------------------------------------------------------------------------
 
-  GxB_MatrixTupleIter *iter;
-  GxB_MatrixTupleIter_new(&iter, (GrB_Matrix)A);
-  GrB_Index col;
+	GxB_MatrixTupleIter *iter;
+	GxB_MatrixTupleIter_new(&iter, (GrB_Matrix)A);
+	GrB_Index col;
 
-  //--------------------------------------------------------------------------
-  // Verify iterator returned values.
-  //--------------------------------------------------------------------------
-  bool depleted = false;
-  for(int i = 0; i < nvals; i++) {
-    GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
-    ASSERT_FALSE(depleted);
-    ASSERT_EQ(col, I_expected[i]);
-  }
-  GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
-  ASSERT_TRUE(depleted);
+	//--------------------------------------------------------------------------
+	// Verify iterator returned values.
+	//--------------------------------------------------------------------------
+	bool depleted = false;
+	for(int i = 0; i < nvals; i++) {
+		GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+		ASSERT_FALSE(depleted);
+		ASSERT_EQ(col, I_expected[i]);
+	}
+	GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+	ASSERT_TRUE(depleted);
 
-  //--------------------------------------------------------------------------
-  // Clean up.
-  //--------------------------------------------------------------------------
-  free(I);
-  free(X);
-  GxB_MatrixTupleIter_free(iter);
-  GrB_Vector_free(&A);
+	//--------------------------------------------------------------------------
+	// Clean up.
+	//--------------------------------------------------------------------------
+	free(I);
+	free(X);
+	GxB_MatrixTupleIter_free(iter);
+	GrB_Vector_free(&A);
 }
 
 TEST_F(TuplesTest, VectorIteratorTest) {
-  //--------------------------------------------------------------------------
-  // Build a vector
-  //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Build a vector
+	//--------------------------------------------------------------------------
 
-  GrB_Vector A;
-  GrB_Vector_new(&A, GrB_BOOL, 4);
+	GrB_Vector A;
+	GrB_Vector_new(&A, GrB_BOOL, 4);
 
-  GrB_Index nvals = 2;
-  GrB_Index I[2] = {1, 3};
-  bool X[2] = {true, true};
-  GrB_Index I_expected[nvals];
+	GrB_Index nvals = 2;
+	GrB_Index I[2] = {1, 3};
+	bool X[2] = {true, true};
+	GrB_Index I_expected[nvals];
 
-  GrB_Vector_build_BOOL(A, I, X, nvals, GrB_FIRST_BOOL);
-  GrB_Vector_extractTuples_BOOL(I_expected, NULL, &nvals, A);
+	GrB_Vector_build_BOOL(A, I, X, nvals, GrB_FIRST_BOOL);
+	GrB_Vector_extractTuples_BOOL(I_expected, NULL, &nvals, A);
 
-  //--------------------------------------------------------------------------
-  // Get an iterator over all vector nonzero elements.
-  //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Get an iterator over all vector nonzero elements.
+	//--------------------------------------------------------------------------
 
-  GxB_MatrixTupleIter *iter;
-  GxB_MatrixTupleIter_new(&iter, (GrB_Matrix)A);
-  GrB_Index col;
+	GxB_MatrixTupleIter *iter;
+	GxB_MatrixTupleIter_new(&iter, (GrB_Matrix)A);
+	GrB_Index col;
 
-  //--------------------------------------------------------------------------
-  // Verify iterator returned values.
-  //--------------------------------------------------------------------------
-  bool depleted = false;
-  for(int i = 0; i < nvals; i++) {
-    GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
-    ASSERT_FALSE(depleted);
-    ASSERT_EQ(col, I_expected[i]);
-  }
-  GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
-  ASSERT_TRUE(depleted);
+	//--------------------------------------------------------------------------
+	// Verify iterator returned values.
+	//--------------------------------------------------------------------------
+	bool depleted = false;
+	for(int i = 0; i < nvals; i++) {
+		GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+		ASSERT_FALSE(depleted);
+		ASSERT_EQ(col, I_expected[i]);
+	}
+	GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+	ASSERT_TRUE(depleted);
 
-  //--------------------------------------------------------------------------
-  // Reset iterator and re-verify.
-  //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Reset iterator and re-verify.
+	//--------------------------------------------------------------------------
 
-  GxB_MatrixTupleIter_reset(iter);
-  for(int i = 0; i < nvals; i++) {
-    GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
-    ASSERT_FALSE(depleted);
-    ASSERT_EQ(col, I_expected[i]);
-  }
-  GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
-  ASSERT_TRUE(depleted);
+	GxB_MatrixTupleIter_reset(iter);
+	for(int i = 0; i < nvals; i++) {
+		GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+		ASSERT_FALSE(depleted);
+		ASSERT_EQ(col, I_expected[i]);
+	}
+	GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+	ASSERT_TRUE(depleted);
 
-  //--------------------------------------------------------------------------
-  // Clean up.
-  //--------------------------------------------------------------------------
-  GxB_MatrixTupleIter_free(iter);
-  GrB_Vector_free(&A);
+	//--------------------------------------------------------------------------
+	// Clean up.
+	//--------------------------------------------------------------------------
+	GxB_MatrixTupleIter_free(iter);
+	GrB_Vector_free(&A);
 }
 
 TEST_F(TuplesTest, RandomMatrixTest) {
-  //--------------------------------------------------------------------------
-  // Build a random matrix
-  //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Build a random matrix
+	//--------------------------------------------------------------------------
 
-  GrB_Matrix A;
-  GrB_Index nvals = 0;
-  GrB_Index nrows = 1024;
-  GrB_Index ncols = 1024;
-  GrB_Index *I = (GrB_Index *)malloc(sizeof(GrB_Index) * ncols * nrows);
-  GrB_Index *J = (GrB_Index *)malloc(sizeof(GrB_Index) * ncols * nrows);
-  bool *X = (bool *)malloc(sizeof(bool) * ncols * nrows);
+	GrB_Matrix A;
+	GrB_Index nvals = 0;
+	GrB_Index nrows = 1024;
+	GrB_Index ncols = 1024;
+	GrB_Index *I = (GrB_Index *)malloc(sizeof(GrB_Index) * ncols * nrows);
+	GrB_Index *J = (GrB_Index *)malloc(sizeof(GrB_Index) * ncols * nrows);
+	bool *X = (bool *)malloc(sizeof(bool) * ncols * nrows);
 
-  GrB_Matrix_new(&A, GrB_BOOL, nrows, ncols);
+	GrB_Matrix_new(&A, GrB_BOOL, nrows, ncols);
 
-  double mid_point = RAND_MAX/2;
-  for(int i = 0; i < nrows; i++) {
-    for(int j = 0; j < ncols; j++) {
-      if(rand() > mid_point) {
-        I[nvals] = i;
-        J[nvals] = j;
-        X[nvals] = true;
-        nvals++;
-      }
-    }
-  }
-  GrB_Matrix_build_BOOL(A, I, J, X, nvals, GrB_FIRST_BOOL);
+	double mid_point = RAND_MAX / 2;
+	for(int i = 0; i < nrows; i++) {
+		for(int j = 0; j < ncols; j++) {
+			if(rand() > mid_point) {
+				I[nvals] = i;
+				J[nvals] = j;
+				X[nvals] = true;
+				nvals++;
+			}
+		}
+	}
+	GrB_Matrix_build_BOOL(A, I, J, X, nvals, GrB_FIRST_BOOL);
 
-  GrB_Index *I_expected = (GrB_Index *)malloc(sizeof(GrB_Index) * nvals);
-  GrB_Index *J_expected = (GrB_Index *)malloc(sizeof(GrB_Index) * nvals);
-  GrB_Matrix_extractTuples_BOOL(I_expected, J_expected, NULL, &nvals, A);
+	GrB_Index *I_expected = (GrB_Index *)malloc(sizeof(GrB_Index) * nvals);
+	GrB_Index *J_expected = (GrB_Index *)malloc(sizeof(GrB_Index) * nvals);
+	GrB_Matrix_extractTuples_BOOL(I_expected, J_expected, NULL, &nvals, A);
 
-  //--------------------------------------------------------------------------
-  // Get an iterator over all matrix nonzero elements.
-  //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Get an iterator over all matrix nonzero elements.
+	//--------------------------------------------------------------------------
 
-  GxB_MatrixTupleIter *iter;
-  GxB_MatrixTupleIter_new(&iter, A);
-  GrB_Index row;
-  GrB_Index col;
+	GxB_MatrixTupleIter *iter;
+	GxB_MatrixTupleIter_new(&iter, A);
+	GrB_Index row;
+	GrB_Index col;
 
-  //--------------------------------------------------------------------------
-  // Verify iterator returned values.
-  //--------------------------------------------------------------------------
-  bool depleted = false;
-  for(int i = 0; i < nvals; i++) {
-    GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
-    ASSERT_FALSE(depleted);
-    ASSERT_EQ(row, I_expected[i]);
-    ASSERT_EQ(col, J_expected[i]);
-  }
-  GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
-  ASSERT_TRUE(depleted);
+	//--------------------------------------------------------------------------
+	// Verify iterator returned values.
+	//--------------------------------------------------------------------------
+	bool depleted = false;
+	for(int i = 0; i < nvals; i++) {
+		GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		ASSERT_FALSE(depleted);
+		ASSERT_EQ(row, I_expected[i]);
+		ASSERT_EQ(col, J_expected[i]);
+	}
+	GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+	ASSERT_TRUE(depleted);
 
-  //--------------------------------------------------------------------------
-  // Clean up.
-  //--------------------------------------------------------------------------
-  free(I);
-  free(J);
-  free(X);
-  free(I_expected);
-  free(J_expected);
-  GxB_MatrixTupleIter_free(iter);
-  GrB_Matrix_free(&A);
+	//--------------------------------------------------------------------------
+	// Clean up.
+	//--------------------------------------------------------------------------
+	free(I);
+	free(J);
+	free(X);
+	free(I_expected);
+	free(J_expected);
+	GxB_MatrixTupleIter_free(iter);
+	GrB_Matrix_free(&A);
 }
 
 TEST_F(TuplesTest, MatrixIteratorTest) {
-  //--------------------------------------------------------------------------
-  // Build a 4X4 matrix
-  //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Build a 4X4 matrix
+	//--------------------------------------------------------------------------
 
-  GrB_Index nvals = 4;
-  GrB_Matrix A = CreateSquareNByNDiagonalMatrix(nvals);
-  GrB_Index I_expected[nvals];
-  GrB_Index J_expected[nvals];
-  GrB_Matrix_extractTuples_BOOL(I_expected, J_expected, NULL, &nvals, A);
+	GrB_Index nvals = 4;
+	GrB_Matrix A = CreateSquareNByNDiagonalMatrix(nvals);
+	GrB_Index I_expected[nvals];
+	GrB_Index J_expected[nvals];
+	GrB_Matrix_extractTuples_BOOL(I_expected, J_expected, NULL, &nvals, A);
 
-  //--------------------------------------------------------------------------
-  // Get an iterator over all matrix nonzero elements.
-  //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Get an iterator over all matrix nonzero elements.
+	//--------------------------------------------------------------------------
 
-  GxB_MatrixTupleIter *iter;
-  GxB_MatrixTupleIter_new(&iter, A);
-  GrB_Index row;
-  GrB_Index col;
+	GxB_MatrixTupleIter *iter;
+	GxB_MatrixTupleIter_new(&iter, A);
+	GrB_Index row;
+	GrB_Index col;
 
-  //--------------------------------------------------------------------------
-  // Verify iterator returned values.
-  //--------------------------------------------------------------------------
-  bool depleted = false;
-  for(int i = 0; i < nvals; i++) {
-    GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
-    ASSERT_FALSE(depleted);
-    ASSERT_EQ(row, I_expected[i]);
-    ASSERT_EQ(col, J_expected[i]);
-  }
-  GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
-  ASSERT_TRUE(depleted);
+	//--------------------------------------------------------------------------
+	// Verify iterator returned values.
+	//--------------------------------------------------------------------------
+	bool depleted = false;
+	for(int i = 0; i < nvals; i++) {
+		GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		ASSERT_FALSE(depleted);
+		ASSERT_EQ(row, I_expected[i]);
+		ASSERT_EQ(col, J_expected[i]);
+	}
+	GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+	ASSERT_TRUE(depleted);
 
-  //--------------------------------------------------------------------------
-  // Reset iterator an re-verify.
-  //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Reset iterator an re-verify.
+	//--------------------------------------------------------------------------
 
-  GxB_MatrixTupleIter_reset(iter);
-  for(int i = 0; i < nvals; i++) {
-    GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
-    ASSERT_FALSE(depleted);
-    ASSERT_EQ(row, I_expected[i]);
-    ASSERT_EQ(col, J_expected[i]);
-  }
-  GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
-  ASSERT_TRUE(depleted);
+	GxB_MatrixTupleIter_reset(iter);
+	for(int i = 0; i < nvals; i++) {
+		GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		ASSERT_FALSE(depleted);
+		ASSERT_EQ(row, I_expected[i]);
+		ASSERT_EQ(col, J_expected[i]);
+	}
+	GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+	ASSERT_TRUE(depleted);
 
-  //--------------------------------------------------------------------------
-  // Clean up.
-  //--------------------------------------------------------------------------
-  GxB_MatrixTupleIter_free(iter);
-  GrB_Matrix_free(&A);
+	//--------------------------------------------------------------------------
+	// Clean up.
+	//--------------------------------------------------------------------------
+	GxB_MatrixTupleIter_free(iter);
+	GrB_Matrix_free(&A);
 }
 
 TEST_F(TuplesTest, ColumnIteratorTest) {
-  //--------------------------------------------------------------------------
-  // Build a 4X4 matrix
-  //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Build a 4X4 matrix
+	//--------------------------------------------------------------------------
 
-  GrB_Index nvals = 4;
-  GrB_Matrix A = CreateSquareNByNDiagonalMatrix(nvals);
-  GrB_Index I_expected[nvals];
-  GrB_Vector v;
-  GrB_Index row;
-  GrB_Index col;
-  GrB_Index nrows = nvals;
-  GrB_Index ncols = nvals;
-  GxB_MatrixTupleIter *iter;
-  GxB_MatrixTupleIter_new(&iter, A);
+	GrB_Index nvals = 4;
+	GrB_Matrix A = CreateSquareNByNDiagonalMatrix(nvals);
+	GrB_Index I_expected[nvals];
+	GrB_Vector v;
+	GrB_Index row;
+	GrB_Index col;
+	GrB_Index nrows = nvals;
+	GrB_Index ncols = nvals;
+	GxB_MatrixTupleIter *iter;
+	GxB_MatrixTupleIter_new(&iter, A);
 
-  for(int j = 0; j < ncols; j++) {
-    GrB_Vector_new(&v, GrB_BOOL, nrows);
-    GrB_Col_extract(v, NULL, NULL, A, GrB_ALL, nrows, j, NULL);
-    GrB_Vector_extractTuples_BOOL(I_expected, NULL, &nvals, v);
+	for(int j = 0; j < ncols; j++) {
+		GrB_Vector_new(&v, GrB_BOOL, nrows);
+		GrB_Col_extract(v, NULL, NULL, A, GrB_ALL, nrows, j, NULL);
+		GrB_Vector_extractTuples_BOOL(I_expected, NULL, &nvals, v);
 
-    //--------------------------------------------------------------------------
-    // Test iterating over each column twice, this is to check
-    // iterator reusability.
-    //--------------------------------------------------------------------------
-    
-    int reuse = 2;
-    for(int k = 0; k < reuse; k++) {
-      //--------------------------------------------------------------------------
-      // Get an iterator over the current column.
-      //--------------------------------------------------------------------------
-      GxB_MatrixTupleIter_iterate_row(iter, j);
+		//--------------------------------------------------------------------------
+		// Test iterating over each column twice, this is to check
+		// iterator reusability.
+		//--------------------------------------------------------------------------
 
-      //--------------------------------------------------------------------------
-      // Verify iterator returned values.
-      //--------------------------------------------------------------------------
-      bool depleted = false;
-      for(int i = 0; i < nvals; i++) {
-        GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
-        ASSERT_FALSE(depleted);
-        ASSERT_EQ(row, I_expected[i]);
-        ASSERT_EQ(col, j);
-      }
-      GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
-      ASSERT_TRUE(depleted);
-    }
+		int reuse = 2;
+		for(int k = 0; k < reuse; k++) {
+			//--------------------------------------------------------------------------
+			// Get an iterator over the current column.
+			//--------------------------------------------------------------------------
+			GxB_MatrixTupleIter_iterate_row(iter, j);
 
-    GrB_Vector_free(&v);
-  }
-  GxB_MatrixTupleIter_free(iter);
-  GrB_Matrix_free(&A);
+			//--------------------------------------------------------------------------
+			// Verify iterator returned values.
+			//--------------------------------------------------------------------------
+			bool depleted = false;
+			for(int i = 0; i < nvals; i++) {
+				GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+				ASSERT_FALSE(depleted);
+				ASSERT_EQ(row, I_expected[i]);
+				ASSERT_EQ(col, j);
+			}
+			GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+			ASSERT_TRUE(depleted);
+		}
+
+		GrB_Vector_free(&v);
+	}
+	GxB_MatrixTupleIter_free(iter);
+	GrB_Matrix_free(&A);
 }
 
 TEST_F(TuplesTest, ColumnIteratorEmptyMatrixTest) {
-    //--------------------------------------------------------------------------
-    // Build a 4X4 empty matrix
-    //--------------------------------------------------------------------------
+	//--------------------------------------------------------------------------
+	// Build a 4X4 empty matrix
+	//--------------------------------------------------------------------------
 
-    GrB_Index nvals = 4;
-    GrB_Matrix A = CreateSquareNByNEmptyMatrix(nvals);
-    GrB_Index row;
-    GrB_Index col;
-    GrB_Index ncols = nvals;
-    GxB_MatrixTupleIter *iter;
-    GxB_MatrixTupleIter_new(&iter, A);
+	GrB_Index nvals = 4;
+	GrB_Matrix A = CreateSquareNByNEmptyMatrix(nvals);
+	GrB_Index row;
+	GrB_Index col;
+	GrB_Index ncols = nvals;
+	GxB_MatrixTupleIter *iter;
+	GxB_MatrixTupleIter_new(&iter, A);
 
-    for(int j = 0; j < ncols; j++) {      
+	for(int j = 0; j < ncols; j++) {
 
-      //--------------------------------------------------------------------------
-      // Get an iterator over the current column.
-      //--------------------------------------------------------------------------
-      GxB_MatrixTupleIter_iterate_row(iter, j);
+		//--------------------------------------------------------------------------
+		// Get an iterator over the current column.
+		//--------------------------------------------------------------------------
+		GxB_MatrixTupleIter_iterate_row(iter, j);
 
-      //--------------------------------------------------------------------------
-      // Verify iterator returned values.
-      //--------------------------------------------------------------------------
-      bool depleted = false;
-      GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
-      ASSERT_TRUE(depleted);
-    }
+		//--------------------------------------------------------------------------
+		// Verify iterator returned values.
+		//--------------------------------------------------------------------------
+		bool depleted = false;
+		GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		ASSERT_TRUE(depleted);
+	}
 
-    GxB_MatrixTupleIter_free(iter);
-    GrB_Matrix_free(&A);
+	GxB_MatrixTupleIter_free(iter);
+	GrB_Matrix_free(&A);
 }

--- a/tests/unit/test_value.cpp
+++ b/tests/unit/test_value.cpp
@@ -18,47 +18,47 @@ extern "C" {
 #endif
 
 TEST(ValueTest, TestNumerics) {
-    Alloc_Reset();
-    SIValue v;
-    char const *str = "12345";
-    v = SIValue_FromString(str);
-    ASSERT_TRUE(v.type == T_DOUBLE);
-    ASSERT_EQ(v.doubleval, 12345);
+	Alloc_Reset();
+	SIValue v;
+	char const *str = "12345";
+	v = SIValue_FromString(str);
+	ASSERT_TRUE(v.type == T_DOUBLE);
+	ASSERT_EQ(v.doubleval, 12345);
 
-    str = "3.14";
-    v = SIValue_FromString(str);
-    ASSERT_TRUE(v.type == T_DOUBLE);
+	str = "3.14";
+	v = SIValue_FromString(str);
+	ASSERT_TRUE(v.type == T_DOUBLE);
 
-    /* Almost equals. */
-    ASSERT_LT(v.doubleval - 3.14, 0.0001);
+	/* Almost equals. */
+	ASSERT_LT(v.doubleval - 3.14, 0.0001);
 
-    str = "-9876";
-    v = SIValue_FromString(str);
-    ASSERT_TRUE(v.type == T_DOUBLE);
-    ASSERT_EQ(v.doubleval, -9876);
+	str = "-9876";
+	v = SIValue_FromString(str);
+	ASSERT_TRUE(v.type == T_DOUBLE);
+	ASSERT_EQ(v.doubleval, -9876);
 
-    str = "+1.0E1";
-    v = SIValue_FromString(str);
-    ASSERT_TRUE(v.type == T_DOUBLE);
-    ASSERT_EQ(v.doubleval, 10);
+	str = "+1.0E1";
+	v = SIValue_FromString(str);
+	ASSERT_TRUE(v.type == T_DOUBLE);
+	ASSERT_EQ(v.doubleval, 10);
 
-    SIValue_Free(&v);
+	SIValue_Free(&v);
 }
 
 TEST(ValueTest, TestStrings) {
-    Alloc_Reset();
-    SIValue v;
-    char const *str = "Test!";
-    v = SIValue_FromString(str);
-    ASSERT_TRUE(v.type == T_STRING);
-    ASSERT_STREQ(v.stringval, "Test!");
-    SIValue_Free(&v);
+	Alloc_Reset();
+	SIValue v;
+	char const *str = "Test!";
+	v = SIValue_FromString(str);
+	ASSERT_TRUE(v.type == T_STRING);
+	ASSERT_STREQ(v.stringval, "Test!");
+	SIValue_Free(&v);
 
-    /* Out of double range */
-    str = "1.0001e10001";
-    v = SIValue_FromString(str);
-    ASSERT_TRUE(v.type == T_STRING);
-    ASSERT_STREQ(v.stringval, "1.0001e10001");
-    SIValue_Free(&v);
+	/* Out of double range */
+	str = "1.0001e10001";
+	v = SIValue_FromString(str);
+	ASSERT_TRUE(v.type == T_STRING);
+	ASSERT_STREQ(v.stringval, "1.0001e10001");
+	SIValue_Free(&v);
 }
 


### PR DESCRIPTION
This PR includes unit tests in the autoformatter, which I think is sensible (though not strictly neccessary).

Running `make format` also updated some source files, so it's possible that not all of our environments are formatting on save!