### PR TITLE
Add LGTM.com configuration file

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,11 @@
+extraction:
+  cpp:
+     prepare:
+        packages: 
+          - build-essential
+          - cmake
+          - m4
+          - automake
+          - peg
+          - libtool
+          - autoconf


### PR DESCRIPTION
[LGTM.com](https://lgtm.com/projects/g/RedisGraph/RedisGraph) needs to have some Debian packages installed for it to analyze the C++ code of the `RedisGraph`. The committed file needs to be in the root of the repository to be picked up by LGTM.com and it contains instructions on what packages it should install before attempting to build a project.

It currently faiIs to build `RedisGraph` due to missing package `peg`. To be future proof (should LGTM.com base environment change), this `lgtm.yml` file contains all packages that are listed in the `RedisGraph` docs as the packages necessary for building a project.

I'd appreciate if you would let this file to be added so that the open-source community would be able to investigate potential code issues in the codebase of `RedisGraph`.

Thank you.