### PR TITLE
set GraphBLAS jobs to the maximum of logical cpu

### DIFF
--- a/deps/GraphBLAS/Makefile
+++ b/deps/GraphBLAS/Makefile
@@ -10,7 +10,14 @@
 # simple Makefile for GraphBLAS, relies on cmake to do the actual build.  Use
 # the CMAKE_OPTIONS argument to this Makefile to pass options to cmake.
 
-JOBS ?= 1
+# Find the OS.
+uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
+# Set number of threads.
+ifeq ($(uname_S),Linux)
+	JOBS ?= $(shell grep -c ^processor /proc/cpuinfo)
+else
+	JOBS ?= $(shell sysctl -n hw.logicalcpu_max)
+endif
 
 default: library
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,12 +26,13 @@ CFLAGS += $(DEBUGFLAGS)
 # Compile flags for linux / osx
 ifeq ($(uname_S),Linux)
 	SHOBJ_LDFLAGS ?= -shared -Bsymbolic -Bsymbolic-functions -ldl -lpthread -fopenmp
+	JOBS := $(shell grep -c ^processor /proc/cpuinfo)
 else
 	CFLAGS += -mmacosx-version-min=10.14
 	SHOBJ_LDFLAGS ?= -mmacosx-version-min=10.14 -bundle -undefined dynamic_lookup -ldl -lpthread -fopenmp
+	JOBS := $(shell sysctl -n hw.logicalcpu_max)
 endif
 SHOBJ_LDFLAGS += $(LDFLAGS)
-
 export CFLAGS
 
 # Sources
@@ -125,7 +126,7 @@ $(LIBXXHASH):
 # Build GraphBLAS only if library does not already exists.
 $(GRAPHBLAS):
 ifeq (,$(wildcard $(GRAPHBLAS)))
-	@$(MAKE) -C ../deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)' -DCMAKE_CXX_COMPILER='$(CC)'" library
+	@$(MAKE) -C ../deps/GraphBLAS JOBS=$(JOBS) CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)' -DCMAKE_CXX_COMPILER='$(CC)'" library
 endif
 .PHONY: $(GRAPHBLAS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,11 +26,9 @@ CFLAGS += $(DEBUGFLAGS)
 # Compile flags for linux / osx
 ifeq ($(uname_S),Linux)
 	SHOBJ_LDFLAGS ?= -shared -Bsymbolic -Bsymbolic-functions -ldl -lpthread -fopenmp
-	JOBS := $(shell grep -c ^processor /proc/cpuinfo)
 else
 	CFLAGS += -mmacosx-version-min=10.14
 	SHOBJ_LDFLAGS ?= -mmacosx-version-min=10.14 -bundle -undefined dynamic_lookup -ldl -lpthread -fopenmp
-	JOBS := $(shell sysctl -n hw.logicalcpu_max)
 endif
 SHOBJ_LDFLAGS += $(LDFLAGS)
 export CFLAGS
@@ -126,7 +124,7 @@ $(LIBXXHASH):
 # Build GraphBLAS only if library does not already exists.
 $(GRAPHBLAS):
 ifeq (,$(wildcard $(GRAPHBLAS)))
-	@$(MAKE) -C ../deps/GraphBLAS JOBS=$(JOBS) CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)' -DCMAKE_CXX_COMPILER='$(CC)'" library
+	@$(MAKE) -C ../deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)' -DCMAKE_CXX_COMPILER='$(CC)'" library
 endif
 .PHONY: $(GRAPHBLAS)
 


### PR DESCRIPTION
This PR sets GraphBLAS `JOBS` build argument to be the maximal amount of logical CPU in the machine.