### PR TITLE
added valdiation for path in filter

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -108,6 +108,17 @@ inline bool AST_ContainsClause(const AST *ast, cypher_astnode_type_t clause) {
 	return AST_GetClause(ast, clause) != NULL;
 }
 
+// Checks to see if an AST tree contains specified node type.
+bool AST_TreeContainsType(const cypher_astnode_t *root, cypher_astnode_type_t search_type) {
+	cypher_astnode_type_t type = cypher_astnode_type(root);
+	if(type == search_type) return true;
+	uint childCount = cypher_astnode_nchildren(root);
+	for(uint i = 0; i < childCount; i++) {
+		if(AST_TreeContainsType(cypher_astnode_get_child(root, i), search_type)) return true;
+	}
+	return false;
+}
+
 // Recursively collect the names of all function calls beneath a node
 void AST_ReferredFunctions(const cypher_astnode_t *root, rax *referred_funcs) {
 	cypher_astnode_type_t root_type = cypher_astnode_type(root);

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -43,6 +43,9 @@ bool AST_ReadOnly(const cypher_parse_result_t *result);
 // Checks to see if AST contains specified clause.
 bool AST_ContainsClause(const AST *ast, cypher_astnode_type_t clause);
 
+// Checks to see if an AST tree contains specified node type.
+bool AST_TreeContainsType(const cypher_astnode_t *root, cypher_astnode_type_t clause);
+
 // Returns all function (aggregated & none aggregated) mentioned in query.
 void AST_ReferredFunctions(const cypher_astnode_t *root, rax *referred_funcs);
 

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -456,6 +456,19 @@ static AST_Validation _ValidateInlinedPropertiesOnPath(const cypher_astnode_t *p
 	return AST_VALID;
 }
 
+// TODO: Remove this once path patterns are supported at filtering.
+// This function is NOT syntax validation function. It is checks there are path pattern in the filter.
+static AST_Validation _Validate_filter_not_contains_path(const cypher_astnode_t *ast_node) {
+	cypher_astnode_type_t type = cypher_astnode_type(ast_node);
+	if(type == CYPHER_AST_PATTERN_PATH) return AST_INVALID;
+	uint childCount = cypher_astnode_nchildren(ast_node);
+	for(uint i = 0; i < childCount; i++) {
+		if(_Validate_filter_not_contains_path(cypher_astnode_get_child(ast_node, i)) == AST_INVALID)
+			return AST_INVALID;
+	}
+	return AST_VALID;
+}
+
 static AST_Validation _Validate_MATCH_Clause_Filters(const cypher_astnode_t *clause,
 													 char **reason) {
 	const cypher_astnode_t *pattern = cypher_ast_match_get_pattern(clause);
@@ -464,10 +477,15 @@ static AST_Validation _Validate_MATCH_Clause_Filters(const cypher_astnode_t *cla
 		const cypher_astnode_t *path = cypher_ast_pattern_get_path(pattern, i);
 		if(_ValidateInlinedPropertiesOnPath(path, reason) != AST_VALID) return AST_INVALID;
 	}
-
-	const cypher_astnode_t *predicate = cypher_ast_match_get_predicate(clause);
-	if(predicate == NULL) return AST_VALID;
-
+	uint childCount = cypher_astnode_nchildren(clause);
+	for(uint i = 0; i < childCount; i++) {
+		const cypher_astnode_t *child = cypher_astnode_get_child(clause, i);
+		if(cypher_astnode_type(child) == CYPHER_AST_PATTERN) continue;
+		if(_Validate_filter_not_contains_path(child) == AST_INVALID) {
+			asprintf(reason, "RedisGraph currently does not support filtering with path pattern");
+			return AST_INVALID;
+		}
+	}
 	return AST_VALID;
 }
 


### PR DESCRIPTION
As a result of #719, this PR adds an AST validation for the existence of path patterns in a filter.  RedisGraph will reply with an error `RedisGraph currently does not support filtering with path pattern`, once path patterns exist in filter.