### PR TITLE
Update AST in QueryCtx after segment construction

### DIFF
--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -671,6 +671,8 @@ ExecutionPlan *NewExecutionPlan(RedisModuleCtx *ctx, GraphContext *gc, ResultSet
 		start_offset = end_offset;
 	}
 
+	QueryCtx_SetAST(ast); // AST segments have been freed, set master AST in QueryCtx.
+
 	OpBase *connecting_op = NULL;
 	// Merge segments.
 	for(int i = 1; i < segment_count; i++) {


### PR DESCRIPTION
Small fix to AST variable in TLS after all ops are constructed (fixes invalid access in `RETURN *` column name building).