### PR TITLE
Fix transpose logic for traversals with non-scan children

### DIFF
--- a/src/execution_plan/ops/op_cond_var_len_traverse.c
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.c
@@ -65,6 +65,7 @@ OpBase *NewCondVarLenTraverseOp(Graph *g, RecordMap *record_map, AlgebraicExpres
 	condVarLenTraverse->minHops = ae->edge->minHops;
 	condVarLenTraverse->maxHops = ae->edge->maxHops;
 	condVarLenTraverse->allPathsCtx = NULL;
+	// The AlgebraicExpression populating a variable-length traversal only contains one operand.
 	condVarLenTraverse->traverseDir = (ae->operands[0].transpose) ? GRAPH_EDGE_DIR_INCOMING :
 									  GRAPH_EDGE_DIR_OUTGOING;
 	condVarLenTraverse->r = NULL;
@@ -167,3 +168,4 @@ void CondVarLenTraverseFree(OpBase *ctx) {
 		op->allPathsCtx = NULL;
 	}
 }
+

--- a/tests/flow/test_relation_patterns.py
+++ b/tests/flow/test_relation_patterns.py
@@ -211,3 +211,19 @@ class testRelationPattern(FlowTestsBase):
                            ['v3', 'v5'],
                            ['v4', 'v5']]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    # Test traversals over transposed edge matrices.
+    def test06_transposed_traversals(self):
+        # The intermediate node 'b' will be used to form the scan operation because it is filtered.
+        # As such, one of the traversals must be transposed.
+        query = """MATCH (a)-[e]->(b {val:'v3'})-[]->(c:L) RETURN COUNT(e)"""
+        plan = redis_graph.execution_plan(query)
+
+        # Verify that the execution plan contains two traversals following opposing edge directions.
+        self.env.assertIn("<-", plan)
+        self.env.assertIn("->", plan)
+
+        # Verify results.
+        actual_result = redis_graph.query(query)
+        expected_result = [[1]]
+        self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
Resolves MOD-340

This PR fixes a bug in which conditional traversals over transposed edge matrices didn't determine the traversal direction properly if the edge matrix wasn't the first operand. 