### PR TITLE
Allow Cartesian products of N streams to be optimized with join ops

### DIFF
--- a/src/execution_plan/execution_plan.h
+++ b/src/execution_plan/execution_plan.h
@@ -31,6 +31,9 @@ struct ExecutionPlan {
 /* Removes operation from execution plan. */
 void ExecutionPlan_RemoveOp(ExecutionPlan *plan, OpBase *op);
 
+/* Detaches operation from its parent. */
+void ExecutionPlan_DetachOp(OpBase *op);
+
 /* Adds operation to execution plan as a child of parent. */
 void ExecutionPlan_AddOp(OpBase *parent, OpBase *newOp);
 

--- a/src/execution_plan/execution_plan_modify.c
+++ b/src/execution_plan/execution_plan_modify.c
@@ -151,6 +151,7 @@ OpBase **ExecutionPlan_LocateOps(OpBase *root, OPType type) {
 	return ops;
 }
 
+// Introduce the new operation B between A and A's parent op.
 void ExecutionPlan_PushBelow(OpBase *a, OpBase *b) {
 	/* B is a new operation. */
 	assert(!(b->parent || b->children));
@@ -211,6 +212,17 @@ void ExecutionPlan_RemoveOp(ExecutionPlan *plan, OpBase *op) {
 	rm_free(op->children);
 	op->children = NULL;
 	op->childCount = 0;
+}
+
+void ExecutionPlan_DetachOp(OpBase *op) {
+	// Operation has no parent.
+	if(op->parent == NULL) return;
+
+	// Remove op from its parent.
+	OpBase *parent = op->parent;
+	_OpBase_RemoveChild(op->parent, op);
+
+	op->parent = NULL;
 }
 
 OpBase *ExecutionPlan_LocateOpResolvingAlias(OpBase *root, const char *alias) {

--- a/src/execution_plan/optimizations/apply_join.c
+++ b/src/execution_plan/optimizations/apply_join.c
@@ -11,6 +11,8 @@
 #include "../ops/op_value_hash_join.h"
 #include "../ops/op_cartesian_product.h"
 
+#define NOT_RESOLVED -1
+
 // Tests to see if given filter can act as a join condition.
 static inline bool _applicableFilter(const FT_FilterNode *f) {
 	// Can only convert filters that test equality
@@ -29,165 +31,168 @@ static OpFilter **_locate_filters(OpBase *cp) {
 	OpFilter **filters = array_new(OpFilter *, 0);
 
 	while(parent && parent->type == OPType_FILTER) {
-		filters = array_append(filters, (OpFilter *)parent);
+		OpFilter *filter_op = (OpFilter *)parent;
+		if(_applicableFilter(filter_op->filterTree)) filters = array_append(filters, filter_op);
 		parent = parent->parent;
 	}
 
 	return filters;
 }
 
-// Tests if stream resolves all entities.
-static bool _stream_resolves_entities(const OpBase *root, rax *entities) {
+// Collect all resolved entities on an operation chain.
+static void _stream_collect_entities(const OpBase *root, rax *entities) {
 	if(root->modifies) {
 		uint modifies_count = array_len(root->modifies);
 		for(uint i = 0; i < modifies_count; i++) {
 			const char *modified = root->modifies[i];
-			raxRemove(entities, (unsigned char *)modified, strlen(modified), NULL);
+			raxInsert(entities, (unsigned char *)modified, strlen(modified), NULL, NULL);
 		}
 	}
-
-	if(raxSize(entities) == 0) return true;
 
 	for(int i = 0; i < root->childCount; i++) {
-		if(_stream_resolves_entities(root->children[i], entities)) {
-			return true;
+		_stream_collect_entities(root->children[i], entities);
+	}
+}
+
+// Returns true if the stream resolves all required entities.
+static bool _stream_resolves_entities(rax *stream_resolves, rax *entities_to_resolve) {
+	bool resolved_all = true;
+	raxIterator it;
+	raxStart(&it, entities_to_resolve);
+
+	raxSeek(&it, "^", NULL, 0);
+	while(raxNext(&it)) {
+		if(raxFind(stream_resolves, it.key, it.key_len) == raxNotFound) {
+			resolved_all = false;
+			break;
 		}
 	}
 
-	return false;
+	raxStop(&it);
+	return resolved_all;
 }
 
-/* filter is composed of two expressions:
- * left and right hand side
- * to apply a join operation each expression
- * must be entirely resolved by one of the branches
- * either left or right of the cartesian product operation
- * _relate_exp_to_stream will try to associate each expression
- * lhs and rhs with the appropriate branch. */
-static void _relate_exp_to_stream(const OpBase *cp, const FT_FilterNode *f, AR_ExpNode **lhs,
-								  AR_ExpNode **rhs) {
-	*lhs = NULL;
-	*rhs = NULL;
-	bool expression_resolved = true;
-
-	AR_ExpNode *lhs_exp = f->pred.lhs;
-	AR_ExpNode *rhs_exp = f->pred.rhs;
-
-	assert(cp->childCount == 2);
-	OpBase *left_child = cp->children[0];
-	OpBase *right_child = cp->children[1];
-
+/* Given an expression node from a filter tree, returns the stream number
+ * that fully resolves the expression's references. */
+static int _relate_exp_to_stream(AR_ExpNode *exp, rax **stream_entities, int stream_count) {
+	// Collect the referenced entities in the expression.
 	rax *entities = raxNew();
+	AR_EXP_CollectEntities(exp, entities);
 
-	/* Make sure LHS and RHS expressions can be resolved.
-	 * Left expression - Left branch
-	 * Right expression - Right branch */
-	AR_EXP_CollectEntities(lhs_exp, entities);
-	if(_stream_resolves_entities(left_child, entities)) {
-		// entities is now empty.
-		AR_EXP_CollectEntities(rhs_exp, entities);
-		if(_stream_resolves_entities(right_child, entities)) {
-			*lhs = lhs_exp;
-			*rhs = rhs_exp;
-			raxFree(entities);
-			return;
-		}
+	int stream_num;
+	for(stream_num = 0; stream_num < stream_count; stream_num ++) {
+		// See if the stream resolves all of the references.
+		if(_stream_resolves_entities(stream_entities[stream_num], entities)) break;
 	}
-
-	/* Left expression - Right branch
-	 * Right expression - Left branch */
-	*lhs = NULL;
-	*rhs = NULL;
-
 	raxFree(entities);
-	entities = raxNew();
 
-	AR_EXP_CollectEntities(lhs_exp, entities);
-	if(_stream_resolves_entities(right_child, entities)) {
-		// entities is now empty.
-		AR_EXP_CollectEntities(rhs_exp, entities);
-		if(_stream_resolves_entities(left_child, entities)) {
-			*lhs = rhs_exp;
-			*rhs = lhs_exp;
-			raxFree(entities);
-			return;
-		}
-	}
-
-	// Couldn't completely resolve either lhs_exp or rhs_exp.
-	*lhs = NULL;
-	*rhs = NULL;
-	raxFree(entities);
+	if(stream_num == stream_count) return NOT_RESOLVED; // No stream resolved all references.
+	return stream_num;
 }
 
-/* Try to replace cartesian product with a value hash join operation */
+// TODO: Consider changing Cartesian Products such that each has exactly two child operations.
+/* Try to replace Cartesian Products (cross joins) with Value Hash Joins.
+ * This is viable when a Cartesian Product is combining two streams that each satisfies
+ * one side of an EQUALS filter operation, like:
+ * MATCH (a), (b) WHERE ID(a) = ID(b) */
 void applyJoin(ExecutionPlan *plan) {
 	OpBase **cps = ExecutionPlan_LocateOps(plan->root, OPType_CARTESIAN_PRODUCT);
-	int cp_count = array_len(cps);
+	uint cp_count = array_len(cps);
 
-	for(int i = 0; i < cp_count; i++) {
+	for(uint i = 0; i < cp_count; i++) {
 		OpBase *cp = cps[i];
-		/* TODO: change the way our cartesian product
-		 * today we alow for cartesian product with > 2 child ops
-		 * I think it might be better to create a chain of cartesian products
-		 * where each pulls from exactly 2 streams
-		 * consider: MATCH a,b,c WHERE a.v = b.v. */
-		if(cp->childCount != 2) continue;
-		OpFilter **filters = _locate_filters(cp);
 
-		int filter_count = array_len(filters);
+		// Retrieve all equality filter operations located upstream from the Cartesian Product.
+		OpFilter **filter_ops = _locate_filters(cp);
+
+		uint filter_count = array_len(filter_ops);
+		if(filter_count == 0) { // No matching filter ops were found.
+			array_free(filter_ops);
+			continue;
+		}
+
+		// For each stream joined by the Cartesian product, collect all entities the stream resolves.
+		int stream_count = cp->childCount;
+		rax *stream_entities[stream_count];
+		for(int j = 0; j < stream_count; j ++) {
+			stream_entities[j] = raxNew();
+			_stream_collect_entities(cp->children[j], stream_entities[j]);
+		}
+
 		for(int j = 0; j < filter_count; j++) {
-			OpFilter *filter = filters[j];
-			if(_applicableFilter(filter->filterTree)) {
-				// Reduce cartesian product to value hash join
-				AR_ExpNode *lhs = NULL;
-				AR_ExpNode *rhs = NULL;
+			// Reduce cartesian product to value hash join
+			OpFilter *filter_op = filter_ops[j];
 
-				/* Make sure lhs expression is resolved by
-				 * left stream, if not swap. */
-				_relate_exp_to_stream(cp, filter->filterTree, &lhs, &rhs);
-				/* There are cases where either lhs or rhs expressions
-				 * require data from both streams, consider:
-				 * a.v + c.v = b.v + d.v
-				 * where a and d are resolved by lhs stream and
-				 * b and c are resolved by rhs stream.
-				 * in which case we can't perform join. */
-				if(lhs == NULL || rhs == NULL) continue;
+			/* Each filter being considered here tests for equality between its left and right values.
+			 * The Cartesian Product can be replaced if both sides of the filter can be fully and
+			 * separately resolved by two child streams. */
+			FT_FilterNode *f = filter_op->filterTree;
 
-				assert(lhs != rhs);
-				lhs = AR_EXP_Clone(lhs);
-				rhs = AR_EXP_Clone(rhs);
+			/* Make sure LHS of the filter is resolved by a stream. */
+			AR_ExpNode *lhs = f->pred.lhs;
+			uint lhs_resolving_stream = _relate_exp_to_stream(lhs, stream_entities, stream_count);
+			if(lhs_resolving_stream == NOT_RESOLVED) continue;
 
-				/* In order to reduce value-hash-join cache size
-				 * prefer to cache a branch which will produce the smallest number
-				 * of records, currently prefer a branch with a filter. */
-				OpBase *left_branch = cp->children[0];
-				OpBase *right_branch = cp->children[1];
-				bool left_branch_filtered = (ExecutionPlan_LocateOp(left_branch, OPType_FILTER) != NULL);
-				bool right_branch_filtered = (ExecutionPlan_LocateOp(right_branch, OPType_FILTER) != NULL);
-				if(!left_branch_filtered && right_branch_filtered) {
-					// Swap branches!
-					cp->children[0] = right_branch;
-					cp->children[1] = left_branch;
+			/* Make sure RHS of the filter is resolved by a stream. */
+			AR_ExpNode *rhs = f->pred.rhs;
+			uint rhs_resolving_stream = _relate_exp_to_stream(rhs, stream_entities, stream_count);
+			if(rhs_resolving_stream == NOT_RESOLVED) continue;
 
-					AR_ExpNode *t = lhs;
-					lhs = rhs;
-					rhs = t;
-				}
+			assert(lhs != rhs);
+			assert(lhs_resolving_stream != rhs_resolving_stream);
 
-				OpBase *value_hash_join = NewValueHashJoin(cp->plan, lhs, rhs);
+			// Clone the filter expressions.
+			lhs = AR_EXP_Clone(lhs);
+			rhs = AR_EXP_Clone(rhs);
 
-				/* Remove filter which is now part of the join operation
-				 * replace cartesian product with join. */
-				ExecutionPlan_RemoveOp(plan, (OpBase *)filter);
-				OpBase_Free((OpBase *)filter);
+			// Detach the streams for the Value Hash Join from the cartesian product.
+			OpBase *right_branch = cp->children[rhs_resolving_stream];
+			OpBase *left_branch = cp->children[lhs_resolving_stream];
+			ExecutionPlan_DetachOp(right_branch);
+			ExecutionPlan_DetachOp(left_branch);
+
+			OpBase *value_hash_join;
+			/* The Value Hash Join will cache its left-hand stream. To reduce the cache size,
+			 * prefer to cache the stream which will produce the smallest number of records.
+			 * Our current heuristic for this is to prefer a stream which contains a filter operation. */
+			bool left_branch_filtered = (ExecutionPlan_LocateOp(left_branch, OPType_FILTER) != NULL);
+			bool right_branch_filtered = (ExecutionPlan_LocateOp(right_branch, OPType_FILTER) != NULL);
+			if(!left_branch_filtered && right_branch_filtered) {
+				// Only the RHS stream is filtered, swap the input streams and expressions.
+				value_hash_join = NewValueHashJoin(cp->plan, rhs, lhs);
+				OpBase *t = left_branch;
+				left_branch = right_branch;
+				right_branch = t;
+			} else {
+				value_hash_join = NewValueHashJoin(cp->plan, lhs, rhs);
+			}
+
+			// The filter will now be resolved by the join operation; remove it.
+			ExecutionPlan_RemoveOp(plan, (OpBase *)filter_op);
+			OpBase_Free((OpBase *)filter_op);
+
+			if(cp->childCount == 0) {
+				// The entire Cartesian Product can be replaced with the join op.
 				ExecutionPlan_ReplaceOp(plan, cp, value_hash_join);
 				OpBase_Free(cp);
-
-				break;
+			} else {
+				// The Cartesian Product still has a child operation; introduce the join op as another child.
+				ExecutionPlan_AddOp(cp, value_hash_join);
+				// It may be possible to reduce the other child; add the Cartesian Product back into the array
+				// to be evaluated again.
+				cps = array_append(cps, cp);
+				cp_count ++;
 			}
+
+			// Add the detached streams to the join op.
+			ExecutionPlan_AddOp(value_hash_join, left_branch);
+			ExecutionPlan_AddOp(value_hash_join, right_branch);
+
+			break; // The operations have been updated, don't evaluate more filters.
 		}
-		array_free(filters);
+
+		for(int j = 0; j < stream_count; j ++) raxFree(stream_entities[j]);
+		array_free(filter_ops);
 	}
 	array_free(cps);
 }


### PR DESCRIPTION
Improve `applyJoin` logic such that join operations can replace Cartesian Products when more than 2 streams are being resolved, as discussed in #688.