### PR TITLE
Changed tck tests to execute with single runtime environment

### DIFF
--- a/tests/tck/features/WithAcceptance.feature
+++ b/tests/tck/features/WithAcceptance.feature
@@ -110,8 +110,8 @@ Feature: WithAcceptance
             RETURN b
             """
         Then the result should be:
-            | b                 |
-            | (:End {num: 423}) |
+            | b                |
+            | (:End {num: 42}) |
         And no side effects
 
     @skip

--- a/tests/tck/features/WithAcceptance.feature
+++ b/tests/tck/features/WithAcceptance.feature
@@ -30,362 +30,362 @@
 
 Feature: WithAcceptance
 
-@skip
-  Scenario: Passing on pattern nodes
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (:A)-[:REL]->(:B)
-      """
-    When executing query:
-      """
-      MATCH (a:A)
-      WITH a
-      MATCH (a)-->(b)
-      RETURN *
-      """
-    Then the result should be:
-      | a    | b    |
-      | (:A) | (:B) |
-    And no side effects
+    @skip
+    Scenario: Passing on pattern nodes
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:A)-[:REL]->(:B)
+            """
+        When executing query:
+            """
+            MATCH (a:A)
+            WITH a
+            MATCH (a)-->(b)
+            RETURN *
+            """
+        Then the result should be:
+            | a    | b    |
+            | (:A) | (:B) |
+        And no side effects
 
-@skip
-  Scenario: ORDER BY and LIMIT can be used
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (a:A), (), (), (),
-             (a)-[:REL]->()
-      """
-    When executing query:
-      """
-      MATCH (a:A)
-      WITH a
-      ORDER BY a.name
-      LIMIT 1
-      MATCH (a)-->(b)
-      RETURN a
-      """
-    Then the result should be:
-      | a    |
-      | (:A) |
-    And no side effects
+    @skip
+    Scenario: ORDER BY and LIMIT can be used
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:A), (), (), (),
+            (a)-[:REL]->()
+            """
+        When executing query:
+            """
+            MATCH (a:A)
+            WITH a
+            ORDER BY a.name
+            LIMIT 1
+            MATCH (a)-->(b)
+            RETURN a
+            """
+        Then the result should be:
+            | a    |
+            | (:A) |
+        And no side effects
 
-@skip
-  Scenario: No dependencies between the query parts
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (:A), (:B)
-      """
-    When executing query:
-      """
-      MATCH (a)
-      WITH a
-      MATCH (b)
-      RETURN a, b
-      """
-    Then the result should be:
-      | a    | b    |
-      | (:A) | (:A) |
-      | (:A) | (:B) |
-      | (:B) | (:A) |
-      | (:B) | (:B) |
-    And no side effects
+    @skip
+    Scenario: No dependencies between the query parts
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:A), (:B)
+            """
+        When executing query:
+            """
+            MATCH (a)
+            WITH a
+            MATCH (b)
+            RETURN a, b
+            """
+        Then the result should be:
+            | a    | b    |
+            | (:A) | (:A) |
+            | (:A) | (:B) |
+            | (:B) | (:A) |
+            | (:B) | (:B) |
+        And no side effects
 
-  Scenario: Aliasing
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (:Begin {num: 42}),
-             (:End {num: 42}),
-             (:End {num: 3})
-      """
-    When executing query:
-      """
-      MATCH (a:Begin)
-      WITH a.num AS property
-      MATCH (b:End)
-      WHERE property = b.num
-      RETURN b
-      """
-    Then the result should be:
-      | b                |
-      | (:End {num: 42}) |
-    And no side effects
+    Scenario: Aliasing
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:Begin {num: 42}),
+            (:End {num: 42}),
+            (:End {num: 3})
+            """
+        When executing query:
+            """
+            MATCH (a:Begin)
+            WITH a.num AS property
+            MATCH (b:End)
+            WHERE property = b.num
+            RETURN b
+            """
+        Then the result should be:
+            | b                 |
+            | (:End {num: 423}) |
+        And no side effects
 
-@skip
-  Scenario: Handle dependencies across WITH
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (a:End {num: 42, id: 0}),
-             (:End {num: 3}),
-             (:Begin {num: a.id})
-      """
-    When executing query:
-      """
-      MATCH (a:Begin)
-      WITH a.num AS property
-        LIMIT 1
-      MATCH (b)
-      WHERE b.id = property
-      RETURN b
-      """
-    Then the result should be:
-      | b                       |
-      | (:End {num: 42, id: 0}) |
-    And no side effects
+    @skip
+    Scenario: Handle dependencies across WITH
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a:End {num: 42, id: 0}),
+            (:End {num: 3}),
+            (:Begin {num: a.id})
+            """
+        When executing query:
+            """
+            MATCH (a:Begin)
+            WITH a.num AS property
+            LIMIT 1
+            MATCH (b)
+            WHERE b.id = property
+            RETURN b
+            """
+        Then the result should be:
+            | b                       |
+            | (:End {num: 42, id: 0}) |
+        And no side effects
 
-@skip
-  Scenario: Handle dependencies across WITH with SKIP
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (a {name: 'A', num: 0, id: 0}),
-             ({name: 'B', num: a.id, id: 1}),
-             ({name: 'C', num: 0, id: 2})
-      """
-    When executing query:
-      """
-      MATCH (a)
-      WITH a.name AS property, a.num AS idToUse
-        ORDER BY property
-        SKIP 1
-      MATCH (b)
-      WHERE b.id = idToUse
-      RETURN DISTINCT b
-      """
-    Then the result should be:
-      | b                            |
-      | ({name: 'A', num: 0, id: 0}) |
-    And no side effects
+    @skip
+    Scenario: Handle dependencies across WITH with SKIP
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a {name: 'A', num: 0, id: 0}),
+            ({name: 'B', num: a.id, id: 1}),
+            ({name: 'C', num: 0, id: 2})
+            """
+        When executing query:
+            """
+            MATCH (a)
+            WITH a.name AS property, a.num AS idToUse
+            ORDER BY property
+            SKIP 1
+            MATCH (b)
+            WHERE b.id = idToUse
+            RETURN DISTINCT b
+            """
+        Then the result should be:
+            | b                            |
+            | ({name: 'A', num: 0, id: 0}) |
+        And no side effects
 
-@skip
-  Scenario: WHERE after WITH should filter results
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({name: 'A'}),
-             ({name: 'B'}),
-             ({name: 'C'})
-      """
-    When executing query:
-      """
-      MATCH (a)
-      WITH a
-      WHERE a.name = 'B'
-      RETURN a
-      """
-    Then the result should be:
-      | a             |
-      | ({name: 'B'}) |
-    And no side effects
+    @skip
+    Scenario: WHERE after WITH should filter results
+        Given an empty graph
+        And having executed:
+            """
+            CREATE ({name: 'A'}),
+            ({name: 'B'}),
+            ({name: 'C'})
+            """
+        When executing query:
+            """
+            MATCH (a)
+            WITH a
+            WHERE a.name = 'B'
+            RETURN a
+            """
+        Then the result should be:
+            | a             |
+            | ({name: 'B'}) |
+        And no side effects
 
