### PR TITLE
hot fixed ast validation for DELETE. fixes #639

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -782,8 +782,21 @@ static AST_Validation _Validate_DELETE_Clauses(const AST *ast, char **reason) {
 	if(!delete_clause) return AST_VALID;
 
 	const cypher_astnode_t *match_clause = AST_GetClause(ast, CYPHER_AST_MATCH);
-	if(!match_clause) return AST_INVALID;
+	// Check for delete a projected entity such in "MATCH (n) WITH n AS x DELETE x".
+	const cypher_astnode_t *with_clause = AST_GetClause(ast, CYPHER_AST_WITH);
+	assert(!(with_clause && match_clause));
+	if(!match_clause && !with_clause) return AST_INVALID;
 
+	// Validate that every deleted object is an identifier and not property.
+	uint nitems = cypher_ast_delete_nexpressions(delete_clause);
+	for(uint i = 0; i < nitems; i++) {
+		const cypher_astnode_t *ast_expr = cypher_ast_delete_get_expression(delete_clause, i);
+		if(cypher_astnode_type(ast_expr) != CYPHER_AST_IDENTIFIER) {
+			asprintf(reason, "DELETE support the removal of valid graph entities only.");
+			return AST_INVALID;
+		}
+		// TODO: Validated that the deleted entities are indeed matched or projected.
+	}
 	return AST_VALID;
 }
 

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -781,12 +781,6 @@ static AST_Validation _Validate_DELETE_Clauses(const AST *ast, char **reason) {
 	const cypher_astnode_t *delete_clause = AST_GetClause(ast, CYPHER_AST_DELETE);
 	if(!delete_clause) return AST_VALID;
 
-	const cypher_astnode_t *match_clause = AST_GetClause(ast, CYPHER_AST_MATCH);
-	// Check for delete a projected entity such in "MATCH (n) WITH n AS x DELETE x".
-	const cypher_astnode_t *with_clause = AST_GetClause(ast, CYPHER_AST_WITH);
-	assert(!(with_clause && match_clause));
-	if(!match_clause && !with_clause) return AST_INVALID;
-
 	// Validate that every deleted object is an identifier and not property.
 	uint nitems = cypher_ast_delete_nexpressions(delete_clause);
 	for(uint i = 0; i < nitems; i++) {


### PR DESCRIPTION
This PR introduces a quick fix for AST validation done over DELETE clause. The additional validation allows the DELETE to be called either after a match clause, or, after a projection. The critical part of the fix is that each delete expression is validated to be an identifier.