### PR TITLE
Fix referenced alias validations for WITH and WHERE clauses

### DIFF
--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -80,3 +80,22 @@ class testQueryValidationFlow(FlowTestsBase):
         except redis.exceptions.ResponseError:
             # Expecting an error.
             pass
+
+    def test06_where_references(self):
+        try:
+            query = """MATCH (a) WHERE fake = true RETURN a"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError:
+            # Expecting an error.
+            pass
+
+    def test07_with_references(self):
+        try:
+            query = """MATCH (a) WITH e RETURN e"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError:
+            # Expecting an error.
+            pass
+


### PR DESCRIPTION
Resolves #651 (as well as some slightly more complicated failures of the same type in WITH clauses).