### PR TITLE
Validate function calls in WITH and CREATE clauses

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -229,8 +229,8 @@ static AST_Validation _VisitFunctions(const cypher_astnode_t *node, rax *func_na
 			return AST_INVALID;
 		}
 
-		// Collect the function name.
-		raxInsert(func_names, (unsigned char *)func_name, strlen(func_name), NULL, NULL);
+		// Collect the function name, which is always "count" here.
+		raxInsert(func_names, (unsigned char *)"count", 5, NULL, NULL);
 
 		// As Apply All operators have no children, we can return here.
 		return AST_VALID;
@@ -698,6 +698,10 @@ static AST_Validation _Validate_WITH_Clauses(const AST *ast, char **reason) {
 		const cypher_astnode_t *clause = cypher_ast_query_get_clause(ast->root, i);
 		cypher_astnode_type_t type = cypher_astnode_type(clause);
 		if(type == CYPHER_AST_WITH) {
+			// Verify that functions invoked by the WITH clause are valid.
+			res = _ValidateFunctionCalls(clause, reason, true);
+			if(res == AST_INVALID) break;
+
 			// Collect projected aliases from WITH clauses into the same triemap
 			_AST_GetWithAliases(clause, with_projections);
 		} else if(type == CYPHER_AST_MATCH) {
@@ -805,11 +809,16 @@ static AST_Validation _Validate_CREATE_Clauses(const AST *ast, char **reason) {
 	AST_Validation res = AST_VALID;
 	uint clause_count = array_len(create_clauses);
 	for(uint i = 0; i < clause_count; i++) {
+		// Verify that functions invoked by the CREATE clause are valid.
+		res = _ValidateFunctionCalls(create_clauses[i], reason, false);
+		if(res == AST_INVALID) goto cleanup;
+
 		if(_Validate_CREATE_Clause_TypedRelations(create_clauses[i]) == AST_INVALID) {
 			asprintf(reason, "Exactly one relationship type must be specified for CREATE");
 			res = AST_INVALID;
 			goto cleanup;
 		}
+
 		// Validate that inlined properties do not use parameters
 		res = _Validate_CREATE_Clause_Properties(create_clauses[i], reason);
 		if(res == AST_INVALID) goto cleanup;


### PR DESCRIPTION
Introduces the validation fixes suggested in review on #717 .

Improved behavior includes:
```
"CREATE (a {v: fake()})"
(error) Unknown function 'fake'

"MATCH (a) WITH fake(a) AS e RETURN e"
(error) Unknown function 'fake'

"CREATE (a {v: COUNT(DISTINCT *)})"
(error) Cannot specify both DISTINCT and * in COUNT(DISTINCT *)
```