### PR TITLE
fix MOD331 - add graph deletion indication

### DIFF
--- a/src/commands/cmd_delete.c
+++ b/src/commands/cmd_delete.c
@@ -48,8 +48,11 @@ void _MGraph_Delete(void *args) {
 
 	// Remove GraphContext from keyspace.
 	if(RedisModule_DeleteKey(key) == REDISMODULE_OK) {
-		// Report query runtime.
-		ResultSet_ReportQueryRuntime(ctx);
+		char *strElapsed;
+		double t = QueryCtx_GetExecutionTime();
+		asprintf(&strElapsed, "Graph removed, internal execution time: %.6f milliseconds", t);
+		RedisModule_ReplyWithStringBuffer(ctx, strElapsed, strlen(strElapsed));
+		free(strElapsed);
 	} else {
 		Graph_ReleaseLock(gc->g);
 		RedisModule_ReplyWithError(ctx, "Graph deletion failed!");


### PR DESCRIPTION
revert a change in cmd_delete to a previous version which adds the information about graph deletion instead just showing statistics.