### PR TITLE
avoid acquiring GIL

### DIFF
--- a/src/commands/cmd_bulk_insert.c
+++ b/src/commands/cmd_bulk_insert.c
@@ -62,7 +62,7 @@ void _MGraph_BulkInsert(void *args) {
 	}
 	argc -= 2; // already read node count and edge count
 
-	gc = GraphContext_Retrieve(cmd_ctx, graphname, false);
+	gc = GraphContext_Retrieve(ctx, graphname, false, true);
 	initial_node_count = Graph_NodeCount(gc->g);
 
 	// Lock the graph for writing.

--- a/src/commands/cmd_context.c
+++ b/src/commands/cmd_context.c
@@ -6,7 +6,7 @@ CommandCtx *CommandCtx_New
 (
 	RedisModuleCtx *ctx,
 	RedisModuleBlockedClient *bc,
-	RedisModuleString *graphName,
+	GraphContext *graph_ctx,
 	RedisModuleString *query,
 	RedisModuleString **argv,
 	int argc,
@@ -18,9 +18,7 @@ CommandCtx *CommandCtx_New
 	context->argv = argv;
 	context->argc = argc;
 	context->replicated_command = replicated_command;
-	context->graphName = NULL;
-	// Make a copy of graph name.
-	if(graphName) context->graphName = rm_strdup(RedisModule_StringPtrLen(graphName, NULL));
+	context->graph_ctx = graph_ctx;
 
 	// Make a copy of query.
 	context->query = (query) ? rm_strdup(RedisModule_StringPtrLen(query, NULL)) : NULL;
@@ -36,6 +34,11 @@ RedisModuleCtx *CommandCtx_GetRedisCtx(CommandCtx *qctx) {
 	assert(qctx->bc);
 	qctx->ctx = RedisModule_GetThreadSafeContext(qctx->bc);
 	return qctx->ctx;
+}
+
+GraphContext *CommandCtx_GetGraphContext(const CommandCtx *qctx) {
+	assert(qctx);
+	return qctx->graph_ctx;
 }
 
 void CommandCtx_ThreadSafeContextLock(const CommandCtx *qctx) {
@@ -61,7 +64,6 @@ void CommandCtx_Free(CommandCtx *qctx) {
 	}
 
 	if(qctx->query) rm_free(qctx->query);
-	if(qctx->graphName) rm_free(qctx->graphName);
 	rm_free(qctx);
 }
 

--- a/src/commands/cmd_context.h
+++ b/src/commands/cmd_context.h
@@ -7,35 +7,42 @@
 #pragma once
 
 #include "../redismodule.h"
+#include "../graph/graphcontext.h"
 #include "cypher-parser.h"
 
 /* Query context, used for concurent query processing. */
 typedef struct {
-	RedisModuleCtx *ctx;                  // Redis module context.
-	RedisModuleBlockedClient *bc;         // Blocked client.
-	char *graphName;                      // Graph ID.
-	char *query;                          // Query string.
-	RedisModuleString **argv;             // Arguments.
-	int argc;                             // Argument count.
-	bool replicated_command;              // Whether this instance was spawned by a replication command.
+	int argc;                       // Argument count.
+	char *query;                    // Query string.
+	RedisModuleCtx *ctx;            // Redis module context.
+	bool replicated_command;        // Whether this instance was spawned by a replication command.
+	GraphContext *graph_ctx;        // Graph context.
+	RedisModuleString **argv;       // Arguments.
+	RedisModuleBlockedClient *bc;   // Blocked client.
 } CommandCtx;
 
 // Create a new command context.
 CommandCtx *CommandCtx_New
 (
-	RedisModuleCtx *ctx,                  // Redis module context.
-	RedisModuleBlockedClient *bc,         // Blocked client.
-	RedisModuleString *graphName,         // Graph ID.
-	RedisModuleString *query,             // Query string.
-	RedisModuleString **argv,             // Arguments.
-	int argc,                             // Argument count.
-	bool replicated_command               // Whether this instance was spawned by a replication command.
+	RedisModuleCtx *ctx,            // Redis module context.
+	RedisModuleBlockedClient *bc,   // Blocked client.
+	GraphContext *graph_ctx,        // Graph context.
+	RedisModuleString *query,       // Query string.
+	RedisModuleString **argv,       // Arguments.
+	int argc,                       // Argument count.
+	bool replicated_command         // Whether this instance was spawned by a replication command.
 );
 
 // Get Redis module context
 RedisModuleCtx *CommandCtx_GetRedisCtx
 (
 	CommandCtx *qctx
+);
+
+// Get GraphContext.
+GraphContext* CommandCtx_GetGraphContext
+(
+	const CommandCtx *qctx
 );
 
 // Acquire Redis global lock.

--- a/src/commands/cmd_delete.c
+++ b/src/commands/cmd_delete.c
@@ -18,11 +18,25 @@ extern RedisModuleType *GraphContextRedisModuleType;
 /* Delete graph, removing the key from Redis and
  * freeing every resource allocated by the graph. */
 void _MGraph_Delete(void *args) {
+	QueryCtx_BeginTimer(); // Start deletion timing.
+
 	CommandCtx *dCtx = (CommandCtx *)args;
 	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(dCtx);
+	GraphContext *gc = CommandCtx_GetGraphContext(dCtx);
+	QueryCtx_SetGraphCtx(gc);
+
 	CommandCtx_ThreadSafeContextLock(dCtx);
-	GraphContext_Delete(ctx, dCtx->graphName);
+	{
+		GraphContext_Delete(gc, ctx);
+	}
 	CommandCtx_ThreadSafeContextUnlock(dCtx);
+
+	char *strElapsed;
+	double t = QueryCtx_GetExecutionTime();
+	asprintf(&strElapsed, "Graph removed, internal execution time: %.6f milliseconds", t);
+	RedisModule_ReplyWithStringBuffer(ctx, strElapsed, strlen(strElapsed));
+	free(strElapsed);
+
 	CommandCtx_Free(dCtx);
 	QueryCtx_Free(); // Reset the QueryCtx and free its allocations.
 }
@@ -31,7 +45,12 @@ int MGraph_Delete(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	if(argc != 2) return RedisModule_WrongArity(ctx);
 
 	CommandCtx *context;
-	RedisModuleString *graph_name = argv[1];
+	const char *graph_name = RedisModule_StringPtrLen(argv[1], NULL);
+	GraphContext *gc = GraphContext_Retrieve(ctx, graph_name, false, false);
+	if(!gc) {
+		RedisModule_ReplyWithError(ctx, "Graph is either missing or referred key is of a different type.");
+		return REDISMODULE_OK;
+	}
 
 	/* Determin query execution context
 	 * queries issued within a LUA script or multi exec block must
@@ -40,15 +59,14 @@ int MGraph_Delete(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	// Delete commands should always modify slaves.
 	bool is_replicated = false;
 	if(flags & (REDISMODULE_CTX_FLAGS_MULTI | REDISMODULE_CTX_FLAGS_LUA)) {
-		context = CommandCtx_New(ctx, NULL, graph_name, NULL, argv, argc, is_replicated);
+		context = CommandCtx_New(ctx, NULL, gc, NULL, argv, argc, is_replicated);
 		_MGraph_Delete(context);
 	} else {
 		RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
-		context = CommandCtx_New(NULL, bc, graph_name, NULL, argv, argc, is_replicated);
+		context = CommandCtx_New(NULL, bc, gc, NULL, argv, argc, is_replicated);
 		thpool_add_work(_thpool, _MGraph_Delete, context);
 	}
 
 	RedisModule_ReplicateVerbatim(ctx);
 	return REDISMODULE_OK;
 }
-

--- a/src/commands/cmd_dispatcher.c
+++ b/src/commands/cmd_dispatcher.c
@@ -1,0 +1,74 @@
+/*
+* Copyright 2018-2019 Redis Labs Ltd. and Contributors
+*
+* This file is available under the Redis Labs Source Available License Agreement
+*/
+
+#include "commands.h"
+#include "cmd_context.h"
+#include <assert.h>
+#include <strings.h>
+
+// Command handler function pointer.
+typedef void(*Command_Handler)(void *args);
+
+// Get command handler.
+static Command_Handler get_command_handler(GRAPH_Commands cmd) {
+	switch(cmd) {
+	case CMD_QUERY:
+		return Graph_Query;
+	case CMD_EXPLAIN:
+		return Graph_Explain;
+	case CMD_PROFILE:
+		return Graph_Profile;
+	default:
+		assert(false);
+	}
+	return NULL;
+}
+
+// Convert from string representation to an enum.
+static GRAPH_Commands determine_command(const char *cmd_name) {
+	if(strcasecmp(cmd_name, "graph.QUERY") == 0) return CMD_QUERY;
+	if(strcasecmp(cmd_name, "graph.EXPLAIN") == 0) return CMD_EXPLAIN;
+	if(strcasecmp(cmd_name, "graph.PROFILE") == 0) return CMD_PROFILE;
+
+	assert(false);
+	return CMD_BULK_UNKNOWN;
+}
+
+int CommandDispatch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+	CommandCtx *context;
+	if(argc < 3) return RedisModule_WrongArity(ctx);
+
+	const char *command_name = RedisModule_StringPtrLen(argv[0], NULL);
+	const char *graph_name = RedisModule_StringPtrLen(argv[1], NULL);
+	GRAPH_Commands cmd = determine_command(command_name);
+	Command_Handler handler = get_command_handler(cmd);
+	GraphContext *gc = GraphContext_Retrieve(ctx, graph_name, true, true);
+
+	/* Determin query execution context
+	 * queries issued within a LUA script or multi exec block must
+	 * run on Redis main thread, others can run on different threads. */
+	int flags = RedisModule_GetContextFlags(ctx);
+	bool is_replicated = RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_REPLICATED;
+	bool execute_on_main_thread = (flags & (REDISMODULE_CTX_FLAGS_MULTI |
+											REDISMODULE_CTX_FLAGS_LUA |
+											REDISMODULE_CTX_FLAGS_LOADING));
+	if(execute_on_main_thread) {
+		// Run query on Redis main thread.
+		context = CommandCtx_New(ctx, NULL, gc, argv[2], argv, argc, is_replicated);
+		handler(context);
+	} else {
+		// Run query on a dedicated thread.
+		RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
+		context = CommandCtx_New(NULL, bc, gc, argv[2], argv, argc, is_replicated);
+		thpool_add_work(_thpool, handler, context);
+	}
+
+	// Replicate the command to slaves and AOF.
+	// If the query is read-only, slaves will do nothing after parsing.
+	// TODO: only replicate if query is a writer.
+	if(cmd == CMD_QUERY || cmd == CMD_PROFILE) RedisModule_ReplicateVerbatim(ctx);
+	return REDISMODULE_OK;
+}

--- a/src/commands/cmd_dispatcher.h
+++ b/src/commands/cmd_dispatcher.h
@@ -1,0 +1,15 @@
+/*
+* Copyright 2018-2019 Redis Labs Ltd. and Contributors
+*
+* This file is available under the Redis Labs Source Available License Agreement
+*/
+
+#pragma once
+
+#include "../redismodule.h"
+
+/* Used as a single point of entrace to
+ * GRAPH.QUERY
+ * GRAPH.EXPLAIN
+ * GRAPH.PROFILE */
+int CommandDispatch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -12,36 +12,20 @@
 #include "../parser/parser.h"
 #include "../execution_plan/execution_plan.h"
 
-GraphContext *_empty_graph_context() {
-	GraphContext *gc = NULL;
-	gc = rm_malloc(sizeof(GraphContext));
-	gc->g = Graph_New(1, 1);
-	gc->index_count = 0;
-	gc->attributes = NULL;
-	gc->node_schemas = NULL;
-	gc->string_mapping = NULL;
-	gc->relation_schemas = NULL;
-	gc->graph_name = rm_strdup("");
-
-	QueryCtx_SetGraphCtx(gc);
-	return gc;
-}
-
 /* Builds an execution plan but does not execute it
  * reports plan back to the client
  * Args:
- * argv[1] graph name [optional]
+ * argv[1] graph name
  * argv[2] query */
-void _MGraph_Explain(void *args) {
+void Graph_Explain(void *args) {
 	AST *ast = NULL;
-	GraphContext *gc = NULL;
 	bool lock_acquired = false;
 	ExecutionPlan *plan = NULL;
-	bool free_graph_ctx = false;
 	CommandCtx *qctx = (CommandCtx *)args;
 	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(qctx);
+	GraphContext *gc = CommandCtx_GetGraphContext(qctx);
+	QueryCtx_SetGraphCtx(gc);
 	const char *query = qctx->query;
-	const char *graphname = qctx->graphName;
 
 	QueryCtx_SetRedisModuleCtx(ctx);
 
@@ -65,14 +49,6 @@ void _MGraph_Explain(void *args) {
 		goto cleanup;
 	}
 
-	// Retrieve the GraphContext and acquire a read lock.
-	if(graphname) {
-		gc = GraphContext_Retrieve(qctx, graphname, true);
-	} else {
-		free_graph_ctx = true;
-		gc = _empty_graph_context();
-	}
-
 	Graph_AcquireReadLock(gc->g);
 	lock_acquired = true;
 
@@ -86,39 +62,5 @@ cleanup:
 	AST_Free(ast);
 	QueryCtx_Free(); // Reset the QueryCtx and free its allocations.
 	CommandCtx_Free(qctx);
-	if(free_graph_ctx) GraphContext_Free(gc);
 	if(parse_result) cypher_parse_result_free(parse_result);
 }
-
-int MGraph_Explain(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-	if(argc < 2) return RedisModule_WrongArity(ctx);
-
-	RedisModuleString *graphName = NULL;
-	RedisModuleString *query;
-
-	if(argc == 2) {
-		query = argv[1];
-	} else {
-		graphName = argv[1];
-		query = argv[2];
-	}
-
-	/* Determin execution context
-	 * queries issued within a LUA script or multi exec block must
-	 * run on Redis main thread, others can run on different threads. */
-	CommandCtx *context;
-	int flags = RedisModule_GetContextFlags(ctx);
-	if(flags & (REDISMODULE_CTX_FLAGS_MULTI | REDISMODULE_CTX_FLAGS_LUA)) {
-		// Run on Redis main thread.
-		context = CommandCtx_New(ctx, NULL, graphName, query, argv, argc, false);
-		_MGraph_Explain(context);
-	} else {
-		// Run on a dedicated thread.
-		RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
-		context = CommandCtx_New(NULL, bc, graphName, query, argv, argc, false);
-		thpool_add_work(_thpool, _MGraph_Explain, context);
-	}
-
-	return REDISMODULE_OK;
-}
-

--- a/src/commands/cmd_explain.h
+++ b/src/commands/cmd_explain.h
@@ -4,14 +4,6 @@
 * This file is available under the Redis Labs Source Available License Agreement
 */
 
-#ifndef GRAPH_EXPLAIN_H
-#define GRAPH_EXPLAIN_H
+#pragma once
 
-#include "../redismodule.h"
-#include "../util/thpool/thpool.h"
-
-extern threadpool _thpool;
-
-int MGraph_Explain(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-
-#endif
+void Graph_Explain(void *args);

--- a/src/commands/cmd_profile.c
+++ b/src/commands/cmd_profile.c
@@ -12,12 +12,14 @@
 #include "../util/arr.h"
 #include "../util/rmalloc.h"
 
-void _MGraph_Profile(void *args) {
+void Graph_Profile(void *args) {
+	AST *ast = NULL;
+	bool lockAcquired = false;
+	ResultSet *result_set = NULL;
 	CommandCtx *qctx = (CommandCtx *)args;
 	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(qctx);
-	ResultSet *result_set = NULL;
-	bool lockAcquired = false;
-	AST *ast = NULL;
+	GraphContext *gc = CommandCtx_GetGraphContext(qctx);
+	QueryCtx_SetGraphCtx(gc);
 
 	QueryCtx_BeginTimer(); // Start query timing.
 	QueryCtx_SetRedisModuleCtx(ctx);
@@ -37,12 +39,16 @@ void _MGraph_Profile(void *args) {
 	// Prepare the constructed AST for accesses from the module
 	ast = AST_Build(parse_result);
 
-	// Try to access the GraphContext
-	GraphContext *gc = GraphContext_Retrieve(qctx, qctx->graphName, readonly);
-
 	// Acquire the appropriate lock.
-	if(readonly) Graph_AcquireReadLock(gc->g);
-	else Graph_WriterEnter(gc->g);  // Single writer.
+	if(readonly) {
+		Graph_AcquireReadLock(gc->g);
+	} else {
+		Graph_WriterEnter(gc->g);  // Single writer.
+		/* If this is a writer query `we need to re-open the graph key with write flag
+		* this notifies Redis that the key is "dirty" any watcher on that key will
+		* be notified. */
+		GraphContext_Retrieve(ctx, gc->graph_name, false, false);
+	}
 	lockAcquired = true;
 
 	const cypher_astnode_type_t root_type = cypher_astnode_type(ast->root);
@@ -75,37 +81,3 @@ cleanup:
 	CommandCtx_Free(qctx);
 	QueryCtx_Free(); // Reset the QueryCtx and free its allocations.
 }
-
-/* Profiles query
- * Args:
- * argv[1] graph name
- * argv[2] query to profile */
-int MGraph_Profile(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-	if(argc < 3) return RedisModule_WrongArity(ctx);
-
-	/* Determin query execution context
-	 * queries issued within a LUA script or multi exec block must
-	 * run on Redis main thread, others can run on different threads. */
-	CommandCtx *context;
-	int flags = RedisModule_GetContextFlags(ctx);
-	bool is_replicated = RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_REPLICATED;
-	if(flags & (REDISMODULE_CTX_FLAGS_MULTI |
-				REDISMODULE_CTX_FLAGS_LUA |
-				REDISMODULE_CTX_FLAGS_LOADING)) {
-		// Run query on Redis main thread.
-		context = CommandCtx_New(ctx, NULL, argv[1], argv[2], argv, argc, is_replicated);
-		_MGraph_Profile(context);
-	} else {
-		// Run query on a dedicated thread.
-		RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
-		context = CommandCtx_New(NULL, bc, argv[1], argv[2], argv, argc, is_replicated);
-		thpool_add_work(_thpool, _MGraph_Profile, context);
-	}
-
-	// Replicate the command to slaves and AOF.
-	// If the query is read-only, slaves will do nothing after parsing.
-	// TODO is this necessary for Profile queries?
-	RedisModule_ReplicateVerbatim(ctx);
-	return REDISMODULE_OK;
-}
-

--- a/src/commands/cmd_profile.h
+++ b/src/commands/cmd_profile.h
@@ -6,9 +6,4 @@
 
 #pragma once
 
-#include "../redismodule.h"
-#include "../util/thpool/thpool.h"
-
-extern threadpool _thpool;
-
-int MGraph_Profile(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+void Graph_Profile(void *args);

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -65,12 +65,14 @@ static inline bool _check_compact_flag(CommandCtx *qctx) {
 			!strcasecmp(RedisModule_StringPtrLen(qctx->argv[3], NULL), "--compact"));
 }
 
-void _MGraph_Query(void *args) {
+void Graph_Query(void *args) {
 	AST *ast = NULL;
 	bool lockAcquired = false;
 	ResultSet *result_set = NULL;
 	CommandCtx *qctx = (CommandCtx *)args;
 	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(qctx);
+	GraphContext *gc = CommandCtx_GetGraphContext(qctx);
+	QueryCtx_SetGraphCtx(gc);
 
 	QueryCtx_BeginTimer(); // Start query timing.
 	QueryCtx_SetRedisModuleCtx(ctx);
@@ -89,13 +91,18 @@ void _MGraph_Query(void *args) {
 	// Prepare the constructed AST for accesses from the module
 	ast = AST_Build(parse_result);
 
-	GraphContext *gc = GraphContext_Retrieve(qctx, qctx->graphName, readonly);
-
 	bool compact = _check_compact_flag(qctx);
 
 	// Acquire the appropriate lock.
-	if(readonly) Graph_AcquireReadLock(gc->g);
-	else Graph_WriterEnter(gc->g);  // Single writer.
+	if(readonly) {
+		Graph_AcquireReadLock(gc->g);
+	} else {
+		Graph_WriterEnter(gc->g);  // Single writer.
+		/* If this is a writer query we need to re-open the graph key with write flag
+		* this notifies Redis that the key is "dirty" any watcher on that key will
+		* be notified. */
+		GraphContext_Retrieve(ctx, gc->graph_name, false, false);
+	}
 	lockAcquired = true;
 
 	const cypher_astnode_type_t root_type = cypher_astnode_type(ast->root);
@@ -128,36 +135,4 @@ cleanup:
 	if(parse_result) cypher_parse_result_free(parse_result);
 	CommandCtx_Free(qctx);
 	QueryCtx_Free(); // Reset the QueryCtx and free its allocations.
-}
-
-/* Queries graph
- * Args:
- * argv[1] graph name
- * argv[2] query to execute */
-int MGraph_Query(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-	if(argc < 3) return RedisModule_WrongArity(ctx);
-
-	/* Determin query execution context
-	 * queries issued within a LUA script or multi exec block must
-	 * run on Redis main thread, others can run on different threads. */
-	CommandCtx *context;
-	int flags = RedisModule_GetContextFlags(ctx);
-	bool is_replicated = RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_REPLICATED;
-	if(flags & (REDISMODULE_CTX_FLAGS_MULTI |
-				REDISMODULE_CTX_FLAGS_LUA |
-				REDISMODULE_CTX_FLAGS_LOADING)) {
-		// Run query on Redis main thread.
-		context = CommandCtx_New(ctx, NULL, argv[1], argv[2], argv, argc, is_replicated);
-		_MGraph_Query(context);
-	} else {
-		// Run query on a dedicated thread.
-		RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
-		context = CommandCtx_New(NULL, bc, argv[1], argv[2], argv, argc, is_replicated);
-		thpool_add_work(_thpool, _MGraph_Query, context);
-	}
-
-	// Replicate the command to slaves and AOF.
-	// If the query is read-only, slaves will do nothing after parsing.
-	RedisModule_ReplicateVerbatim(ctx);
-	return REDISMODULE_OK;
 }

--- a/src/commands/cmd_query.h
+++ b/src/commands/cmd_query.h
@@ -4,14 +4,6 @@
 * This file is available under the Redis Labs Source Available License Agreement
 */
 
-#ifndef GRAPH_QUERY_H
-#define GRAPH_QUERY_H
+#pragma once
 
-#include "../redismodule.h"
-#include "../util/thpool/thpool.h"
-
-extern threadpool _thpool;
-
-int MGraph_Query(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-
-#endif
+void Graph_Query(void *args);

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -4,12 +4,23 @@
 * This file is available under the Redis Labs Source Available License Agreement
 */
 
+#pragma once
+
 //------------------------------------------------------------------------------
 // Module Commands
 //------------------------------------------------------------------------------
-
 #include "cmd_query.h"
 #include "cmd_delete.h"
 #include "cmd_explain.h"
 #include "cmd_profile.h"
+#include "cmd_dispatcher.h"
 #include "cmd_bulk_insert.h"
+
+typedef enum {
+	CMD_QUERY,
+	CMD_DELETE,
+	CMD_EXPLAIN,
+    CMD_PROFILE,
+    CMD_BULK_INSERT,
+    CMD_BULK_UNKNOWN
+} GRAPH_Commands;

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -11,7 +11,6 @@
 #include "../redismodule.h"
 #include "../index/index.h"
 #include "../schema/schema.h"
-#include "../commands/cmd_context.h"
 #include "graph.h"
 
 typedef struct {
@@ -30,9 +29,9 @@ typedef struct {
 /* GraphContext API */
 /* Retrive the graph context according to the graph name
  * readOnly is the access mode to the graph key */
-GraphContext *GraphContext_Retrieve(CommandCtx *cmdCtx, const char *graphName, bool readOnly);
-// Deletes a graph context from the module, according to the graph name.
-void GraphContext_Delete(RedisModuleCtx *ctx, const char *graphName);
+GraphContext *GraphContext_Retrieve(RedisModuleCtx *ctx, const char *graphName, bool readOnly, bool shouldCreate);
+// Deletes a graph context from the module.
+void GraphContext_Delete(GraphContext *gc, RedisModuleCtx *ctx);
 
 /* Schema API */
 // Retrieve number of schemas created for given type.

--- a/src/module.c
+++ b/src/module.c
@@ -134,7 +134,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
 	if(_RegisterDataTypes(ctx) != REDISMODULE_OK) return REDISMODULE_ERR;
 
-	if(RedisModule_CreateCommand(ctx, "graph.QUERY", MGraph_Query, "write deny-oom", 1, 1,
+	if(RedisModule_CreateCommand(ctx, "graph.QUERY", CommandDispatch, "write deny-oom", 1, 1,
 								 1) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}
@@ -144,12 +144,12 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_CreateCommand(ctx, "graph.EXPLAIN", MGraph_Explain, "write", 1, 1,
+	if(RedisModule_CreateCommand(ctx, "graph.EXPLAIN", CommandDispatch, "write", 1, 1,
 								 1) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}
 
-	if(RedisModule_CreateCommand(ctx, "graph.PROFILE", MGraph_Profile, "write", 1, 1,
+	if(RedisModule_CreateCommand(ctx, "graph.PROFILE", CommandDispatch, "write", 1, 1,
 								 1) == REDISMODULE_ERR) {
 		return REDISMODULE_ERR;
 	}

--- a/tests/flow/test_multi_exec.py
+++ b/tests/flow/test_multi_exec.py
@@ -83,9 +83,7 @@ class testMultiExecFlow(FlowTestsBase):
         no_edges = no_edges[1]
         self.env.assertEquals(len(no_edges), 0)
 
-
     def test_transaction_failure(self):
-        
         redis_con_a = self.env.getConnection()
         redis_con_b = self.env.getConnection()
         results = redis_con_b.execute_command("INFO", "CLIENTS")


### PR DESCRIPTION
As every query execution starts off on Redis main thread, we can acquire our graph context at that stage and avoid GIL locking at a later stage once we're executing on a different thread.