### PR TITLE
check for node degree using original query graph

### DIFF
--- a/src/algorithms/longest_path.c
+++ b/src/algorithms/longest_path.c
@@ -11,7 +11,7 @@
 #include"./detect_cycle.h"
 
 // Scans the graph in a DFS fashion, keeps track after the longest path length.
-static void __DFSMaxDepth(QGNode *n, int level, int *max_depth, rax *visited) {
+static void __DFSMaxDepth(QGNode *n, int level, int *max_depth, rax *visited, rax *used_edges) {
 	if(level > *max_depth) *max_depth = level;
 
 	// Mark n as visited, return if node already marked.
@@ -23,7 +23,17 @@ static void __DFSMaxDepth(QGNode *n, int level, int *max_depth, rax *visited) {
 	// Expand node N by visiting all of its neighbors
 	for(uint i = 0; i < array_len(n->outgoing_edges); i++) {
 		QGEdge *e = n->outgoing_edges[i];
-		__DFSMaxDepth(e->dest, level + 1, max_depth, visited);
+		if(!raxInsert(used_edges, (unsigned char *)e->alias, strlen(e->alias), NULL, NULL)) continue;
+		__DFSMaxDepth(e->dest, level + 1, max_depth, visited, used_edges);
+		raxRemove(used_edges, (unsigned char *)e->alias, strlen(e->alias), NULL);
+	}
+
+	// Expand node N by visiting all of its neighbors
+	for(uint i = 0; i < array_len(n->incoming_edges); i++) {
+		QGEdge *e = n->incoming_edges[i];
+		if(!raxInsert(used_edges, (unsigned char *)e->alias, strlen(e->alias), NULL, NULL)) continue;
+		__DFSMaxDepth(e->src, level + 1, max_depth, visited, used_edges);
+		raxRemove(used_edges, (unsigned char *)e->alias, strlen(e->alias), NULL);
 	}
 
 	raxRemove(visited, (unsigned char *)n->alias, strlen(n->alias), NULL);
@@ -34,10 +44,12 @@ static int _DFSMaxDepth(QGNode *n) {
 	int level = 0;              // Starting at level 0.
 	int max_depth = 0;          // Longest path length.
 	rax *visited = raxNew();    // Dictionary of visited nodes.
+	rax *used_edges = raxNew(); // Dictionary of used edges.
 
-	__DFSMaxDepth(n, level, &max_depth, visited);
+	__DFSMaxDepth(n, level, &max_depth, visited, used_edges);
 
 	raxFree(visited);
+	raxFree(used_edges);
 	return max_depth;
 }
 

--- a/src/arithmetic/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression.c
@@ -25,7 +25,9 @@ static AlgebraicExpression *_AE_MUL(size_t operand_cap) {
 
 /* Node with (income + outcome degree) > 2
  * is considered a highly connected node. */
-static bool _highly_connected_node(const QGNode *n) {
+static bool _highly_connected_node(const QueryGraph *qg, const char *alias) {
+	// Look up node in qg.
+	QGNode *n = QueryGraph_GetNodeByAlias(qg, alias);
 	return ((array_len(n->incoming_edges) + array_len(n->outgoing_edges)) > 2);
 }
 
@@ -235,19 +237,19 @@ static inline bool _should_populate_edge(QGEdge *e) {
 	return (_referred_entity(e->alias) || QGEdge_VariableLength(e));
 }
 
-static inline bool _should_divide_expression(QGEdge **path, int idx) {
+static inline bool _should_divide_expression(QGEdge **path, int idx, const QueryGraph *qg) {
 	QGEdge *e = path[idx];
 
-	return (_should_populate_edge(e)                  ||      // This edge is populated.
-			_should_populate_edge(path[idx + 1])      ||      // The next edge is populated.
-			_highly_connected_node(e->dest)           ||      // Destination node in+out degree > 2.
-			_referred_entity(e->dest->alias));                // Destination node is referenced.
+	return (_should_populate_edge(e)                    ||  // This edge is populated.
+			_should_populate_edge(path[idx + 1])        ||  // The next edge is populated.
+			_highly_connected_node(qg, e->dest->alias)  ||  // Destination node in+out degree > 2.
+			_referred_entity(e->dest->alias));              // Destination node is referenced.
 }
 
 /* Break down expression into sub expressions.
  * considering referenced intermidate nodes and edges. */
-static AlgebraicExpression **_AlgebraicExpression_Intermidate_Expressions(
-	AlgebraicExpression *exp, QGEdge **path, const QueryGraph *g) {
+static AlgebraicExpression **_AlgebraicExpression_Intermidate_Expressions(AlgebraicExpression *exp,
+																		  QGEdge **path, const QueryGraph *qg) {
 
 	/* Allocating maximum number of expression possible. */
 	QGEdge *e = NULL;
@@ -268,7 +270,7 @@ static AlgebraicExpression **_AlgebraicExpression_Intermidate_Expressions(
 	divide_at[pathLen - 1] = false; // Only check intermediate edges, not the last.
 	for(int i = 0; i < pathLen - 1; i++) {
 		// Track which points the expression should be subdivided at.
-		divide_at[i] = _should_divide_expression(path, i);
+		divide_at[i] = _should_divide_expression(path, i, qg);
 	}
 
 	for(int i = 0; i < pathLen; i++) {
@@ -537,7 +539,7 @@ AlgebraicExpression **AlgebraicExpression_FromQueryGraph(const QueryGraph *qg, u
 		AlgebraicExpression *exp = _AlgebraicExpression_FromPath(path, level);
 
 		// Split constructed expression into sub expressions.
-		AlgebraicExpression **sub_exps = _AlgebraicExpression_Intermidate_Expressions(exp, path, g);
+		AlgebraicExpression **sub_exps = _AlgebraicExpression_Intermidate_Expressions(exp, path, qg);
 		sub_exps = _AlgebraicExpression_IsolateVariableLenExps(sub_exps);
 
 		// Remove path from graph.

--- a/src/graph/query_graph.c
+++ b/src/graph/query_graph.c
@@ -409,6 +409,29 @@ GrB_Matrix QueryGraph_MatrixRepresentation(const QueryGraph *qg) {
 	return m;
 }
 
+void QueryGraph_Print(const QueryGraph *qg) {
+	char *buff = calloc(1024, sizeof(char));
+
+	uint node_count = QueryGraph_NodeCount(qg);
+	uint edge_count = QueryGraph_EdgeCount(qg);
+
+	for(int i = 0; i < node_count; i++) {
+		QGNode *n = qg->nodes[i];
+		if(QGNode_IncomeDegree(n) + QGNode_OutgoingDegree(n) == 0) {
+			// Floating node.
+			asprintf(&buff, "%s%s;\n", buff, n->alias);
+		}
+	}
+
+	for(int i = 0; i < edge_count; i++) {
+		QGEdge *e = qg->edges[i];
+		asprintf(&buff, "%s%s -> %s;\n", buff, e->src->alias, e->dest->alias);
+	}
+
+	printf("%s\n", buff);
+	free(buff);
+}
+
 /* Frees entire graph. */
 void QueryGraph_Free(QueryGraph *qg) {
 	if(!qg) return;
@@ -429,4 +452,3 @@ void QueryGraph_Free(QueryGraph *qg) {
 	array_free(qg->edges);
 	rm_free(qg);
 }
-

--- a/src/graph/query_graph.h
+++ b/src/graph/query_graph.h
@@ -77,5 +77,9 @@ uint QueryGraph_EdgeCount(const QueryGraph *qg);
 /* Build a matrix representation of query graph. */
 GrB_Matrix QueryGraph_MatrixRepresentation(const QueryGraph *qg);
 
+/* Returns a string representation of query graph. 
+ * http://viz-js.com/ */
+void QueryGraph_Print(const QueryGraph *qg);
+
 /* Frees entire graph */
 void QueryGraph_Free(QueryGraph *qg);

--- a/tests/unit/test_algebraic_expression.cpp
+++ b/tests/unit/test_algebraic_expression.cpp
@@ -1115,6 +1115,224 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	free_algebraic_expressions(expected, exp_count);
 	free(expected);
 	free(actual);
+
+    //(p1)-[]->(p2)-[]->(p3)-[]->(p2)-[]->(p4)-[]->(p5) RETURN p1
+    exp_count = 0;
+	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p2)-[:friend]->(p4)-[:friend]->(p5) RETURN p1";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 3);
+
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 3);
+	exp = AlgebraicExpression_Empty();	
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+    expected[0] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	expected[1] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	expected[2] = exp;
+
+	compare_algebraic_expressions(actual, expected, 3);
+
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
+
+    // (p1)-[]->(p2)-[]->(p3)-[]->(p2)-[]->(p4)-[]->(p5) RETURN p1,p2,p3,p4,p5
+    exp_count = 0;
+	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p2)-[:friend]->(p4)-[:friend]->(p5) RETURN p1,p2,p3,p4,p5";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 5);
+
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 5);
+	exp = AlgebraicExpression_Empty();	
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+    expected[0] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[1] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[2] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[3] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[4] = exp;
+
+	compare_algebraic_expressions(actual, expected, 5);
+
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
+
+    // MATCH (p1)-[]->(p2)-[]->(p3)-[]->(p4)-[]->(p5)-[]->(p2)-[]->(p6)-[]->(p7)-[]->(p3) RETURN p1
+    exp_count = 0;
+	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p4)-[:friend]->(p5)-[:friend]->(p2)-[:friend]->(p6)-[:friend]->(p7)-[:friend]->(p3) RETURN p1";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 4);
+
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 4);
+	exp = AlgebraicExpression_Empty();	
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+    expected[0] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	expected[1] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[2] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[3] = exp;
+
+	compare_algebraic_expressions(actual, expected, 4);
+
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
+
+    // MATCH (p1)-[]->(p2)-[]->(p3)-[]->(p4)-[]->(p5)-[]->(p2)-[]->(p6)-[]->(p7)-[]->(p3) RETURN p1,p2,p3,p4,p5,p6,p7
+    exp_count = 0;
+	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p4)-[:friend]->(p5)-[:friend]->(p2)-[:friend]->(p6)-[:friend]->(p7)-[:friend]->(p3) RETURN p1,p2,p3,p4,p5,p6,p7";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 8);
+
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 8);
+	exp = AlgebraicExpression_Empty();	
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+    expected[0] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	expected[1] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[2] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[3] = exp;
+
+    exp = AlgebraicExpression_Empty();	
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+    expected[4] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	expected[5] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[6] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[7] = exp;
+
+	compare_algebraic_expressions(actual, expected, 8);
+
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
+
+    // MATCH (p1)-[]->(p2)-[]->(p3)-[]->(p4)-[]->(p1)-[]->(p4),(p4)-[]->(p5) RETURN p1
+    exp_count = 0;
+	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p4)-[:friend]->(p1)-[:friend]->(p4)-[:friend]->(p5) RETURN p1";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 4);
+
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 4);
+	exp = AlgebraicExpression_Empty();	
+	AlgebraicExpression_AppendTerm(exp, mat_ef, true, false, false);
+    expected[0] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	expected[1] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[2] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);	
+	expected[3] = exp;
+
+	compare_algebraic_expressions(actual, expected, 4);
+
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
+
+    // MATCH (p1)-[]->(p2)-[]->(p3)-[]->(p4)-[]->(p1)-[]->(p4),(p4)-[]->(p5) RETURN p1,p2,p3,p4,p5
+    exp_count = 0;
+	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p4)-[:friend]->(p1)-[:friend]->(p4)-[:friend]->(p5) RETURN p1,p2,p3,p4,p5";
+	actual = build_algebraic_expression(q, &exp_count);
+	ASSERT_EQ(exp_count, 6);
+
+	expected = (AlgebraicExpression **)malloc(sizeof(AlgebraicExpression *) * 6);
+	exp = AlgebraicExpression_Empty();	
+	AlgebraicExpression_AppendTerm(exp, mat_ef, true, false, false);
+    expected[0] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	expected[1] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	expected[2] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	expected[3] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	expected[4] = exp;
+
+    exp = AlgebraicExpression_Empty();
+	AlgebraicExpression_AppendTerm(exp, mat_ef, false, false, false);
+	expected[5] = exp;
+
+	compare_algebraic_expressions(actual, expected, 6);
+
+	// Clean up.
+	free_algebraic_expressions(actual, exp_count);
+	free_algebraic_expressions(expected, exp_count);
+	free(expected);
+	free(actual);
 }
 
 TEST_F(AlgebraicExpressionTest, VariableLength) {


### PR DESCRIPTION
This PR improves on issue #738 , although there are still cases such as:
`MATCH (p1)-[c1:connected_to]->(p2),(p2)-[c2:connected_to]->(p3),(p3)-[c3:connected_to]->(p4),(p4)-[c4:connected_to]->(p1),(p1)-[c5:connected_to]->(p5),(p5)-[c6:connected_to]->(p6),(p6)-[c7:connected_to]->(p2),(p2)-[c8:connected_to]->(p7),(p7)-[c9:connected_to]->(p8),(p8)-[c10:connected_to]->(p6),(p6)-[c11:connected_to]->(p2),(p2)-[c12:connected_to]->(p3),(p3)-[c13:connected_to]->(p9),(p9)-[c14:connected_to]->(p7) WHERE 1=1 AND p1 <> p2 AND p1 <> p3 AND p1 <> p4 AND p1 <> p5 AND p1 <> p6 AND p1 <> p7 AND p1 <> p8 AND p1 <> p9 AND p2 <> p3 AND p2 <> p4 AND p2 <> p5 AND p2 <> p6 AND p2 <> p7 AND p2 <> p8 AND p2 <> p9 AND p3 <> p4 AND p3 <> p5 AND p3 <> p6 AND p3 <> p7 AND p3 <> p8 AND p3 <> p9 AND p4 <> p5 AND p4 <> p6 AND p4 <> p7 AND p4 <> p8 AND p4 <> p9 AND p5 <> p6 AND p5 <> p7 AND p5 <> p8 AND p5 <> p9 AND p6 <> p7 AND p6 <> p8 AND p6 <> p9 AND p7 <> p8 AND p7 <> p9 AND p8 <> p9 RETURN DISTINCT p1,p2,p3,p4,p5,p6,p7,p8,p9,c1,c2,c3,c4,c5,c6,c7,c8,c9,c10,c11,c12,c13,c14`

which seems to loop infinitely after algebraic expression construction.