-@skip
-  Scenario: WHERE after WITH can filter on top of an aggregation
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (a {name: 'A'}),
-             (b {name: 'B'})
-      CREATE (a)-[:REL]->(),
-             (a)-[:REL]->(),
-             (a)-[:REL]->(),
-             (b)-[:REL]->()
-      """
-    When executing query:
-      """
-      MATCH (a)-->()
-      WITH a, count(*) AS relCount
-      WHERE relCount > 1
-      RETURN a
-      """
-    Then the result should be:
-      | a             |
-      | ({name: 'A'}) |
-    And no side effects
+    @skip
+    Scenario: WHERE after WITH can filter on top of an aggregation
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a {name: 'A'}),
+            (b {name: 'B'})
+            CREATE (a)-[:REL]->(),
+            (a)-[:REL]->(),
+            (a)-[:REL]->(),
+            (b)-[:REL]->()
+            """
+        When executing query:
+            """
+            MATCH (a)-->()
+            WITH a, count(*) AS relCount
+            WHERE relCount > 1
+            RETURN a
+            """
+        Then the result should be:
+            | a             |
+            | ({name: 'A'}) |
+        And no side effects
 
-@skip
-  Scenario: ORDER BY on an aggregating key
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({name: 'A'}),
-             ({name: 'A'}),
-             ({name: 'B'})
-      """
-    When executing query:
-      """
-      MATCH (a)
-      WITH a.name AS bars, count(*) AS relCount
-      ORDER BY a.name
-      RETURN *
-      """
-    Then the result should be:
-      | bars | relCount |
-      | 'A'  | 2        |
-      | 'B'  | 1        |
-    And no side effects
+    @skip
+    Scenario: ORDER BY on an aggregating key
+        Given an empty graph
+        And having executed:
+            """
+            CREATE ({name: 'A'}),
+            ({name: 'A'}),
+            ({name: 'B'})
+            """
+        When executing query:
+            """
+            MATCH (a)
+            WITH a.name AS bars, count(*) AS relCount
+            ORDER BY a.name
+            RETURN *
+            """
+        Then the result should be:
+            | bars | relCount |
+            | 'A'  | 2        |
+            | 'B'  | 1        |
+        And no side effects
 
-  Scenario: ORDER BY a DISTINCT column
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({name: 'A'}),
-             ({name: 'A'}),
-             ({name: 'B'})
-      """
-    When executing query:
-      """
-      MATCH (a)
-      WITH DISTINCT a.name AS bars
-      ORDER BY a.name
-      RETURN *
-      """
-    Then the result should be:
-      | bars |
-      | 'A'  |
-      | 'B'  |
-    And no side effects
+    Scenario: ORDER BY a DISTINCT column
+        Given an empty graph
+        And having executed:
+            """
+            CREATE ({name: 'A'}),
+            ({name: 'A'}),
+            ({name: 'B'})
+            """
+        When executing query:
+            """
+            MATCH (a)
+            WITH DISTINCT a.name AS bars
+            ORDER BY a.name
+            RETURN *
+            """
+        Then the result should be:
+            | bars |
+            | 'A'  |
+            | 'B'  |
+        And no side effects
 
