### PR TITLE
Perform WITH clause validations before subdividing AST scopes

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1303,10 +1303,6 @@ static AST_Validation _ValidateClauses(const AST *ast, char **reason) {
 		return AST_INVALID;
 	}
 
-	if(_Validate_WITH_Clauses(ast, reason) == AST_INVALID) {
-		return AST_INVALID;
-	}
-
 	if(_Validate_MERGE_Clauses(ast, reason) == AST_INVALID) {
 		return AST_INVALID;
 	}
@@ -1420,6 +1416,10 @@ static AST_Validation _ValidateScopes(const cypher_astnode_t *root, char **reaso
 		res = _ValidateClauses(&mock_ast, reason);
 		goto cleanup;
 	}
+
+	// Validate that entities passed between scopes are not reused in other patterns (temporary limitation).
+	res = _Validate_WITH_Clauses(&mock_ast, reason);
+	if(res != AST_VALID) goto cleanup;
 
 	AST *scoped_ast;
 	uint scope_end;


### PR DESCRIPTION
This PR fixes a regression in AST validations that had caused cross-scope WITH clause validations to not function. Specifically, we block the reuse in patterns of WITH-projected entities:
```
GRAPH.QUERY G "MATCH (a) WITH a MATCH (a)-[e]->(b) RETURN a, e, b"
(error) Reusing the WITH projection 'a' in another pattern is currently not supported
``` 