### PR TITLE
must not free execution plan record-map before freeing individual ope…

### DIFF
--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -914,27 +914,22 @@ static void _ExecutionPlan_FreeSegment(ExecutionPlan *plan) {
 
 void ExecutionPlan_Free(ExecutionPlan *plan) {
 	if(plan == NULL) return;
+	_ExecutionPlan_FreeOperations(plan->root);
 
-	// All segments but the last should have everything but
-	// their operation chain freed.
-	// The last segment is the actual plan passed as an argument to this function.
-	// TODO this logic isn't ideal, try to improve.
-	for(int i = 0; i < plan->segment_count - 1; i++) {
-		_ExecutionPlan_FreeSegment(plan->segments[i]);
-	}
+	/* All segments but the last should have everything but
+	 * their operation chain freed.
+	 * The last segment is the actual plan passed as an argument to this function.
+	 * TODO this logic isn't ideal, try to improve. */
+	for(int i = 0; i < plan->segment_count - 1; i++) _ExecutionPlan_FreeSegment(plan->segments[i]);
 	rm_free(plan->segments);
 
 	if(plan->connected_components) {
 		uint connected_component_count = array_len(plan->connected_components);
-		for(uint i = 0; i < connected_component_count; i ++) {
-			QueryGraph_Free(plan->connected_components[i]);
-		}
+		for(uint i = 0; i < connected_component_count; i ++) QueryGraph_Free(plan->connected_components[i]);
 		array_free(plan->connected_components);
 	}
 
 	QueryGraph_Free(plan->query_graph);
-	_ExecutionPlan_FreeOperations(plan->root);
 	raxFree(plan->record_map);
 	rm_free(plan);
 }
-

--- a/src/execution_plan/ops/op_cartesian_product.c
+++ b/src/execution_plan/ops/op_cartesian_product.c
@@ -78,10 +78,7 @@ static Record CartesianProductConsume(OpBase *opBase) {
 		for(int i = 0; i < op->op.childCount; i++) {
 			child = op->op.children[i];
 			childRecord = OpBase_Consume(child);
-			if(!childRecord) {
-				// TODO: leak childRecord.
-				return NULL;
-			}
+			if(!childRecord) return NULL;
 			Record_TransferEntries(&op->r, childRecord);
 			Record_Free(childRecord);
 		}


### PR DESCRIPTION
…ration as those might relay on the mapping, as in freeing cached records