-@skip
-  Scenario: WHERE on a DISTINCT column
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({name2: 'A'}),
-             ({name2: 'A'}),
-             ({name2: 'B'})
-      """
-    When executing query:
-      """
-      MATCH (a)
-      WITH DISTINCT a.name2 AS bars
-      WHERE a.name2 = 'B'
-      RETURN *
-      """
-    Then the result should be:
-      | bars |
-      | 'B'  |
-    And no side effects
+    @skip
+    Scenario: WHERE on a DISTINCT column
+        Given an empty graph
+        And having executed:
+            """
+            CREATE ({name2: 'A'}),
+            ({name2: 'A'}),
+            ({name2: 'B'})
+            """
+        When executing query:
+            """
+            MATCH (a)
+            WITH DISTINCT a.name2 AS bars
+            WHERE a.name2 = 'B'
+            RETURN *
+            """
+        Then the result should be:
+            | bars |
+            | 'B'  |
+        And no side effects
 
-@skip
-  Scenario: A simple pattern with one bound endpoint
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (:A)-[:REL]->(:B)
-      """
-    When executing query:
-      """
-      MATCH (a:A)-[r:REL]->(b:B)
-      WITH a AS b, b AS tmp, r AS r
-      WITH b AS a, r
-      LIMIT 1
-      MATCH (a)-[r]->(b)
-      RETURN a, r, b
-      """
-    Then the result should be:
-      | a    | r      | b    |
-      | (:A) | [:REL] | (:B) |
-    And no side effects
+    @skip
+    Scenario: A simple pattern with one bound endpoint
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:A)-[:REL]->(:B)
+            """
+        When executing query:
+            """
+            MATCH (a:A)-[r:REL]->(b:B)
+            WITH a AS b, b AS tmp, r AS r
+            WITH b AS a, r
+            LIMIT 1
+            MATCH (a)-[r]->(b)
+            RETURN a, r, b
+            """
+        Then the result should be:
+            | a    | r      | b    |
+            | (:A) | [:REL] | (:B) |
+        And no side effects
 
-@skip
-  Scenario: Null handling
-    Given an empty graph
-    When executing query:
-      """
-      OPTIONAL MATCH (a:Start)
-      WITH a
-      MATCH (a)-->(b)
-      RETURN *
-      """
-    Then the result should be:
-      | a | b |
-    And no side effects
+    @skip
+    Scenario: Null handling
+        Given an empty graph
+        When executing query:
+            """
+            OPTIONAL MATCH (a:Start)
+            WITH a
+            MATCH (a)-->(b)
+            RETURN *
+            """
+        Then the result should be:
+            | a | b |
+        And no side effects
 
-@skip
-  Scenario: Nested maps
-    Given an empty graph
-    When executing query:
-      """
-      WITH {name: {name2: 'baz'}} AS nestedMap
-      RETURN nestedMap.name.name2
-      """
-    Then the result should be:
-      | nestedMap.name.name2 |
-      | 'baz'                |
-    And no side effects
+    @skip
+    Scenario: Nested maps
+        Given an empty graph
+        When executing query:
+            """
+            WITH {name: {name2: 'baz'}} AS nestedMap
+            RETURN nestedMap.name.name2
+            """
+        Then the result should be:
+            | nestedMap.name.name2 |
+            | 'baz'                |
+        And no side effects
 
-@skip
-  Scenario: Connected components succeeding WITH
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (:A)-[:REL]->(:X)
-      CREATE (:B)
-      """
-    When executing query:
-      """
-      MATCH (n:A)
-      WITH n
-      LIMIT 1
-      MATCH (m:B), (n)-->(x:X)
-      RETURN *
-      """
-    Then the result should be:
-      | m    | n    | x    |
-      | (:B) | (:A) | (:X) |
-    And no side effects
+    @skip
+    Scenario: Connected components succeeding WITH
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (:A)-[:REL]->(:X)
+            CREATE (:B)
+            """
+        When executing query:
+            """
+            MATCH (n:A)
+            WITH n
+            LIMIT 1
+            MATCH (m:B), (n)-->(x:X)
+            RETURN *
+            """
+        Then the result should be:
+            | m    | n    | x    |
+            | (:B) | (:A) | (:X) |
+        And no side effects
 
-@skip
-  Scenario: Single WITH using a predicate and aggregation
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({num: 43}), ({num: 42})
-      """
-    When executing query:
-      """
-      MATCH (n)
-      WITH n
-      WHERE n.num = 42
-      RETURN count(*)
-      """
-    Then the result should be:
-      | count(*) |
-      | 1        |
-    And no side effects
+    @skip
+    Scenario: Single WITH using a predicate and aggregation
+        Given an empty graph
+        And having executed:
+            """
+            CREATE ({num: 43}), ({num: 42})
+            """
+        When executing query:
+            """
+            MATCH (n)
+            WITH n
+            WHERE n.num = 42
+            RETURN count(*)
+            """
+        Then the result should be:
+            | count(*) |
+            | 1        |
+        And no side effects
 
