### PR TITLE
added IS NULL and IS NOT NULL unary operators

### DIFF
--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -1116,6 +1116,18 @@ SIValue AR_NE(SIValue *argv, int argc) {
 	return SI_BoolVal(res != 0);
 }
 
+SIValue AR_IS_NULL(SIValue *argv, int argc) {
+	assert(argc == 1);
+	SIValue v = argv[0];
+	return SI_BoolVal(v.type == T_NULL);
+}
+
+SIValue AR_IS_NOT_NULL(SIValue *argv, int argc) {
+	assert(argc == 1);
+	SIValue v = argv[0];
+	return SI_BoolVal(v.type != T_NULL);
+}
+
 //==============================================================================
 //=== List functions ===========================================================
 //==============================================================================
@@ -1298,20 +1310,20 @@ SIValue AR_RANDOMUUID(SIValue *argv, int argc) {
 	unsigned char r[16];
 	int i;
 
-	for (i=0; i<16; i++) {
+	for(i = 0; i < 16; i++) {
 		r[i] = rand() % 0xff;
 	}
 
 	char *uuid = rm_malloc(37 * sizeof(char));
 	sprintf(uuid, "%08x-%04x-%04x-%04x-%04x%08x",
-		*((uint32_t*)r),
-		*((uint16_t*)(r + 4)),
-		// Set the four most significant bits of the 7th byte to 0100'B, so the high nibble is "4".
-		(*((uint16_t*)(r + 6)) & 0b0000111111111111) | 0b0100000000000000,
-		// Set the two most significant bits of the 9th byte to 10'B, so the high nibble will be one of "8", "9", "A", or "B" (see Note 1).
-		(*((uint16_t*)(r + 8)) & 0b0011111111111111) | 0b1000000000000000,
-		*((uint16_t*)(r + 10)),
-		*((uint32_t*)(r + 12)));
+			*((uint32_t *)r),
+			*((uint16_t *)(r + 4)),
+			// Set the four most significant bits of the 7th byte to 0100'B, so the high nibble is "4".
+			(*((uint16_t *)(r + 6)) & 0b0000111111111111) | 0b0100000000000000,
+			// Set the two most significant bits of the 9th byte to 10'B, so the high nibble will be one of "8", "9", "A", or "B" (see Note 1).
+			(*((uint16_t *)(r + 8)) & 0b0011111111111111) | 0b1000000000000000,
+			*((uint16_t *)(r + 10)),
+			*((uint32_t *)(r + 12)));
 
 	uuid[36] = '\0';
 
@@ -1332,15 +1344,15 @@ void AR_RegisterFuncs() {
 		AR_Func func_ptr;
 	};
 
-	struct RegFunc functions[50] = {
+	struct RegFunc functions[52] = {
 		{"add", AR_ADD}, {"sub", AR_SUB}, {"mul", AR_MUL}, {"div", AR_DIV}, {"abs", AR_ABS}, {"ceil", AR_CEIL},
 		{"floor", AR_FLOOR}, {"rand", AR_RAND}, {"round", AR_ROUND}, {"sign", AR_SIGN}, {"left", AR_LEFT},
 		{"reverse", AR_REVERSE}, {"right", AR_RIGHT}, {"ltrim", AR_LTRIM}, {"rtrim", AR_RTRIM}, {"substring", AR_SUBSTRING},
 		{"tolower", AR_TOLOWER}, {"toupper", AR_TOUPPER}, {"tostring", AR_TOSTRING}, {"trim", AR_TRIM}, {"contains", AR_CONTAINS},
 		{"starts with", AR_STARTSWITH}, {"ends with", AR_ENDSWITH}, {"id", AR_ID}, {"labels", AR_LABELS}, {"type", AR_TYPE}, {"exists", AR_EXISTS},
 		{"timestamp", AR_TIMESTAMP}, {"and", AR_AND}, {"or", AR_OR}, {"xor", AR_XOR}, {"not", AR_NOT}, {"gt", AR_GT}, {"ge", AR_GE},
-		{"lt", AR_LT}, {"le", AR_LE}, {"eq", AR_EQ}, {"neq", AR_NE}, {"case", AR_CASEWHEN}, {"indegree", AR_INCOMEDEGREE},
-		{"outdegree", AR_OUTGOINGDEGREE},
+		{"lt", AR_LT}, {"le", AR_LE}, {"eq", AR_EQ}, {"neq", AR_NE}, {"is null", AR_IS_NULL}, {"is not null", AR_IS_NOT_NULL},
+		{"case", AR_CASEWHEN}, {"indegree", AR_INCOMEDEGREE}, {"outdegree", AR_OUTGOINGDEGREE},
 		{"tolist", AR_TOLIST}, {"subscript", AR_SUBSCRIPT}, {"slice", AR_SLICE}, {"range", AR_RANGE}, {"in", AR_IN},
 		{"size", AR_SIZE}, {"head", AR_HEAD}, {"tail", AR_TAIL},
 		{"randomuuid", AR_RANDOMUUID}
@@ -1349,7 +1361,7 @@ void AR_RegisterFuncs() {
 	char lower_func_name[32] = {0};
 	short lower_func_name_len = 32;
 
-	for(int i = 0; i < 50; i++) {
+	for(int i = 0; i < 52; i++) {
 		_toLower(functions[i].func_name, &lower_func_name[0], &lower_func_name_len);
 		_AR_RegFunc(lower_func_name, lower_func_name_len, functions[i].func_ptr);
 		lower_func_name_len = 32;

--- a/src/arithmetic/funcs.h
+++ b/src/arithmetic/funcs.h
@@ -93,6 +93,10 @@ SIValue AR_LE(SIValue *argv, int argc);
 SIValue AR_EQ(SIValue *argv, int argc);
 /* returns true if argv[0] != argv[1] */
 SIValue AR_NE(SIValue *argv, int argc);
+/* returns true if argv[0] is null */
+SIValue AR_IS_NULL(SIValue *argv, int argc);
+/* returns true if argv[0] is not null */
+SIValue AR_IS_NOT_NULL(SIValue *argv, int argc);
 
 /* List operations */
 /* returns an array */

--- a/src/ast/ast_build_ar_exp.c
+++ b/src/ast/ast_build_ar_exp.c
@@ -153,32 +153,31 @@ static AR_ExpNode *_AR_EXP_FromUnaryOpExpression(RecordMap *record_map,
 												 const cypher_astnode_t *expr) {
 	const cypher_astnode_t *arg = cypher_ast_unary_operator_get_argument(expr); // CYPHER_AST_EXPRESSION
 	const cypher_operator_t *operator = cypher_ast_unary_operator_get_operator(expr);
+	AR_ExpNode *op = NULL;
 	if(operator == CYPHER_OP_UNARY_MINUS) {
 		// This expression can be something like -3 or -a.val
 		// In the former case, we'll reduce the tree to a constant after building it fully.
-		AR_ExpNode *op = AR_EXP_NewOpNodeFromAST(OP_MULT, 2);
+		op = AR_EXP_NewOpNodeFromAST(OP_MULT, 2);
 		op->op.children[0] = AR_EXP_NewConstOperandNode(SI_LongVal(-1));
 		op->op.children[1] = _AR_EXP_FromExpression(record_map, arg);
-		return op;
 	} else if(operator == CYPHER_OP_UNARY_PLUS) {
 		// This expression is something like +3 or +a.val.
 		// I think the + can always be safely ignored.
-		return _AR_EXP_FromExpression(record_map, arg);
+		op = _AR_EXP_FromExpression(record_map, arg);
 	} else if(operator == CYPHER_OP_NOT) {
-		AR_ExpNode *op = AR_EXP_NewOpNodeFromAST(OP_NOT, 1);
+		op = AR_EXP_NewOpNodeFromAST(OP_NOT, 1);
 		op->op.children[0] = _AR_EXP_FromExpression(record_map, arg);
-		return op;
 	} else if(operator == CYPHER_OP_IS_NULL) {
-		AR_ExpNode *op = AR_EXP_NewOpNodeFromAST(OP_IS_NULL, 1);
+		op = AR_EXP_NewOpNodeFromAST(OP_IS_NULL, 1);
 		op->op.children[0] = _AR_EXP_FromExpression(record_map, arg);
-		return op;
 	} else if(operator == CYPHER_OP_IS_NOT_NULL) {
-		AR_ExpNode *op = AR_EXP_NewOpNodeFromAST(OP_IS_NOT_NULL, 1);
+		op = AR_EXP_NewOpNodeFromAST(OP_IS_NOT_NULL, 1);
 		op->op.children[0] = _AR_EXP_FromExpression(record_map, arg);
-		return op;
+	} else {
+		// No supported operator found.
+		assert(false);
 	}
-	assert(false);
-	return NULL;
+	return op;
 }
 
 static AR_ExpNode *_AR_EXP_FromBinaryOpExpression(RecordMap *record_map,

--- a/src/ast/ast_build_ar_exp.c
+++ b/src/ast/ast_build_ar_exp.c
@@ -55,6 +55,10 @@ static const char *_ASTOpToString(AST_Operator op) {
 		return "POW";
 	case OP_IN:
 		return "IN";
+	case OP_IS_NULL:
+		return "IS NULL";
+	case OP_IS_NOT_NULL:
+		return "IS NOT NULL";
 	default:
 		assert(false && "Unhandled operator was specified in query");
 		return NULL;
@@ -162,6 +166,14 @@ static AR_ExpNode *_AR_EXP_FromUnaryOpExpression(RecordMap *record_map,
 		return _AR_EXP_FromExpression(record_map, arg);
 	} else if(operator == CYPHER_OP_NOT) {
 		AR_ExpNode *op = AR_EXP_NewOpNodeFromAST(OP_NOT, 1);
+		op->op.children[0] = _AR_EXP_FromExpression(record_map, arg);
+		return op;
+	} else if(operator == CYPHER_OP_IS_NULL) {
+		AR_ExpNode *op = AR_EXP_NewOpNodeFromAST(OP_IS_NULL, 1);
+		op->op.children[0] = _AR_EXP_FromExpression(record_map, arg);
+		return op;
+	} else if(operator == CYPHER_OP_IS_NOT_NULL) {
+		AR_ExpNode *op = AR_EXP_NewOpNodeFromAST(OP_IS_NOT_NULL, 1);
 		op->op.children[0] = _AR_EXP_FromExpression(record_map, arg);
 		return op;
 	}

--- a/src/ast/ast_build_filter_tree.c
+++ b/src/ast/ast_build_filter_tree.c
@@ -102,8 +102,13 @@ static FT_FilterNode *_convertUnaryOperator(RecordMap *record_map,
 	// Argument is of type CYPHER_AST_EXPRESSION
 	const cypher_astnode_t *arg = cypher_ast_unary_operator_get_argument(op_node);
 	AST_Operator op = AST_ConvertOperatorNode(operator);
-
-	return _CreateFilterSubtree(record_map, op, arg, NULL);
+	switch(op) {
+	case OP_IS_NULL:
+	case OP_IS_NOT_NULL:
+		return FilterTree_CreateExpressionFilter(AR_EXP_FromExpression(record_map, op_node));
+	default:
+		return _CreateFilterSubtree(record_map, op, arg, NULL);
+	}
 }
 
 static FT_FilterNode *_convertApplyOperator(RecordMap *record_map,
@@ -121,7 +126,8 @@ static FT_FilterNode *_convertFalseOperator() {
 	return FilterTree_CreateExpressionFilter(exp);
 }
 
-static FT_FilterNode *_convertIntegerOperator(RecordMap *record_map, const cypher_astnode_t *expr) {
+static FT_FilterNode *_convertIntegerOperator(RecordMap *record_map,
+											  const cypher_astnode_t *expr) {
 	AR_ExpNode *exp = AR_EXP_FromExpression(record_map, expr);
 	return FilterTree_CreateExpressionFilter(exp);
 }

--- a/src/ast/ast_build_filter_tree.c
+++ b/src/ast/ast_build_filter_tree.c
@@ -126,8 +126,7 @@ static FT_FilterNode *_convertFalseOperator() {
 	return FilterTree_CreateExpressionFilter(exp);
 }
 
-static FT_FilterNode *_convertIntegerOperator(RecordMap *record_map,
-											  const cypher_astnode_t *expr) {
+static FT_FilterNode *_convertIntegerOperator(RecordMap *record_map, const cypher_astnode_t *expr) {
 	AR_ExpNode *exp = AR_EXP_FromExpression(record_map, expr);
 	return FilterTree_CreateExpressionFilter(exp);
 }

--- a/src/ast/ast_shared.c
+++ b/src/ast/ast_shared.c
@@ -46,6 +46,10 @@ AST_Operator AST_ConvertOperatorNode(const cypher_operator_t *op) {
 		return OP_ENDSWITH;
 	} else if(op == CYPHER_OP_IN) {
 		return OP_IN;
+	} else if(op == CYPHER_OP_IS_NULL) {
+		return OP_IS_NULL;
+	} else if(op == CYPHER_OP_IS_NOT_NULL) {
+		return OP_IS_NOT_NULL;
 	}
 
 	return -1;

--- a/src/ast/ast_shared.h
+++ b/src/ast/ast_shared.h
@@ -35,7 +35,9 @@ typedef enum
     OP_CONTAINS,
     OP_STARTSWITH,
     OP_ENDSWITH,
-    OP_IN
+    OP_IN,
+    OP_IS_NULL,
+    OP_IS_NOT_NULL
 } AST_Operator;
 
 typedef struct

--- a/src/ast/cypher_whitelist.c
+++ b/src/ast/cypher_whitelist.c
@@ -182,8 +182,8 @@ static void _buildOperatorsWhitelist(void) {
 		CYPHER_OP_STARTS_WITH,
 		CYPHER_OP_ENDS_WITH,
 		CYPHER_OP_CONTAINS,
-		// CYPHER_OP_IS_NULL,
-		// CYPHER_OP_IS_NOT_NULL,
+		CYPHER_OP_IS_NULL,
+		CYPHER_OP_IS_NOT_NULL,
 		CYPHER_OP_PROPERTY,
 		CYPHER_OP_LABEL,
 		end_of_operator_list

--- a/tests/tck/features/NullOperator.feature
+++ b/tests/tck/features/NullOperator.feature
@@ -30,100 +30,98 @@
 
 Feature: NullOperator
 
-@skip
-  Scenario: Property null check on non-null node
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({exists: 42})
-      """
-    When executing query:
-      """
-      MATCH (n)
-      RETURN n.missing IS NULL,
-             n.exists IS NULL
-      """
-    Then the result should be:
-      | n.missing IS NULL | n.exists IS NULL |
-      | true              | false            |
-    And no side effects
+    Scenario: Property null check on non-null node
+        Given an empty graph
+        And having executed:
+            """
+            CREATE ({exists: 42})
+            """
+        When executing query:
+            """
+            MATCH (n)
+            RETURN n.missing IS NULL,
+            n.exists IS NULL
+            """
+        Then the result should be:
+            | n.missing IS NULL | n.exists IS NULL |
+            | true              | false            |
+        And no side effects
 
-@skip
-  Scenario: Property not null check on non-null node
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({exists: 42})
-      """
-    When executing query:
-      """
-      MATCH (n)
-      RETURN n.missing IS NOT NULL,
-             n.exists IS NOT NULL
-      """
-    Then the result should be:
-      | n.missing IS NOT NULL | n.exists IS NOT NULL |
-      | false                 | true                 |
-    And no side effects
+    Scenario: Property not null check on non-null node
+        Given an empty graph
+        And having executed:
+            """
+            CREATE ({exists: 42})
+            """
+        When executing query:
+            """
+            MATCH (n)
+            RETURN n.missing IS NOT NULL,
+            n.exists IS NOT NULL
+            """
+        Then the result should be:
+            | n.missing IS NOT NULL | n.exists IS NOT NULL |
+            | false                 | true                 |
+        And no side effects
 
-@skip
-  Scenario: Property null check on optional non-null node
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({exists: 42})
-      """
-    When executing query:
-      """
-      OPTIONAL MATCH (n)
-      RETURN n.missing IS NULL,
-             n.exists IS NULL
-      """
-    Then the result should be:
-      | n.missing IS NULL | n.exists IS NULL |
-      | true              | false            |
-    And no side effects
+    @skip
+    Scenario: Property null check on optional non-null node
+        Given an empty graph
+        And having executed:
+            """
+            CREATE ({exists: 42})
+            """
+        When executing query:
+            """
+            OPTIONAL MATCH (n)
+            RETURN n.missing IS NULL,
+            n.exists IS NULL
+            """
+        Then the result should be:
+            | n.missing IS NULL | n.exists IS NULL |
+            | true              | false            |
+        And no side effects
 
-@skip
-  Scenario: Property not null check on optional non-null node
-    Given an empty graph
-    And having executed:
-      """
-      CREATE ({exists: 42})
-      """
-    When executing query:
-      """
-      OPTIONAL MATCH (n)
-      RETURN n.missing IS NOT NULL,
-             n.exists IS NOT NULL
-      """
-    Then the result should be:
-      | n.missing IS NOT NULL | n.exists IS NOT NULL |
-      | false                 | true                 |
-    And no side effects
+    @skip
+    Scenario: Property not null check on optional non-null node
+        Given an empty graph
+        And having executed:
+            """
+            CREATE ({exists: 42})
+            """
+        When executing query:
+            """
+            OPTIONAL MATCH (n)
+            RETURN n.missing IS NOT NULL,
+            n.exists IS NOT NULL
+            """
+        Then the result should be:
+            | n.missing IS NOT NULL | n.exists IS NOT NULL |
+            | false                 | true                 |
+        And no side effects
 
-@skip
-  Scenario: Property null check on null node
-    Given an empty graph
-    When executing query:
-      """
-      OPTIONAL MATCH (n)
-      RETURN n.missing IS NULL
-      """
-    Then the result should be:
-      | n.missing IS NULL |
-      | true              |
-    And no side effects
+    @skip
+    Scenario: Property null check on null node
+        Given an empty graph
+        When executing query:
+            """
+            OPTIONAL MATCH (n)
+            RETURN n.missing IS NULL
+            """
+        Then the result should be:
+            | n.missing IS NULL |
+            | true              |
+        And no side effects
 
-@skip
-  Scenario: Property not null check on null node
-    Given an empty graph
-    When executing query:
-      """
-      OPTIONAL MATCH (n)
-      RETURN n.missing IS NOT NULL
-      """
-    Then the result should be:
-      | n.missing IS NOT NULL |
-      | false                 |
-    And no side effects
+    @skip
+    Scenario: Property not null check on null node
+        Given an empty graph
+        When executing query:
+            """
+            OPTIONAL MATCH (n)
+            RETURN n.missing IS NOT NULL
+            """
+        Then the result should be:
+            | n.missing IS NOT NULL |
+            | false                 |
+        And no side effects

--- a/tests/tck/features/TernaryLogicAcceptance.feature
+++ b/tests/tck/features/TernaryLogicAcceptance.feature
@@ -30,147 +30,145 @@
 
 Feature: TernaryLogicAcceptanceTest
 
-  Background:
-    Given any graph
+    Background:
+        Given any graph
 
-  Scenario: The inverse of a null is a null
-    When executing query:
-      """
-      RETURN NOT null AS value
-      """
-    Then the result should be:
-      | value |
-      | null  |
-    And no side effects
+    Scenario: The inverse of a null is a null
+        When executing query:
+            """
+            RETURN NOT null AS value
+            """
+        Then the result should be:
+            | value |
+            | null  |
+        And no side effects
 
-@skip
-  Scenario: A literal null IS null
-    When executing query:
-      """
-      RETURN null IS NULL AS value
-      """
-    Then the result should be:
-      | value |
-      | true  |
-    And no side effects
+    Scenario: A literal null IS null
+        When executing query:
+            """
+            RETURN null IS NULL AS value
+            """
+        Then the result should be:
+            | value |
+            | true  |
+        And no side effects
 
-@skip
-  Scenario: A literal null is not IS NOT null
-    When executing query:
-      """
-      RETURN null IS NOT NULL AS value
-      """
-    Then the result should be:
-      | value |
-      | false |
-    And no side effects
+    Scenario: A literal null is not IS NOT null
+        When executing query:
+            """
+            RETURN null IS NOT NULL AS value
+            """
+        Then the result should be:
+            | value |
+            | false |
+        And no side effects
 
-  Scenario: It is unknown - i.e. null - if a null is equal to a null
-    When executing query:
-      """
-      RETURN null = null AS value
-      """
-    Then the result should be:
-      | value |
-      | null  |
-    And no side effects
+    Scenario: It is unknown - i.e. null - if a null is equal to a null
+        When executing query:
+            """
+            RETURN null = null AS value
+            """
+        Then the result should be:
+            | value |
+            | null  |
+        And no side effects
 
-  Scenario: It is unknown - i.e. null - if a null is not equal to a null
-    When executing query:
-      """
-      RETURN null <> null AS value
-      """
-    Then the result should be:
-      | value |
-      | null  |
-    And no side effects
+    Scenario: It is unknown - i.e. null - if a null is not equal to a null
+        When executing query:
+            """
+            RETURN null <> null AS value
+            """
+        Then the result should be:
+            | value |
+            | null  |
+        And no side effects
 
-@skip
-  Scenario Outline: Using null in AND
-    And parameters are:
-      | lhs | <lhs> |
-      | rhs | <rhs> |
-    When executing query:
-      """
-      RETURN $lhs AND $rhs AS result
-      """
-    Then the result should be:
-      | result   |
-      | <result> |
-    And no side effects
+    @skip
+    Scenario Outline: Using null in AND
+        And parameters are:
+            | lhs | <lhs> |
+            | rhs | <rhs> |
+        When executing query:
+            """
+            RETURN $lhs AND $rhs AS result
+            """
+        Then the result should be:
+            | result   |
+            | <result> |
+        And no side effects
 
-    Examples:
-      | lhs   | rhs   | result |
-      | null  | null  | null   |
-      | null  | true  | null   |
-      | true  | null  | null   |
-      | null  | false | false  |
-      | false | null  | false  |
+        Examples:
+            | lhs   | rhs   | result |
+            | null  | null  | null   |
+            | null  | true  | null   |
+            | true  | null  | null   |
+            | null  | false | false  |
+            | false | null  | false  |
 
-@skip
-  Scenario Outline: Using null in OR
-    And parameters are:
-      | lhs | <lhs> |
-      | rhs | <rhs> |
-    When executing query:
-      """
-      RETURN $lhs OR $rhs AS result
-      """
-    Then the result should be:
-      | result   |
-      | <result> |
-    And no side effects
+    @skip
+    Scenario Outline: Using null in OR
+        And parameters are:
+            | lhs | <lhs> |
+            | rhs | <rhs> |
+        When executing query:
+            """
+            RETURN $lhs OR $rhs AS result
+            """
+        Then the result should be:
+            | result   |
+            | <result> |
+        And no side effects
 
-    Examples:
-      | lhs   | rhs   | result |
-      | null  | null  | null   |
-      | null  | true  | true   |
-      | true  | null  | true   |
-      | null  | false | null   |
-      | false | null  | null   |
+        Examples:
+            | lhs   | rhs   | result |
+            | null  | null  | null   |
+            | null  | true  | true   |
+            | true  | null  | true   |
+            | null  | false | null   |
+            | false | null  | null   |
 
-@skip
-  Scenario Outline: Using null in XOR
-    And parameters are:
-      | lhs    | <lhs>    |
-      | rhs    | <rhs>    |
-    When executing query:
-      """
-      RETURN $lhs XOR $rhs AS result
-      """
-    Then the result should be:
-      | result   |
-      | <result> |
-    And no side effects
+    @skip
+    Scenario Outline: Using null in XOR
+        And parameters are:
+            | lhs | <lhs> |
+            | rhs | <rhs> |
+        When executing query:
+            """
+            RETURN $lhs XOR $rhs AS result
+            """
+        Then the result should be:
+            | result   |
+            | <result> |
+        And no side effects
 
-    Examples:
-      | lhs   | rhs   | result |
-      | null  | null  | null   |
-      | null  | true  | null   |
-      | true  | null  | null   |
-      | null  | false | null   |
-      | false | null  | null   |
+        Examples:
+            | lhs   | rhs   | result |
+            | null  | null  | null   |
+            | null  | true  | null   |
+            | true  | null  | null   |
+            | null  | false | null   |
+            | false | null  | null   |
 
-@skip
-  Scenario Outline: Using null in IN
-    And parameters are:
-      | elt    | <elt>    |
-      | coll   | <coll>   |
-    When executing query:
-      """
-      RETURN $elt IN $coll AS result
-      """
-    Then the result should be:
-      | result   |
-      | <result> |
-    And no side effects
+    @skip
+    Scenario Outline: Using null in IN
+        And parameters are:
+            | elt  | <elt>  |
+            | coll | <coll> |
+        When executing query:
+            """
+            RETURN $elt IN $coll AS result
+            """
+        Then the result should be:
+            | result   |
+            | <result> |
+        And no side effects
 
-    Examples:
-      | elt  | coll            | result |
-      | null | null            | null   |
-      | null | [1, 2, 3]       | null   |
-      | null | [1, 2, 3, null] | null   |
-      | null | []              | false  |
-      | 1    | [1, 2, 3, null] | true   |
-      | 1    | [null, 1]       | true   |
-      | 5    | [1, 2, 3, null] | null   |
+        Examples:
+            | elt  | coll            | result |
+            | null | null            | null   |
+            | null | [1, 2, 3]       | null   |
+            | null | [1, 2, 3, null] | null   |
+            | null | []              | false  |
+            | 1    | [1, 2, 3, null] | true   |
+            | 1    | [null, 1]       | true   |
+            | 5    | [1, 2, 3, null] | null   |

--- a/tests/unit/test_arithmetic_expression.cpp
+++ b/tests/unit/test_arithmetic_expression.cpp
@@ -1476,7 +1476,7 @@ TEST_F(ArithmeticTest, IsNullTest)
     char *values[6] = {"1", "1.2", "true", "false", "'string'", "[1,2,3]"};
     for (int i = 0; i < 6; i++)
     {
-        char buff[100];
+        char buff[128];
         // Check if value is not null.
         sprintf(buff, "RETURN %s IS NOT NULL", values[i]);
         arExp = _exp_from_query(buff);

--- a/tests/unit/test_arithmetic_expression.cpp
+++ b/tests/unit/test_arithmetic_expression.cpp
@@ -1448,3 +1448,48 @@ TEST_F(ArithmeticTest, InTest)
     ASSERT_EQ(T_BOOL, result.type);
     ASSERT_EQ(true, result.longval);
 }
+
+TEST_F(ArithmeticTest, IsNullTest)
+{
+    SIValue result;
+    const char *query;
+    AR_ExpNode *arExp;
+    Record r = Record_New(0);
+
+    // Check if null is null.
+    query = "RETURN null IS NULL";
+    arExp = _exp_from_query(query);
+    result = AR_EXP_Evaluate(arExp, r);
+
+    ASSERT_EQ(T_BOOL, result.type);
+    ASSERT_EQ(true, result.longval);
+
+    // Check if null is not "not null".
+    query = "RETURN null IS NOT NULL";
+    arExp = _exp_from_query(query);
+    result = AR_EXP_Evaluate(arExp, r);
+
+    ASSERT_EQ(T_BOOL, result.type);
+    ASSERT_EQ(false, result.longval);
+
+    // Check for different types values.
+    char *values[6] = {"1", "1.2", "true", "false", "'string'", "[1,2,3]"};
+    for (int i = 0; i < 6; i++)
+    {
+        char buff[100];
+        // Check if value is not null.
+        sprintf(buff, "RETURN %s IS NOT NULL", values[i]);
+        arExp = _exp_from_query(buff);
+        result = AR_EXP_Evaluate(arExp, r);
+
+        ASSERT_EQ(T_BOOL, result.type);
+        ASSERT_EQ(true, result.longval);
+
+        sprintf(buff, "RETURN %s IS NULL", values[i]);
+        arExp = _exp_from_query(buff);
+        result = AR_EXP_Evaluate(arExp, r);
+
+        ASSERT_EQ(T_BOOL, result.type);
+        ASSERT_EQ(false, result.longval);
+    }
+}


### PR DESCRIPTION
Added both IS NULL and IS NOT NULL unary operators to the arsenal. They can be used both as an expression the evaluate in RETURN clause, or as a leaf in a filter tree.
Added a test in test_arithmetic_expression.cpp
Enabled some TCK scenarios
Added a flow test for filter testing, since currently no TCK tests are enabled with those tests