### PR TITLE
create graph if not exists

### DIFF
--- a/src/commands/cmd_delete.c
+++ b/src/commands/cmd_delete.c
@@ -22,7 +22,6 @@ void _MGraph_Delete(void *args) {
 	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(dCtx);
 	CommandCtx_ThreadSafeContextLock(dCtx);
 	GraphContext_Delete(ctx, dCtx->graphName);
-
 	CommandCtx_ThreadSafeContextUnlock(dCtx);
 	CommandCtx_Free(dCtx);
 	QueryCtx_Free(); // Reset the QueryCtx and free its allocations.

--- a/src/commands/cmd_delete.c
+++ b/src/commands/cmd_delete.c
@@ -20,46 +20,9 @@ extern RedisModuleType *GraphContextRedisModuleType;
 void _MGraph_Delete(void *args) {
 	CommandCtx *dCtx = (CommandCtx *)args;
 	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(dCtx);
-
-	QueryCtx_BeginTimer(); // Start deletion timing.
-
-	RedisModuleString *graph_name = RedisModule_CreateString(ctx, dCtx->graphName,
-															 strlen(dCtx->graphName));
 	CommandCtx_ThreadSafeContextLock(dCtx);
+	GraphContext_Delete(ctx, dCtx->graphName);
 
-	RedisModuleKey *key = RedisModule_OpenKey(ctx, graph_name, REDISMODULE_WRITE);
-	int keytype = RedisModule_KeyType(key);
-	if(keytype == REDISMODULE_KEYTYPE_EMPTY) {
-		RedisModule_ReplyWithError(ctx, "Graph was not found in database.");
-		goto cleanup;
-	} else if(keytype != REDISMODULE_KEYTYPE_MODULE) {
-		RedisModule_ReplyWithError(ctx, "Specified graph name referred to incorrect key type.");
-		goto cleanup;
-	}
-
-	// Retrieve the GraphContext to disable synchronization.
-	GraphContext *gc = RedisModule_ModuleTypeGetValue(key);
-
-	// Acquire write lock, guarantee we're the only thread executing.
-	Graph_AcquireWriteLock(gc->g);
-
-	// Disable matrix synchronization for graph deletion.
-	Graph_SetMatrixPolicy(gc->g, DISABLED);
-
-	// Remove GraphContext from keyspace.
-	if(RedisModule_DeleteKey(key) == REDISMODULE_OK) {
-		char *strElapsed;
-		double t = QueryCtx_GetExecutionTime();
-		asprintf(&strElapsed, "Graph removed, internal execution time: %.6f milliseconds", t);
-		RedisModule_ReplyWithStringBuffer(ctx, strElapsed, strlen(strElapsed));
-		free(strElapsed);
-	} else {
-		Graph_ReleaseLock(gc->g);
-		RedisModule_ReplyWithError(ctx, "Graph deletion failed!");
-	}
-
-cleanup:
-	RedisModule_Free(graph_name);
 	CommandCtx_ThreadSafeContextUnlock(dCtx);
 	CommandCtx_Free(dCtx);
 	QueryCtx_Free(); // Reset the QueryCtx and free its allocations.

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -67,7 +67,7 @@ void _MGraph_Explain(void *args) {
 
 	// Retrieve the GraphContext and acquire a read lock.
 	if(graphname) {
-		gc = GraphContext_Retrieve(ctx, graphname, true);
+		gc = GraphContext_Retrieve(qctx, graphname, true);
 	} else {
 		free_graph_ctx = true;
 		gc = _empty_graph_context();

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -68,14 +68,6 @@ void _MGraph_Explain(void *args) {
 	// Retrieve the GraphContext and acquire a read lock.
 	if(graphname) {
 		gc = GraphContext_Retrieve(ctx, graphname, true);
-		if(!gc) {
-			gc = GraphContext_New(ctx, qctx->graphName, GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
-			if(!gc) {
-				CommandCtx_ThreadSafeContextUnlock(qctx);
-				RedisModule_ReplyWithError(ctx, "Graph name already in use as a Redis key.");
-				goto cleanup;
-			}
-		}
 	} else {
 		free_graph_ctx = true;
 		gc = _empty_graph_context();

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -69,8 +69,12 @@ void _MGraph_Explain(void *args) {
 	if(graphname) {
 		gc = GraphContext_Retrieve(ctx, graphname, true);
 		if(!gc) {
-			RedisModule_ReplyWithError(ctx, "key doesn't contains a graph object.");
-			goto cleanup;
+			gc = GraphContext_New(ctx, qctx->graphName, GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
+			if(!gc) {
+				CommandCtx_ThreadSafeContextUnlock(qctx);
+				RedisModule_ReplyWithError(ctx, "Graph name already in use as a Redis key.");
+				goto cleanup;
+			}
 		}
 	} else {
 		free_graph_ctx = true;

--- a/src/commands/cmd_profile.c
+++ b/src/commands/cmd_profile.c
@@ -40,18 +40,6 @@ void _MGraph_Profile(void *args) {
 	// Try to access the GraphContext
 	CommandCtx_ThreadSafeContextLock(qctx);
 	GraphContext *gc = GraphContext_Retrieve(ctx, qctx->graphName, readonly);
-	if(!gc) {
-
-		gc = GraphContext_New(ctx, qctx->graphName, GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
-		if(!gc) {
-			CommandCtx_ThreadSafeContextUnlock(qctx);
-			RedisModule_ReplyWithError(ctx, "Graph name already in use as a Redis key.");
-			goto cleanup;
-		}
-		// If in readonly mode, retrive key in read only privileges
-		if(readonly) gc = GraphContext_Retrieve(ctx, qctx->graphName, readonly);
-		// TODO: free graph if no entities were created.
-	}
 
 	CommandCtx_ThreadSafeContextUnlock(qctx);
 

--- a/src/commands/cmd_profile.c
+++ b/src/commands/cmd_profile.c
@@ -38,10 +38,7 @@ void _MGraph_Profile(void *args) {
 	ast = AST_Build(parse_result);
 
 	// Try to access the GraphContext
-	CommandCtx_ThreadSafeContextLock(qctx);
-	GraphContext *gc = GraphContext_Retrieve(ctx, qctx->graphName, readonly);
-
-	CommandCtx_ThreadSafeContextUnlock(qctx);
+	GraphContext *gc = GraphContext_Retrieve(qctx, qctx->graphName, readonly);
 
 	// Acquire the appropriate lock.
 	if(readonly) Graph_AcquireReadLock(gc->g);

--- a/src/commands/cmd_profile.c
+++ b/src/commands/cmd_profile.c
@@ -41,19 +41,15 @@ void _MGraph_Profile(void *args) {
 	CommandCtx_ThreadSafeContextLock(qctx);
 	GraphContext *gc = GraphContext_Retrieve(ctx, qctx->graphName, readonly);
 	if(!gc) {
-		if(!AST_ContainsClause(ast, CYPHER_AST_CREATE) &&
-		   !AST_ContainsClause(ast, CYPHER_AST_MERGE)) {
-			CommandCtx_ThreadSafeContextUnlock(qctx);
-			RedisModule_ReplyWithError(ctx, "key doesn't contains a graph object.");
-			goto cleanup;
-		}
-		assert(!readonly);
+
 		gc = GraphContext_New(ctx, qctx->graphName, GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
 		if(!gc) {
 			CommandCtx_ThreadSafeContextUnlock(qctx);
 			RedisModule_ReplyWithError(ctx, "Graph name already in use as a Redis key.");
 			goto cleanup;
 		}
+		// If in readonly mode, retrive key in read only privileges
+		if(readonly) gc = GraphContext_Retrieve(ctx, qctx->graphName, readonly);
 		// TODO: free graph if no entities were created.
 	}
 

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -93,12 +93,8 @@ void _MGraph_Query(void *args) {
 	CommandCtx_ThreadSafeContextLock(qctx);
 	GraphContext *gc = GraphContext_Retrieve(ctx, qctx->graphName, readonly);
 	if(!gc) {
-		if(!AST_ContainsClause(ast, CYPHER_AST_CREATE) &&
-		   !AST_ContainsClause(ast, CYPHER_AST_MERGE)) {
-			CommandCtx_ThreadSafeContextUnlock(qctx);
-			RedisModule_ReplyWithError(ctx, "key doesn't contains a graph object.");
-			goto cleanup;
-		}
+
+		// Create.
 		gc = GraphContext_New(ctx, qctx->graphName, GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
 
 		if(!gc) {
@@ -106,6 +102,8 @@ void _MGraph_Query(void *args) {
 			RedisModule_ReplyWithError(ctx, "Graph name already in use as a Redis key.");
 			goto cleanup;
 		}
+		// If in readonly mode, retrive key in read only privileges
+		if(readonly) gc = GraphContext_Retrieve(ctx, qctx->graphName, readonly);
 		/* TODO: free graph if no entities were created. */
 	}
 	CommandCtx_ThreadSafeContextUnlock(qctx);

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -92,20 +92,7 @@ void _MGraph_Query(void *args) {
 	// Try to access the GraphContext
 	CommandCtx_ThreadSafeContextLock(qctx);
 	GraphContext *gc = GraphContext_Retrieve(ctx, qctx->graphName, readonly);
-	if(!gc) {
 
-		// Create.
-		gc = GraphContext_New(ctx, qctx->graphName, GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
-
-		if(!gc) {
-			CommandCtx_ThreadSafeContextUnlock(qctx);
-			RedisModule_ReplyWithError(ctx, "Graph name already in use as a Redis key.");
-			goto cleanup;
-		}
-		// If in readonly mode, retrive key in read only privileges
-		if(readonly) gc = GraphContext_Retrieve(ctx, qctx->graphName, readonly);
-		/* TODO: free graph if no entities were created. */
-	}
 	CommandCtx_ThreadSafeContextUnlock(qctx);
 
 	bool compact = _check_compact_flag(qctx);

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -89,11 +89,7 @@ void _MGraph_Query(void *args) {
 	// Prepare the constructed AST for accesses from the module
 	ast = AST_Build(parse_result);
 
-	// Try to access the GraphContext
-	CommandCtx_ThreadSafeContextLock(qctx);
-	GraphContext *gc = GraphContext_Retrieve(ctx, qctx->graphName, readonly);
-
-	CommandCtx_ThreadSafeContextUnlock(qctx);
+	GraphContext *gc = GraphContext_Retrieve(qctx, qctx->graphName, readonly);
 
 	bool compact = _check_compact_flag(qctx);
 

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -34,6 +34,9 @@ GraphContext *GraphContext_New(RedisModuleCtx *ctx, const char *graphname,
 // readOnly is the access mode to the graph key
 GraphContext *GraphContext_Retrieve(RedisModuleCtx *ctx, const char *graphname, bool readOnly);
 
+// Deletes a graph context from the module, according to the graph name.
+void GraphContext_Delete(RedisModuleCtx *ctx, const char *graphname);
+
 /* Schema API */
 // Retrieve number of schemas created for given type.
 unsigned short GraphContext_SchemaCount(const GraphContext *gc, SchemaType t);

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -11,6 +11,7 @@
 #include "../redismodule.h"
 #include "../index/index.h"
 #include "../schema/schema.h"
+#include "../commands/cmd_context.h"
 #include "graph.h"
 
 typedef struct {
@@ -27,15 +28,11 @@ typedef struct {
 } GraphContext;
 
 /* GraphContext API */
-GraphContext *GraphContext_New(RedisModuleCtx *ctx, const char *graphname,
-							   size_t node_cap, size_t edge_cap);
-
-// Retrive the graph context according to the graph name
-// readOnly is the access mode to the graph key
-GraphContext *GraphContext_Retrieve(RedisModuleCtx *ctx, const char *graphname, bool readOnly);
-
+/* Retrive the graph context according to the graph name
+ * readOnly is the access mode to the graph key */
+GraphContext *GraphContext_Retrieve(CommandCtx *cmdCtx, const char *graphName, bool readOnly);
 // Deletes a graph context from the module, according to the graph name.
-void GraphContext_Delete(RedisModuleCtx *ctx, const char *graphname);
+void GraphContext_Delete(RedisModuleCtx *ctx, const char *graphName);
 
 /* Schema API */
 // Retrieve number of schemas created for given type.
@@ -46,21 +43,16 @@ Schema *GraphContext_GetSchemaByID(const GraphContext *gc, int id, SchemaType t)
 Schema *GraphContext_GetSchema(const GraphContext *gc, const char *label, SchemaType t);
 // Add a new schema and matrix for the given label
 Schema *GraphContext_AddSchema(GraphContext *gc, const char *label, SchemaType t);
-
 // Retrieve the label string for a given Node object
 const char *GraphContext_GetNodeLabel(const GraphContext *gc, Node *n);
 // Retrieve the relation type string for a given Edge object
 const char *GraphContext_GetEdgeRelationType(const GraphContext *gc, Edge *e);
-
 // Retrieve number of unique attribute keys
 uint GraphContext_AttributeCount(GraphContext *gc);
-
 // Retrieve an attribute ID given a string, creating one if not found
 Attribute_ID GraphContext_FindOrAddAttribute(GraphContext *gc, const char *attribute);
-
 // Retrieve an attribute string given an ID
 const char *GraphContext_GetAttributeString(const GraphContext *gc, Attribute_ID id);
-
 // Retrieve an attribute ID given a string, or ATTRIBUTE_NOTFOUND if attribute doesn't exist.
 Attribute_ID GraphContext_GetAttributeID(const GraphContext *gc, const char *str);
 

--- a/src/module.c
+++ b/src/module.c
@@ -57,7 +57,10 @@ static int _RegisterDataTypes(RedisModuleCtx *ctx) {
 }
 
 static void _PrepareModuleGlobals() {
-	assert(pthread_mutex_init(&_module_mutex, NULL) == 0);
+	pthread_mutexattr_t attr;
+	pthread_mutexattr_init(&attr);
+	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+	assert(pthread_mutex_init(&_module_mutex, &attr) == 0);
 	graphs_in_keyspace = array_new(GraphContext *, 1);
 	process_is_child = false;
 }

--- a/src/module.c
+++ b/src/module.c
@@ -26,7 +26,6 @@
 //------------------------------------------------------------------------------
 // Module-level global variables
 //------------------------------------------------------------------------------
-pthread_mutex_t _module_mutex;     // Module-level lock.
 GraphContext **graphs_in_keyspace; // Global array tracking all extant GraphContexts.
 bool process_is_child;             // Flag indicating whether the running process is a child.
 
@@ -57,10 +56,6 @@ static int _RegisterDataTypes(RedisModuleCtx *ctx) {
 }
 
 static void _PrepareModuleGlobals() {
-	pthread_mutexattr_t attr;
-	pthread_mutexattr_init(&attr);
-	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
-	assert(pthread_mutex_init(&_module_mutex, &attr) == 0);
 	graphs_in_keyspace = array_new(GraphContext *, 1);
 	process_is_child = false;
 }
@@ -71,10 +66,6 @@ static void RG_ForkPrepare() {
 	 * the child process will deadlock when attempting to acquire that lock.
 	 * 1. If a writer thread is active, we'll wait until the writer finishes and releases the lock.
 	 * 2. Otherwise, no write in progress. Acquire the lock and release it immediately after forking. */
-
-	/* Acquire the module-scoped lock to ensure that no graphs are created or deleted during the
-	 * lock acquisition process. It will be released after forking. */
-	assert(pthread_mutex_lock(&_module_mutex) == 0);
 
 	uint graph_count = array_len(graphs_in_keyspace);
 	for(uint i = 0; i < graph_count; i++) {
@@ -93,7 +84,6 @@ static void RG_AfterForkParent() {
 		Graph_ReleaseLock(graphs_in_keyspace[i]->g);
 	}
 
-	assert(pthread_mutex_unlock(&_module_mutex) == 0); // Release the module-scoped lock.
 }
 
 static void RG_AfterForkChild() {

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -164,6 +164,8 @@ class testGraphDeletionFlow(FlowTestsBase):
         # Try to query a deleted graph should raise an exception.
         try:
             redis_graph.query(query)
-            self.env.assertTrue(False)
+            result = redis_graph.query(query)
+            nodeCount = result.result_set[0][0]
+            self.env.assertEquals(nodeCount, 0)
         except:
-            pass
+             self.env.assertTrue(False)

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -168,4 +168,4 @@ class testGraphDeletionFlow(FlowTestsBase):
             nodeCount = result.result_set[0][0]
             self.env.assertEquals(nodeCount, 0)
         except:
-             self.env.assertTrue(False)
+            self.env.false()


### PR DESCRIPTION
This PR creates a new empty graph for queries that should execute, even if the graph does not exist. This PR removes the need to create at least one node to execute a query.

This PR closes #666 as well as long-awaited behavioral enhancement.