-@skip
-  Scenario: Multiple WITHs using a predicate and aggregation
-    Given an empty graph
-    And having executed:
-      """
-      CREATE (a {name: 'David'}),
-             (b {name: 'Other'}),
-             (c {name: 'NotOther'}),
-             (d {name: 'NotOther2'}),
-             (a)-[:REL]->(b),
-             (a)-[:REL]->(c),
-             (a)-[:REL]->(d),
-             (b)-[:REL]->(),
-             (b)-[:REL]->(),
-             (c)-[:REL]->(),
-             (c)-[:REL]->(),
-             (d)-[:REL]->()
-      """
-    When executing query:
-      """
-      MATCH (david {name: 'David'})--(otherPerson)-->()
-      WITH otherPerson, count(*) AS foaf
-      WHERE foaf > 1
-      WITH otherPerson
-      WHERE otherPerson.name <> 'NotOther'
-      RETURN count(*)
-      """
-    Then the result should be:
-      | count(*) |
-      | 1        |
-    And no side effects
+    @skip
+    Scenario: Multiple WITHs using a predicate and aggregation
+        Given an empty graph
+        And having executed:
+            """
+            CREATE (a {name: 'David'}),
+            (b {name: 'Other'}),
+            (c {name: 'NotOther'}),
+            (d {name: 'NotOther2'}),
+            (a)-[:REL]->(b),
+            (a)-[:REL]->(c),
+            (a)-[:REL]->(d),
+            (b)-[:REL]->(),
+            (b)-[:REL]->(),
+            (c)-[:REL]->(),
+            (c)-[:REL]->(),
+            (d)-[:REL]->()
+            """
+        When executing query:
+            """
+            MATCH (david {name: 'David'})--(otherPerson)-->()
+            WITH otherPerson, count(*) AS foaf
+            WHERE foaf > 1
+            WITH otherPerson
+            WHERE otherPerson.name <> 'NotOther'
+            RETURN count(*)
+            """
+        Then the result should be:
+            | count(*) |
+            | 1        |
+        And no side effects

