### PR TITLE
Var len bugfix

### DIFF
--- a/src/execution_plan/ops/op_cond_var_len_traverse.c
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.c
@@ -92,7 +92,7 @@ static Record CondVarLenTraverseConsume(OpBase *opBase) {
 	/* Incase we don't have any relations to traverse we can return quickly
 	 * Consider: MATCH (S)-[:L*]->(M) RETURN M
 	 * where label L does not exists. */
-	if(op->edgeRelationCount == 0) {
+	if(op->edgeRelationCount == 0 || op->edgeRelationTypes[0] == GRAPH_UNKNOWN_RELATION) {
 		return NULL;
 	}
 

--- a/src/graph/entities/edge.c
+++ b/src/graph/entities/edge.c
@@ -13,20 +13,6 @@
 #include "../graphcontext.h"
 #include "../../query_ctx.h"
 
-// Edge* Edge_New(Node *src, Node *dest, const char *relationship, const char *alias) {
-// assert(src && dest);
-
-// Edge* e = calloc(1, sizeof(Edge));
-// Edge_SetSrcNode(e, src);
-// Edge_SetDestNode(e, dest);
-// e->relationID = GRAPH_UNKNOWN_RELATION;
-
-// e->relationship = relationship;
-// e->alias = alias;
-
-// return e;
-// }
-
 NodeID Edge_GetSrcNodeID(const Edge *edge) {
 	assert(edge);
 	return edge->srcNodeID;

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -564,6 +564,8 @@ void Graph_GetNodeEdges(const Graph *g, const Node *n, GRAPH_EDGE_DIR dir, int e
 	NodeID destNodeID;
 	GxB_MatrixTupleIter *tupleIter;
 
+	if(edgeType == GRAPH_UNKNOWN_RELATION) return;
+
 	// Outgoing.
 	if(dir == GRAPH_EDGE_DIR_OUTGOING || dir == GRAPH_EDGE_DIR_BOTH) {
 		/* If a relationship type is specified, retrieve the appropriate relation matrix;
@@ -1140,3 +1142,4 @@ void Graph_Free(Graph *g) {
 
 	rm_free(g);
 }
+


### PR DESCRIPTION
The change in `cond_var_len_traverse.c ` is the actual fix here (good call, @DvirDukhan !), and the addition to `graph.c` is an additional downstream safeguard.