### PR TITLE
Don't override GraphBLAS C++ compiler

### DIFF
--- a/deps/GraphBLAS/Makefile
+++ b/deps/GraphBLAS/Makefile
@@ -40,6 +40,9 @@ cmake:
 # the same as "make library"
 static: library
 
+static_only:
+	( cd build ; cmake $(CMAKE_OPTIONS) .. ; $(MAKE) --jobs=$(JOBS) graphblas_static )
+
 # installs GraphBLAS to the install location defined by cmake, usually
 # /usr/local/lib and /usr/local/include
 install:

--- a/deps/GraphBLAS/README.md
+++ b/deps/GraphBLAS/README.md
@@ -3,7 +3,7 @@
 SuiteSparse:GraphBLAS, Timothy A. Davis, (c) 2017-2019, All Rights Reserved.
 http://suitesparse.com   See GraphBLAS/Doc/License.txt for license.
 
-VERSION 3.0.1, July 26, 2019
+VERSION 3.0.2, July 26, 2019
 
 SuiteSparse:GraphBLAS is an full implementation of the GraphBLAS standard,
 which defines a set of sparse matrix operations on an extended algebra of

--- a/deps/GraphBLAS/README.md
+++ b/deps/GraphBLAS/README.md
@@ -3,7 +3,7 @@
 SuiteSparse:GraphBLAS, Timothy A. Davis, (c) 2017-2019, All Rights Reserved.
 http://suitesparse.com   See GraphBLAS/Doc/License.txt for license.
 
-VERSION 3.0.2, July 26, 2019
+VERSION 3.0.1, July 26, 2019
 
 SuiteSparse:GraphBLAS is an full implementation of the GraphBLAS standard,
 which defines a set of sparse matrix operations on an extended algebra of

--- a/src/Makefile
+++ b/src/Makefile
@@ -124,7 +124,7 @@ $(LIBXXHASH):
 # Build GraphBLAS only if library does not already exists.
 $(GRAPHBLAS):
 ifeq (,$(wildcard $(GRAPHBLAS)))
-	@$(MAKE) -C ../deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)'" library
+	@$(MAKE) -C ../deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)'" static_only
 endif
 .PHONY: $(GRAPHBLAS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -124,7 +124,7 @@ $(LIBXXHASH):
 # Build GraphBLAS only if library does not already exists.
 $(GRAPHBLAS):
 ifeq (,$(wildcard $(GRAPHBLAS)))
-	@$(MAKE) -C ../deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)' -DCMAKE_CXX_COMPILER='$(CC)'" library
+	@$(MAKE) -C ../deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)'" library
 endif
 .PHONY: $(GRAPHBLAS)
 


### PR DESCRIPTION
I needed this change in order to compile locally.

(The README update was automated, I'm not sure why it didn't occur for you!)