### PR TITLE
Fix entity resolution in Value Hash Join insertions

### DIFF
--- a/src/execution_plan/optimizations/apply_join.c
+++ b/src/execution_plan/optimizations/apply_join.c
@@ -42,7 +42,7 @@ static bool _stream_resolves_entities(const OpBase *root, rax *entities) {
 		uint modifies_count = array_len(root->modifies);
 		for(uint i = 0; i < modifies_count; i++) {
 			const char *modified = root->modifies[i];
-			raxRemove(entities, (unsigned char *)&modified, sizeof(modified), NULL);
+			raxRemove(entities, (unsigned char *)modified, strlen(modified), NULL);
 		}
 	}
 


### PR DESCRIPTION
This PR resolves a regression in alias resolution when attempting to replace Cartesian Products with ValueHashJoin ops.