### PR TITLE
Only build the graphblas_static target

### DIFF
--- a/deps/GraphBLAS/Makefile
+++ b/deps/GraphBLAS/Makefile
@@ -41,6 +41,9 @@ cmake:
 static:
 	( cd build ; cmake $(CMAKE_OPTIONS) -DBUILD_GRB_STATIC_LIBRARY=1 .. ; $(MAKE) --jobs=$(JOBS) )
 
+static_only:
+	( cd build ; cmake $(CMAKE_OPTIONS) -DBUILD_GRB_STATIC_LIBRARY=1 .. ; $(MAKE) --jobs=$(JOBS) graphblas_static )
+
 # installs GraphBLAS to the install location defined by cmake, usually
 # /usr/local/lib and /usr/local/include
 install:

--- a/src/Makefile
+++ b/src/Makefile
@@ -127,7 +127,7 @@ $(LIBXXHASH):
 # Build GraphBLAS only if library does not already exists.
 $(GRAPHBLAS):
 ifeq (,$(wildcard $(GRAPHBLAS)))
-	@$(MAKE) -C ../deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)' -DCMAKE_CXX_COMPILER='$(CXX)'" static
+	@$(MAKE) -C ../deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)' -DCMAKE_CXX_COMPILER='$(CXX)'" static_only
 endif
 .PHONY: $(GRAPHBLAS)
 


### PR DESCRIPTION
Introduce updated `static_only` Makefile target, skip GraphBLAS demo compilation and resolve Docker build issues.