--- a/tests/tck/test_tck.py
+++ b/tests/tck/test_tck.py
@@ -2,18 +2,21 @@ from RLTest import Env
 from behave.__main__ import main as behave_main
 
 # this test class is built in order to use 'behave' framework
-# inside an RLTests managed environment. 
+# inside an RLTests managed environment.
 # This class is instanciated in RLTest processes during runtime and
-# the call to test_tck method is intializing and executing a 'behave' 
-# framework with the TCK feature tests inside the 'features' folder. 
+# the call to test_tck method is intializing and executing a 'behave'
+# framework with the TCK feature tests inside the 'features' folder.
 # See /features/steps/Steps.py and utils/graphs.py to for understanding how
 # 'behave' step is preformed against RLTest environment
+
+
 class testTCK():
     def test_tck(self):
         env = Env()
         cmd = ["./features/", '--tags=-skip']
         if not env.verbose:
             cmd.append('--format=progress')
-        res = 'pass' if behave_main(cmd) == 0 else 'fail'
-        env.assertEquals(res,'pass')
- 
+        res = behave_main(cmd)
+        print(res)
+        res = 'pass' if res == 0 else 'fail'
+        env.assertEquals(res, 'pass')

--- a/tests/tck/test_tck.py
+++ b/tests/tck/test_tck.py
@@ -10,13 +10,11 @@ from behave.__main__ import main as behave_main
 # 'behave' step is preformed against RLTest environment
 
 
-class testTCK():
-    def test_tck(self):
-        env = Env()
-        cmd = ["./features/", '--tags=-skip']
-        if not env.verbose:
-            cmd.append('--format=progress')
-        res = behave_main(cmd)
-        print(res)
-        res = 'pass' if res == 0 else 'fail'
-        env.assertEquals(res, 'pass')
+def test_tck():
+    env = Env()
+    cmd = ["./features/", '--tags=-skip']
+    if not env.verbose:
+        cmd.append('--format=progress')
+    res = behave_main(cmd)
+    res = 'pass' if res == 0 else 'fail'
+    env.assertEquals(res, 'pass')

--- a/tests/tck/utils/graphs.py
+++ b/tests/tck/utils/graphs.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from RLTest import Env 
+from RLTest import Env
 
 from redisgraph import Graph, Node, Edge
 
@@ -8,20 +8,23 @@ r = None
 graph_name = "G"
 redis_graph = None
 
+
 def redis():
-   return Env()
+    return Env.RTestInstance.currEnv
+
 
 def _brand_new_redis():
     global r
     if r is not None:
-        r.stop()
+        r.flush()
 
     r = redis()
     return r.getConnection()
 
+
 def empty_graph():
     global redis_graph
-    
+
     redis_con = _brand_new_redis()
     redis_graph = Graph("G", redis_con)
 
@@ -32,8 +35,10 @@ def empty_graph():
     # Delete node to have an empty graph.
     redis_graph.query("MATCH (n) DELETE n")
 
+
 def any_graph():
     return empty_graph()
+
 
 def binary_tree_graph1():
     global redis_graph
@@ -107,6 +112,7 @@ def binary_tree_graph2():
                       (b3)-[:FRIEND] -> (b4),       \
                       (b4)-[:FRIEND] -> (b1)        \
                       ")
+
 
 def query(q):
     return redis_graph.query(q)


### PR DESCRIPTION
This branch modifies the TCK "behave" test suit to use a single running environment. The environment is injected to the test suit before the test suit is executed. This fixes a bug in our execution where failed TCK scenarios where both marked as failed and pass.