### PR TITLE
Disallow potentially unhandled MERGE queries

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1320,6 +1320,40 @@ static AST_Validation _ValidateClauses(const AST *ast, char **reason) {
 	return AST_VALID;
 }
 
+static AST_Validation _BlockUnsupportedMerges(AST *ast, char **reason) {
+	/* The current merge implementation does not work properly when the query is
+	 * intended to operate on multiple data streams, as in:
+	 * CREATE (a:A), (b:B)
+	 * MATCH (a:A), (b:B) MERGE (a)-[:TYPE]->(b)
+	 * This currently creates two new nodes. TODO fix */
+	uint *merge_clause_indices = AST_GetClauseIndices(ast, CYPHER_AST_MERGE);
+	uint merge_count = array_len(merge_clause_indices);
+	if(merge_count == 0) return AST_VALID;
+
+	if(merge_count > 1) {
+		asprintf(reason, "RedisGraph does not currently support multiple MERGE clauses in a single query.");
+		return AST_INVALID;
+	}
+
+	AST_Validation res = AST_VALID;
+
+	uint merge_idx = merge_clause_indices[0];
+	for(uint i = 0; i < merge_idx; i ++) {
+		const cypher_astnode_t *prev_clause = cypher_ast_query_get_clause(ast->root, i);
+		cypher_astnode_type_t prev_clause_type = cypher_astnode_type(prev_clause);
+		if(prev_clause_type == CYPHER_AST_MATCH || prev_clause_type == CYPHER_AST_CREATE) {
+			asprintf(reason,
+					 "RedisGraph does not currently support MERGE clauses after MATCH or CREATE clauses.");
+			res = AST_INVALID;
+			break;
+		}
+	}
+
+	array_free(merge_clause_indices);
+
+	return res;
+}
+
 static AST *_NewMockASTSegment(const cypher_astnode_t *root, uint start_offset, uint end_offset) {
 	AST *ast = rm_malloc(sizeof(AST));
 	ast->free_root = true;
@@ -1348,6 +1382,8 @@ static AST_Validation _ValidateScopes(const cypher_astnode_t *root, char **reaso
 
 	// Validate identifiers, which may be passed between scopes
 	if(_Validate_Aliases_Defined(&mock_ast, reason) == AST_INVALID) return AST_INVALID;
+
+	if(_BlockUnsupportedMerges(&mock_ast, reason) == AST_INVALID) return AST_INVALID;
 
 	// Aliases are scoped by the WITH clauses within the query.
 	// If we have one or more WITH clauses, MATCH validations should be performed one scope at a time.
@@ -1446,3 +1482,4 @@ AST_Validation AST_Validate(RedisModuleCtx *ctx, const cypher_parse_result_t *re
 
 	return res;
 }
+

--- a/tests/flow/test_graph_merge.py
+++ b/tests/flow/test_graph_merge.py
@@ -237,9 +237,10 @@ class testGraphMergeFlow(FlowTestsBase):
         self.env.assertEquals(result.properties_set, 0)
 
         # Verify that MATCH...MERGE on the same entity does not introduce changes
-        query = """MATCH (q {name: 'ABCDE'}) MERGE (r {name: q.name}) RETURN r.name"""
-        result = redis_graph.query(query)
-        self.env.assertEquals(result.labels_added, 0)
-        self.env.assertEquals(result.nodes_created, 0)
-        self.env.assertEquals(result.properties_set, 0)
-        self.env.assertEquals(result.result_set, expected)
+        # TODO currently unsupported
+        #  query = """MATCH (q {name: 'ABCDE'}) MERGE (r {name: q.name}) RETURN r.name"""
+        #  result = redis_graph.query(query)
+        #  self.env.assertEquals(result.labels_added, 0)
+        #  self.env.assertEquals(result.nodes_created, 0)
+        #  self.env.assertEquals(result.properties_set, 0)
+        #  self.env.assertEquals(result.result_set, expected)

--- a/tests/tck/features/MergeRelationshipAcceptance.feature
+++ b/tests/tck/features/MergeRelationshipAcceptance.feature
@@ -49,6 +49,7 @@ Feature: MergeRelationshipAcceptance
     And the side effects should be:
       | +relationships | 1 |
 
+@skip
   Scenario: Matching a relationship
     Given an empty graph
     And having executed:
@@ -67,6 +68,7 @@ Feature: MergeRelationshipAcceptance
       | 1        |
     And no side effects
 
+@skip
   Scenario: Matching two relationships
     Given an empty graph
     And having executed:
@@ -86,6 +88,7 @@ Feature: MergeRelationshipAcceptance
       | 2        |
     And no side effects
 
+@skip
   Scenario: Filtering relationships
     Given an empty graph
     And having executed:
@@ -105,6 +108,7 @@ Feature: MergeRelationshipAcceptance
       | 1        |
     And no side effects
 
+@skip
   Scenario: Creating relationship when all matches filtered out
     Given an empty graph
     And having executed:
@@ -125,6 +129,7 @@ Feature: MergeRelationshipAcceptance
       | +relationships | 1 |
       | +properties    | 1 |
 
+@skip
   Scenario: Matching incoming relationship
     Given an empty graph
     And having executed:
@@ -144,6 +149,7 @@ Feature: MergeRelationshipAcceptance
       | 1        |
     And no side effects
 
+@skip
   Scenario: Creating relationship with property
     Given an empty graph
     And having executed:
@@ -456,6 +462,7 @@ Feature: MergeRelationshipAcceptance
       | 1        |
     And no side effects
 
+@skip
   Scenario: Using bound variables from other updating clause
     Given an empty graph
     When executing query:


### PR DESCRIPTION
This PR raises a validation error when a MERGE clause is preceded by a CREATE or MATCH clause, or more than 1 MERGE clause is present.

One current problem with OpMerge is that it doesn't differentiate between multiple streams.

2 TCK tests that are now skipped actually worked incorrectly:
```
gq G "CREATE (a:A), (b:B) CREATE (a)-[:TYPE {name: 'r1'}]->(b)"
gq G "MATCH (a:A), (b:B) MERGE (a)-[r:TYPE {name: 'r2'}]->(b) RETURN count(r)"
```
```
gq G "CREATE (a:A), (b:B)"
gq G "MATCH (a:A), (b:B) MERGE (a)-[r:TYPE {name: 'Lola'}]->(b) RETURN count(r)"
```
In both of these cases, we fail to resolve the pattern and create 2 erroneous nodes (the tests do not check for that side-effect).

5 other TCK tests that did pass appropriately are now disallowed, but I'd prefer to remove support this broadly given the potential for misbehaving queries.

Additionally, unlike OpCreate, OpMerge does not buffer its graph updates, so it is capable of incorrectly committing new entities.