### PR TITLE
Module key access

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For more verbose output, run ```make test V=1```.
 
 ## Loading RedisGraph into Redis
 
-RedisGraph is hosted by [Redis](https://redis.io), so you'll first have to load it as a Module to a Redis server: running [Redis v4.0 or above](https://redis.io/download).
+RedisGraph is hosted by [Redis](https://redis.io), so you'll first have to load it as a Module to a Redis server: running [Redis v5.0.7 or above](https://redis.io/download).
 
 We recommend having Redis load RedisGraph during startup by adding the following to your redis.conf file:
 

--- a/ramp.yml
+++ b/ramp.yml
@@ -5,8 +5,8 @@ description: A graph database on top of Redis which supports Open-Cypher query l
 homepage: http://redisgraph.io
 license: Redis Source Available License Agreement
 command_line_args: ""
-min_redis_version: "5.0.5"
-min_redis_pack_version: "5.4.2"
+min_redis_version: "5.0.7"
+min_redis_pack_version: "5.4.11"
 capabilities:
     - types
     - hash_policy

--- a/src/commands/cmd_bulk_insert.c
+++ b/src/commands/cmd_bulk_insert.c
@@ -12,13 +12,13 @@
 
 void _MGraph_BulkInsert(void *args) {
 	// Establish thread-safe environment for batch insertion
-	CommandCtx *cmd_ctx = (CommandCtx *)args;
-	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(cmd_ctx);
+	CommandCtx *command_ctx = (CommandCtx *)args;
+	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(command_ctx);
 
-	RedisModuleString **argv = cmd_ctx->argv + 1; // skip "GRAPH.BULK"
+	RedisModuleString **argv = command_ctx->argv + 1; // skip "GRAPH.BULK"
 	RedisModuleString *rs_graph_name = *argv++;
 	const char *graphname = RedisModule_StringPtrLen(rs_graph_name, NULL);
-	int argc = cmd_ctx->argc - 2; // skip "GRAPH.BULK [GRAPHNAME]"
+	int argc = command_ctx->argc - 2; // skip "GRAPH.BULK [GRAPHNAME]"
 	RedisModuleKey *key;
 
 	char reply[1024] = {0}; // Prepare the Redis string response
@@ -94,8 +94,8 @@ cleanup:
 		Graph_ReleaseLock(gc->g);
 		GraphContext_Release(gc);
 	}
-	CommandCtx_ThreadSafeContextUnlock(cmd_ctx);
-	CommandCtx_Free(cmd_ctx);
+	CommandCtx_ThreadSafeContextUnlock(command_ctx);
+	CommandCtx_Free(command_ctx);
 }
 
 int MGraph_BulkInsert(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {

--- a/src/commands/cmd_bulk_insert.c
+++ b/src/commands/cmd_bulk_insert.c
@@ -103,7 +103,7 @@ int MGraph_BulkInsert(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	CommandCtx *context;
 	// Bulk commands should always modify slaves.
 	bool is_replicated = false;
-	context = CommandCtx_New(ctx, NULL, NULL, NULL, argv, argc, is_replicated);
+	context = CommandCtx_New(ctx, NULL, NULL, NULL, NULL, argv, argc, is_replicated);
 	_MGraph_BulkInsert(context);
 	RedisModule_ReplicateVerbatim(ctx);
 	return REDISMODULE_OK;

--- a/src/commands/cmd_context.c
+++ b/src/commands/cmd_context.c
@@ -28,59 +28,59 @@ CommandCtx *CommandCtx_New
 	return context;
 }
 
-RedisModuleCtx *CommandCtx_GetRedisCtx(CommandCtx *qctx) {
-	assert(qctx);
+RedisModuleCtx *CommandCtx_GetRedisCtx(CommandCtx *command_ctx) {
+	assert(command_ctx);
 	// Either we already have a context or block client is set.
-	if(qctx->ctx) return qctx->ctx;
+	if(command_ctx->ctx) return command_ctx->ctx;
 
-	assert(qctx->bc);
-	qctx->ctx = RedisModule_GetThreadSafeContext(qctx->bc);
-	return qctx->ctx;
+	assert(command_ctx->bc);
+	command_ctx->ctx = RedisModule_GetThreadSafeContext(command_ctx->bc);
+	return command_ctx->ctx;
 }
 
-RedisModuleBlockedClient *CommandCtx_GetBlockingClient(const CommandCtx *qctx) {
-	assert(qctx);
-	return qctx->bc;
+RedisModuleBlockedClient *CommandCtx_GetBlockingClient(const CommandCtx *command_ctx) {
+	assert(command_ctx);
+	return command_ctx->bc;
 }
 
-GraphContext *CommandCtx_GetGraphContext(const CommandCtx *qctx) {
-	assert(qctx);
-	return qctx->graph_ctx;
+GraphContext *CommandCtx_GetGraphContext(const CommandCtx *command_ctx) {
+	assert(command_ctx);
+	return command_ctx->graph_ctx;
 }
 
-const char *CommandCtx_GetCommandName(const CommandCtx *qctx) {
-	assert(qctx);
-	return qctx->command_name;
+const char *CommandCtx_GetCommandName(const CommandCtx *command_ctx) {
+	assert(command_ctx);
+	return command_ctx->command_name;
 }
 
-const char *CommandCtx_GetQuery(const CommandCtx *qctx) {
-	assert(qctx);
-	return qctx->query;
+const char *CommandCtx_GetQuery(const CommandCtx *command_ctx) {
+	assert(command_ctx);
+	return command_ctx->query;
 }
 
-void CommandCtx_ThreadSafeContextLock(const CommandCtx *qctx) {
+void CommandCtx_ThreadSafeContextLock(const CommandCtx *command_ctx) {
 	/* Acquire lock only when working with a blocked client
 	 * otherwise we're running on Redis main thread,
 	 * no need to acquire lock. */
-	assert(qctx && qctx->ctx);
-	if(qctx->bc) RedisModule_ThreadSafeContextLock(qctx->ctx);
+	assert(command_ctx && command_ctx->ctx);
+	if(command_ctx->bc) RedisModule_ThreadSafeContextLock(command_ctx->ctx);
 }
 
-void CommandCtx_ThreadSafeContextUnlock(const CommandCtx *qctx) {
+void CommandCtx_ThreadSafeContextUnlock(const CommandCtx *command_ctx) {
 	/* Release lock only when working with a blocked client
 	 * otherwise we're running on Redis main thread,
 	 * no need to release lock. */
-	assert(qctx && qctx->ctx);
-	if(qctx->bc) RedisModule_ThreadSafeContextUnlock(qctx->ctx);
+	assert(command_ctx && command_ctx->ctx);
+	if(command_ctx->bc) RedisModule_ThreadSafeContextUnlock(command_ctx->ctx);
 }
 
-void CommandCtx_Free(CommandCtx *qctx) {
-	if(qctx->bc) {
-		RedisModule_UnblockClient(qctx->bc, NULL);
-		RedisModule_FreeThreadSafeContext(qctx->ctx);
+void CommandCtx_Free(CommandCtx *command_ctx) {
+	if(command_ctx->bc) {
+		RedisModule_UnblockClient(command_ctx->bc, NULL);
+		RedisModule_FreeThreadSafeContext(command_ctx->ctx);
 	}
 
-	if(qctx->query) rm_free(qctx->query);
-	rm_free(qctx);
+	if(command_ctx->query) rm_free(command_ctx->query);
+	rm_free(command_ctx);
 }
 

--- a/src/commands/cmd_context.c
+++ b/src/commands/cmd_context.c
@@ -6,6 +6,7 @@ CommandCtx *CommandCtx_New
 (
 	RedisModuleCtx *ctx,
 	RedisModuleBlockedClient *bc,
+	const char *command_name,
 	GraphContext *graph_ctx,
 	RedisModuleString *query,
 	RedisModuleString **argv,
@@ -19,6 +20,7 @@ CommandCtx *CommandCtx_New
 	context->argc = argc;
 	context->replicated_command = replicated_command;
 	context->graph_ctx = graph_ctx;
+	context->command_name = command_name;
 
 	// Make a copy of query.
 	context->query = (query) ? rm_strdup(RedisModule_StringPtrLen(query, NULL)) : NULL;
@@ -36,9 +38,24 @@ RedisModuleCtx *CommandCtx_GetRedisCtx(CommandCtx *qctx) {
 	return qctx->ctx;
 }
 
+RedisModuleBlockedClient *CommandCtx_GetBlockingClient(const CommandCtx *qctx) {
+	assert(qctx);
+	return qctx->bc;
+}
+
 GraphContext *CommandCtx_GetGraphContext(const CommandCtx *qctx) {
 	assert(qctx);
 	return qctx->graph_ctx;
+}
+
+const char *CommandCtx_GetCommandName(const CommandCtx *qctx) {
+	assert(qctx);
+	return qctx->command_name;
+}
+
+const char *CommandCtx_GetQuery(const CommandCtx *qctx) {
+	assert(qctx);
+	return qctx->query;
 }
 
 void CommandCtx_ThreadSafeContextLock(const CommandCtx *qctx) {

--- a/src/commands/cmd_context.h
+++ b/src/commands/cmd_context.h
@@ -14,6 +14,7 @@
 typedef struct {
 	char *query;                    // Query string.
 	RedisModuleCtx *ctx;            // Redis module context.
+	const char *command_name;       // Command to execute.
 	GraphContext *graph_ctx;        // Graph context.
 	RedisModuleString **argv;       // Arguments.
 	RedisModuleBlockedClient *bc;   // Blocked client.
@@ -26,6 +27,7 @@ CommandCtx *CommandCtx_New
 (
 	RedisModuleCtx *ctx,            // Redis module context.
 	RedisModuleBlockedClient *bc,   // Blocked client.
+	const char *command_name,       // Command to execute.
 	GraphContext *graph_ctx,        // Graph context.
 	RedisModuleString *query,       // Query string.
 	RedisModuleString **argv,       // Arguments.
@@ -39,8 +41,23 @@ RedisModuleCtx *CommandCtx_GetRedisCtx
 	CommandCtx *qctx
 );
 
+// Get blocking client.
+RedisModuleBlockedClient *CommandCtx_GetBlockingClient(
+	const CommandCtx *qctx
+);
+
 // Get GraphContext.
-GraphContext* CommandCtx_GetGraphContext
+GraphContext *CommandCtx_GetGraphContext
+(
+	const CommandCtx *qctx
+);
+
+// Get command name.
+const char *CommandCtx_GetCommandName(
+	const CommandCtx *qctx
+);
+
+const char *CommandCtx_GetQuery
 (
 	const CommandCtx *qctx
 );

--- a/src/commands/cmd_context.h
+++ b/src/commands/cmd_context.h
@@ -38,45 +38,46 @@ CommandCtx *CommandCtx_New
 // Get Redis module context
 RedisModuleCtx *CommandCtx_GetRedisCtx
 (
-	CommandCtx *qctx
+	CommandCtx *command_ctx
 );
 
 // Get blocking client.
-RedisModuleBlockedClient *CommandCtx_GetBlockingClient(
-	const CommandCtx *qctx
+RedisModuleBlockedClient *CommandCtx_GetBlockingClient
+(
+	const CommandCtx *command_ctx
 );
 
 // Get GraphContext.
 GraphContext *CommandCtx_GetGraphContext
 (
-	const CommandCtx *qctx
+	const CommandCtx *command_ctx
 );
 
 // Get command name.
-const char *CommandCtx_GetCommandName(
-	const CommandCtx *qctx
+const char *CommandCtx_GetCommandName
+(
+	const CommandCtx *command_ctx
 );
 
 const char *CommandCtx_GetQuery
 (
-	const CommandCtx *qctx
+	const CommandCtx *command_ctx
 );
 
 // Acquire Redis global lock.
 void CommandCtx_ThreadSafeContextLock
 (
-	const CommandCtx *qctx
+	const CommandCtx *command_ctx
 );
 
 // Release Redis global lock.
 void CommandCtx_ThreadSafeContextUnlock
 (
-	const CommandCtx *qctx
+	const CommandCtx *command_ctx
 );
 
 // Free command context.
 void CommandCtx_Free
 (
-	CommandCtx *qctx
+	CommandCtx *command_ctx
 );
-

--- a/src/commands/cmd_dispatcher.c
+++ b/src/commands/cmd_dispatcher.c
@@ -57,12 +57,12 @@ int CommandDispatch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 											REDISMODULE_CTX_FLAGS_LOADING));
 	if(execute_on_main_thread) {
 		// Run query on Redis main thread.
-		context = CommandCtx_New(ctx, NULL, gc, argv[2], argv, argc, is_replicated);
+		context = CommandCtx_New(ctx, NULL, command_name, gc, argv[2], argv, argc, is_replicated);
 		handler(context);
 	} else {
 		// Run query on a dedicated thread.
 		RedisModuleBlockedClient *bc = RedisModule_BlockClient(ctx, NULL, NULL, NULL, 0);
-		context = CommandCtx_New(NULL, bc, gc, argv[2], argv, argc, is_replicated);
+		context = CommandCtx_New(NULL, bc, command_name, gc, argv[2], argv, argc, is_replicated);
 		thpool_add_work(_thpool, handler, context);
 	}
 

--- a/src/commands/cmd_dispatcher.c
+++ b/src/commands/cmd_dispatcher.c
@@ -66,9 +66,5 @@ int CommandDispatch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 		thpool_add_work(_thpool, handler, context);
 	}
 
-	// Replicate the command to slaves and AOF.
-	// If the query is read-only, slaves will do nothing after parsing.
-	// TODO: only replicate if query is a writer.
-	if(cmd == CMD_QUERY || cmd == CMD_PROFILE) RedisModule_ReplicateVerbatim(ctx);
 	return REDISMODULE_OK;
 }

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -20,14 +20,14 @@ void Graph_Explain(void *args) {
 	AST *ast = NULL;
 	bool lock_acquired = false;
 	ExecutionPlan *plan = NULL;
-	CommandCtx *qctx = (CommandCtx *)args;
-	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(qctx);
-	GraphContext *gc = CommandCtx_GetGraphContext(qctx);
-	QueryCtx_SetGlobalExecCtx(qctx);
-	const char *query = qctx->query;
+	CommandCtx *command_ctx = (CommandCtx *)args;
+	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(command_ctx);
+	GraphContext *gc = CommandCtx_GetGraphContext(command_ctx);
+	QueryCtx_SetGlobalExecutionCtx(command_ctx);
+	const char *query = command_ctx->query;
 
 	// Parse the query to construct an AST
-	cypher_parse_result_t *parse_result = parse(qctx->query);
+	cypher_parse_result_t *parse_result = parse(command_ctx->query);
 	if(parse_result == NULL) goto cleanup;
 
 	// Perform query validations
@@ -59,7 +59,7 @@ cleanup:
 	AST_Free(ast);
 	QueryCtx_Free(); // Reset the QueryCtx and free its allocations.
 	GraphContext_Release(gc);
-	CommandCtx_Free(qctx);
+	CommandCtx_Free(command_ctx);
 	parse_result_free(parse_result);
 }
 

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -23,10 +23,8 @@ void Graph_Explain(void *args) {
 	CommandCtx *qctx = (CommandCtx *)args;
 	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(qctx);
 	GraphContext *gc = CommandCtx_GetGraphContext(qctx);
-	QueryCtx_SetGraphCtx(gc);
+	QueryCtx_SetGlobalExecCtx(qctx);
 	const char *query = qctx->query;
-
-	QueryCtx_SetRedisModuleCtx(ctx);
 
 	// Parse the query to construct an AST
 	cypher_parse_result_t *parse_result = parse(qctx->query);

--- a/src/commands/cmd_profile.c
+++ b/src/commands/cmd_profile.c
@@ -28,8 +28,6 @@ void Graph_Profile(void *args) {
 	if(parse_result == NULL) goto cleanup;
 
 	bool readonly = AST_ReadOnly(parse_result);
-	// If we are a replica and the query is read-only, no work needs to be done.
-	if(readonly && command_ctx->replicated_command) goto cleanup;
 
 	// Perform query validations
 	if(AST_Validate(ctx, parse_result) != AST_VALID) goto cleanup;

--- a/src/commands/cmd_profile.c
+++ b/src/commands/cmd_profile.c
@@ -19,10 +19,9 @@ void Graph_Profile(void *args) {
 	CommandCtx *qctx = (CommandCtx *)args;
 	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(qctx);
 	GraphContext *gc = CommandCtx_GetGraphContext(qctx);
-	QueryCtx_SetGraphCtx(gc);
+	QueryCtx_SetGlobalExecCtx(qctx);
 
 	QueryCtx_BeginTimer(); // Start query timing.
-	QueryCtx_SetRedisModuleCtx(ctx);
 
 	// Parse the query to construct an AST
 	cypher_parse_result_t *parse_result = parse(qctx->query);

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -79,8 +79,6 @@ void Graph_Query(void *args) {
 	cypher_parse_result_t *parse_result = parse(command_ctx->query);
 	if(parse_result == NULL) goto cleanup;
 	bool readonly = AST_ReadOnly(parse_result);
-	// If we are a replica and the query is read-only, no work needs to be done.
-	if(readonly && command_ctx->replicated_command) goto cleanup;
 
 	// Perform query validations
 	if(AST_Validate(ctx, parse_result) != AST_VALID) goto cleanup;

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -57,37 +57,37 @@ static void _index_operation(RedisModuleCtx *ctx, GraphContext *gc,
 	ResultSet_ReportQueryRuntime(ctx);
 }
 
-static inline bool _check_compact_flag(CommandCtx *qctx) {
+static inline bool _check_compact_flag(CommandCtx *command_ctx) {
 	// The only additional argument to check currently is whether the query results
 	// should be returned in compact form
-	return (qctx->argc > 3 &&
-			!strcasecmp(RedisModule_StringPtrLen(qctx->argv[3], NULL), "--compact"));
+	return (command_ctx->argc > 3 &&
+			!strcasecmp(RedisModule_StringPtrLen(command_ctx->argv[3], NULL), "--compact"));
 }
 
 void Graph_Query(void *args) {
 	AST *ast = NULL;
 	bool lockAcquired = false;
 	ResultSet *result_set = NULL;
-	CommandCtx *qctx = (CommandCtx *)args;
-	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(qctx);
-	GraphContext *gc = CommandCtx_GetGraphContext(qctx);
-	QueryCtx_SetGlobalExecCtx(qctx);
+	CommandCtx *command_ctx = (CommandCtx *)args;
+	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(command_ctx);
+	GraphContext *gc = CommandCtx_GetGraphContext(command_ctx);
+	QueryCtx_SetGlobalExecutionCtx(command_ctx);
 
 	QueryCtx_BeginTimer(); // Start query timing.
 
 	// Parse the query to construct an AST.
-	cypher_parse_result_t *parse_result = parse(qctx->query);
+	cypher_parse_result_t *parse_result = parse(command_ctx->query);
 	if(parse_result == NULL) goto cleanup;
 	bool readonly = AST_ReadOnly(parse_result);
 	// If we are a replica and the query is read-only, no work needs to be done.
-	if(readonly && qctx->replicated_command) goto cleanup;
+	if(readonly && command_ctx->replicated_command) goto cleanup;
 
 	// Perform query validations
 	if(AST_Validate(ctx, parse_result) != AST_VALID) goto cleanup;
 	// Prepare the constructed AST for accesses from the module
 	ast = AST_Build(parse_result);
 
-	bool compact = _check_compact_flag(qctx);
+	bool compact = _check_compact_flag(command_ctx);
 	// Acquire the appropriate lock.
 	if(readonly) {
 		Graph_AcquireReadLock(gc->g);
@@ -96,11 +96,11 @@ void Graph_Query(void *args) {
 		/* If this is a writer query we need to re-open the graph key with write flag
 		* this notifies Redis that the key is "dirty" any watcher on that key will
 		* be notified. */
-		CommandCtx_ThreadSafeContextLock(qctx);
+		CommandCtx_ThreadSafeContextLock(command_ctx);
 		{
 			GraphContext_MarkWriter(ctx, gc);
 		}
-		CommandCtx_ThreadSafeContextUnlock(qctx);
+		CommandCtx_ThreadSafeContextUnlock(command_ctx);
 	}
 	lockAcquired = true;
 
@@ -136,7 +136,7 @@ cleanup:
 	AST_Free(ast);
 	parse_result_free(parse_result);
 	GraphContext_Release(gc);
-	CommandCtx_Free(qctx);
+	CommandCtx_Free(command_ctx);
 	QueryCtx_Free(); // Reset the QueryCtx and free its allocations.
 }
 

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -71,10 +71,9 @@ void Graph_Query(void *args) {
 	CommandCtx *qctx = (CommandCtx *)args;
 	RedisModuleCtx *ctx = CommandCtx_GetRedisCtx(qctx);
 	GraphContext *gc = CommandCtx_GetGraphContext(qctx);
-	QueryCtx_SetGraphCtx(gc);
+	QueryCtx_SetGlobalExecCtx(qctx);
 
 	QueryCtx_BeginTimer(); // Start query timing.
-	QueryCtx_SetRedisModuleCtx(ctx);
 
 	// Parse the query to construct an AST.
 	cypher_parse_result_t *parse_result = parse(qctx->query);

--- a/src/execution_plan/ops/op_create.c
+++ b/src/execution_plan/ops/op_create.c
@@ -249,7 +249,7 @@ static bool _CommitNewEntities(OpCreate *op) {
 	if(array_len(op->created_edges) > 0) _CommitEdges(op);
 	Graph_SetMatrixPolicy(g, SYNC_AND_MINIMIZE_SPACE);
 	// Release lock.
-	QueryCtx_NotifyCommitAndUnlock();
+	QueryCtx_UnlockCommit();
 
 	op->stats->nodes_created += node_count;
 	return true;

--- a/src/execution_plan/ops/op_create.c
+++ b/src/execution_plan/ops/op_create.c
@@ -9,6 +9,7 @@
 #include "../../query_ctx.h"
 #include "../../schema/schema.h"
 #include <assert.h>
+#include "../../query_ctx.h"
 
 /* Forward declarations. */
 static Record CreateConsume(OpBase *opBase);
@@ -237,20 +238,21 @@ static void _CommitEdges(OpCreate *op) {
 	op->stats->relationships_created += relationships_created;
 }
 
-static void _CommitNewEntities(OpCreate *op) {
+static bool _CommitNewEntities(OpCreate *op) {
 	Graph *g = op->gc->g;
 
 	// Lock everything.
-	Graph_AcquireWriteLock(g);
+	if(!QueryCtx_LockForCommit()) return false;
 	Graph_SetMatrixPolicy(g, RESIZE_TO_CAPACITY);
 	uint node_count = array_len(op->created_nodes);
 	if(node_count > 0) _CommitNodes(op);
 	if(array_len(op->created_edges) > 0) _CommitEdges(op);
 	Graph_SetMatrixPolicy(g, SYNC_AND_MINIMIZE_SPACE);
 	// Release lock.
-	Graph_ReleaseLock(g);
+	QueryCtx_NotifyCommitAndUnlock();
 
 	op->stats->nodes_created += node_count;
+	return true;
 }
 
 static Record _handoff(OpCreate *op) {
@@ -305,7 +307,7 @@ static Record CreateConsume(OpBase *opBase) {
 	if(child) OpBase_PropagateFree(child);
 
 	// Create entities.
-	_CommitNewEntities(op);
+	if(!_CommitNewEntities(op)) return NULL;
 
 	// Return record.
 	return _handoff(op);

--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -25,7 +25,7 @@ void _DeleteEntities(OpDelete *op) {
 	if((node_count + edge_count) == 0) return;
 
 	/* Lock everything. */
-	Graph_AcquireWriteLock(g);
+	QueryCtx_LockForCommit();
 
 	if(GraphContext_HasIndices(op->gc)) {
 		for(int i = 0; i < node_count; i++) {
@@ -38,7 +38,7 @@ void _DeleteEntities(OpDelete *op) {
 					 edge_count, &node_deleted, &relationships_deleted);
 
 	/* Release lock. */
-	Graph_ReleaseLock(g);
+	QueryCtx_NotifyCommitAndUnlock();
 
 	if(op->stats) op->stats->nodes_deleted += node_deleted;
 	if(op->stats) op->stats->relationships_deleted += relationships_deleted;

--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -38,7 +38,7 @@ void _DeleteEntities(OpDelete *op) {
 					 edge_count, &node_deleted, &relationships_deleted);
 
 	/* Release lock. */
-	QueryCtx_NotifyCommitAndUnlock();
+	QueryCtx_UnlockCommit();
 
 	if(op->stats) op->stats->nodes_deleted += node_deleted;
 	if(op->stats) op->stats->relationships_deleted += relationships_deleted;

--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -114,7 +114,7 @@ static bool _CreateEntities(OpMerge *op, Record r) {
 	_CommitEdges(op, r);
 
 	// Release lock.
-	QueryCtx_NotifyCommitAndUnlock();
+	QueryCtx_UnlockCommit();
 
 	OpBase_RemoveVolatileRecords((OpBase *)op); // No exceptions encountered, Records are not dangling.
 	return true;

--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -102,21 +102,22 @@ static void _CommitEdges(OpMerge *op, Record r) {
 	if(op->stats) op->stats->relationships_created += edge_count;
 }
 
-static void _CreateEntities(OpMerge *op, Record r) {
+static bool _CreateEntities(OpMerge *op, Record r) {
 	// Track the inherited Record and the newly-allocated Record so that they may be freed if execution fails.
 	OpBase_AddVolatileRecord((OpBase *)op, r);
 
 	// Lock everything.
-	Graph_AcquireWriteLock(op->gc->g);
+	if(!QueryCtx_LockForCommit()) return false;
 
 	// Commit query graph and set resultset statistics.
 	_CommitNodes(op, r);
 	_CommitEdges(op, r);
 
 	// Release lock.
-	Graph_ReleaseLock(op->gc->g);
+	QueryCtx_NotifyCommitAndUnlock();
 
 	OpBase_RemoveVolatileRecords((OpBase *)op); // No exceptions encountered, Records are not dangling.
+	return true;
 
 }
 
@@ -178,7 +179,7 @@ static Record MergeConsume(OpBase *opBase) {
 		OpBase_PropagateFree(child);
 
 		r = OpBase_CreateRecord((OpBase *)op);
-		_CreateEntities(op, r);
+		if(!_CreateEntities(op, r)) return NULL;
 		op->created = true;
 	}
 

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -210,7 +210,7 @@ static Record UpdateConsume(OpBase *opBase) {
 	if(!QueryCtx_LockForCommit()) return NULL;
 	_CommitUpdates(op);
 	// Release lock.
-	QueryCtx_NotifyCommitAndUnlock();
+	QueryCtx_UnlockCommit();
 
 	op->updates_commited = true;
 	return _handoff(op);

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -8,6 +8,7 @@
 #include "../../util/arr.h"
 #include "../../util/rmalloc.h"
 #include "../../arithmetic/arithmetic_expression.h"
+#include "../../query_ctx.h"
 
 /* Forward declarations. */
 static OpResult UpdateInit(OpBase *opBase);
@@ -206,10 +207,10 @@ static Record UpdateConsume(OpBase *opBase) {
 	OpBase_PropagateFree(child);
 
 	/* Lock everything. */
-	Graph_AcquireWriteLock(op->gc->g);
+	if(!QueryCtx_LockForCommit()) return NULL;
 	_CommitUpdates(op);
 	// Release lock.
-	Graph_ReleaseLock(op->gc->g);
+	QueryCtx_NotifyCommitAndUnlock();
 
 	op->updates_commited = true;
 	return _handoff(op);

--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -7,6 +7,7 @@
 #include "query_ctx.h"
 #include "util/simple_timer.h"
 #include <assert.h>
+#include "graph/serializers/graphcontext_type.h"
 
 pthread_key_t _tlsQueryCtxKey;  // Thread local storage query context key.
 
@@ -23,13 +24,13 @@ static inline QueryCtx *_QueryCtx_GetCtx(void) {
 /* Retrieve the exception handler. */
 static jmp_buf *_QueryCtx_GetExceptionHandler(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	return ctx->breakpoint;
+	return ctx->internal_exec_ctx.breakpoint;
 }
 
 /* Retrieve the error message if the query generated one. */
 static char *_QueryCtx_GetError(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	return ctx->error;
+	return ctx->internal_exec_ctx.error;
 }
 
 bool QueryCtx_Init(void) {
@@ -42,7 +43,7 @@ void QueryCtx_Finalize(void) {
 
 void QueryCtx_BeginTimer(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx(); // Attempt to retrieve the QueryCtx.
-	simple_tic(ctx->timer); // Start the execution timer.
+	simple_tic(ctx->internal_exec_ctx.timer); // Start the execution timer.
 }
 
 /* An error was encountered during evaluation, and has already been set in the QueryCtx.
@@ -63,9 +64,17 @@ void QueryCtx_EmitException(void) {
 	}
 }
 
+void QueryCtx_SetGlobalExecCtx(CommandCtx *cmd_ctx) {
+	QueryCtx *ctx = _QueryCtx_GetCtx();
+	ctx->global_exec_ctx.redis_ctx = cmd_ctx->ctx;
+	ctx->global_exec_ctx.bc = cmd_ctx->bc;
+	ctx->gc = cmd_ctx->graph_ctx;
+	ctx->query_data.query = cmd_ctx->query;
+}
+
 void QueryCtx_SetAST(AST *ast) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	ctx->ast = ast;
+	ctx->query_data.ast = ast;
 }
 
 void QueryCtx_SetGraphCtx(GraphContext *gc) {
@@ -75,24 +84,19 @@ void QueryCtx_SetGraphCtx(GraphContext *gc) {
 
 void QueryCtx_SetError(char *error) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	ctx->error = error;
-}
-
-void QueryCtx_SetRedisModuleCtx(RedisModuleCtx *redisctx) {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
-	ctx->redisctx = redisctx;
+	ctx->internal_exec_ctx.error = error;
 }
 
 AST *QueryCtx_GetAST(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	assert(ctx->ast);
-	return ctx->ast;
+	assert(ctx->query_data.ast);
+	return ctx->query_data.ast;
 }
 
 rax *QueryCtx_GetParams(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	if(!ctx->params) ctx->params = raxNew();
-	return ctx->params;
+	if(!ctx->query_data.params) ctx->query_data.params = raxNew();
+	return ctx->query_data.params;
 }
 
 GraphContext *QueryCtx_GetGraphCtx(void) {
@@ -108,35 +112,100 @@ Graph *QueryCtx_GetGraph(void) {
 
 RedisModuleCtx *QueryCtx_GetRedisModuleCtx(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	return ctx->redisctx;
+	return ctx->global_exec_ctx.redis_ctx;
+}
+
+static void _QueryCtx_ThreadSafeContextLock(QueryCtx *ctx) {
+	if(ctx->global_exec_ctx.bc) RedisModule_ThreadSafeContextLock(ctx->global_exec_ctx.redis_ctx);
+}
+
+static void _QueryCtx_ThreadSafeContextUnlock(QueryCtx *ctx) {
+	if(ctx->global_exec_ctx.bc) RedisModule_ThreadSafeContextUnlock(ctx->global_exec_ctx.redis_ctx);
+}
+
+bool QueryCtx_LockForCommit(void) {
+	QueryCtx *ctx = _QueryCtx_GetCtx();
+	// Lock GIL.
+	RedisModuleCtx *redis_ctx = ctx->global_exec_ctx.redis_ctx;
+	GraphContext *gc = ctx->gc;
+	_QueryCtx_ThreadSafeContextLock(ctx);
+	// Open key and verify.
+	RedisModuleString *graphID = RedisModule_CreateString(redis_ctx, gc->graph_name,
+														  strlen(gc->graph_name));
+	RedisModuleKey *key = RedisModule_OpenKey(redis_ctx, graphID, REDISMODULE_WRITE);
+	if(RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_EMPTY) {
+		asprintf(&ctx->internal_exec_ctx.error, "Encountered an empty key when opened key %s ",
+				 ctx->gc->graph_name);
+
+		goto clean_up;
+	}
+	if(RedisModule_ModuleTypeGetType(key) != GraphContextRedisModuleType) {
+		asprintf(&ctx->internal_exec_ctx.error, "Encountered a non-graph value type when opened key %s ",
+				 ctx->gc->graph_name);
+		goto clean_up;
+
+	}
+	if(gc != RedisModule_ModuleTypeGetValue(key)) {
+		asprintf(&ctx->internal_exec_ctx.error, "Encountered different graph value when opened key %s ",
+				 ctx->gc->graph_name);
+		goto clean_up;
+	}
+	RedisModule_FreeString(redis_ctx, graphID);
+	ctx->internal_exec_ctx.key = key;
+	// Acquire graph write lock.
+	Graph_AcquireWriteLock(gc->g);
+	return true;
+
+clean_up:
+	// Unlock GIL.
+	_QueryCtx_ThreadSafeContextUnlock(ctx);
+	// If there is a break point for runtime exception, raise it, otherwise return false.
+	QueryCtx_RaiseRuntimeException();
+	return false;
+
+}
+
+void QueryCtx_NotifyCommitAndUnlock(void) {
+	QueryCtx *ctx = _QueryCtx_GetCtx();
+	RedisModuleCtx *redis_ctx = ctx->global_exec_ctx.redis_ctx;
+	GraphContext *gc = ctx->gc;
+
+	// Replicate.
+	RedisModule_ReplicateVerbatim(redis_ctx);
+	// Release graph R/W lock.
+	Graph_ReleaseLock(gc->g);
+	// Close Key.
+	RedisModule_CloseKey(ctx->internal_exec_ctx.key);
+	// Unlock GIL.
+	_QueryCtx_ThreadSafeContextUnlock(ctx);
 }
 
 inline bool QueryCtx_EncounteredError(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	return ctx->error != NULL;
+	return ctx->internal_exec_ctx.error != NULL;
 }
 
 double QueryCtx_GetExecutionTime(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	return simple_toc(ctx->timer) * 1000;
+	return simple_toc(ctx->internal_exec_ctx.timer) * 1000;
 }
 
 void QueryCtx_Free(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
 
-	if(ctx->error) {
-		free(ctx->error);
-		ctx->error = NULL;
+	if(ctx->internal_exec_ctx.error) {
+		free(ctx->internal_exec_ctx.error);
+		ctx->internal_exec_ctx.error = NULL;
 	}
 
-	if(ctx->breakpoint) {
-		rm_free(ctx->breakpoint);
-		ctx->breakpoint = NULL;
+	if(ctx->internal_exec_ctx.breakpoint) {
+		rm_free(ctx->internal_exec_ctx.breakpoint);
+		ctx->internal_exec_ctx.breakpoint = NULL;
 	}
 
-	if(ctx->params) {
-		raxFree(ctx->params);
-		ctx->params = NULL;
+	if(ctx->query_data.params) {
+		raxFree(ctx->query_data.params);
+		ctx->query_data.params = NULL;
 	}
 
 	rm_free(ctx);

--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -135,19 +135,19 @@ bool QueryCtx_LockForCommit(void) {
 														  strlen(gc->graph_name));
 	RedisModuleKey *key = RedisModule_OpenKey(redis_ctx, graphID, REDISMODULE_WRITE);
 	if(RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_EMPTY) {
-		asprintf(&ctx->internal_exec_ctx.error, "Encountered an empty key when opened key %s ",
+		asprintf(&ctx->internal_exec_ctx.error, "Encountered an empty key when opened key %s",
 				 ctx->gc->graph_name);
 
 		goto clean_up;
 	}
 	if(RedisModule_ModuleTypeGetType(key) != GraphContextRedisModuleType) {
-		asprintf(&ctx->internal_exec_ctx.error, "Encountered a non-graph value type when opened key %s ",
+		asprintf(&ctx->internal_exec_ctx.error, "Encountered a non-graph value type when opened key %s",
 				 ctx->gc->graph_name);
 		goto clean_up;
 
 	}
 	if(gc != RedisModule_ModuleTypeGetValue(key)) {
-		asprintf(&ctx->internal_exec_ctx.error, "Encountered different graph value when opened key %s ",
+		asprintf(&ctx->internal_exec_ctx.error, "Encountered different graph value when opened key %s",
 				 ctx->gc->graph_name);
 		goto clean_up;
 	}

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -12,17 +12,33 @@
 #include "graph/graphcontext.h"
 #include <setjmp.h>
 #include <pthread.h>
+#include "commands/cmd_context.h"
 
 extern pthread_key_t _tlsQueryCtxKey;  // Thread local storage query context key.
 
 typedef struct {
-	AST *ast;                   // The scoped AST associated with this query.
-	rax *params;                // Query parameters.
-	char *error;                // The error message produced by this query, if any.
-	double timer[2];            // Query execution time tracking.
-	GraphContext *gc;           // The GraphContext associated with this query's graph.
-	jmp_buf *breakpoint;        // The breakpoint to return to if the query causes an exception.
-	RedisModuleCtx *redisctx;   // The Redis module context.
+	AST *ast;       // The scoped AST associated with this query.
+	rax *params;    // Query parameters.
+	char *query;    // Query string.
+} QueryCtx_QueryData;
+
+typedef struct {
+	char *error;            // The error message produced by this query, if any.
+	double timer[2];        // Query execution time tracking.
+	jmp_buf *breakpoint;    // The breakpoint to return to if the query causes an exception.
+	RedisModuleKey *key;    // Saves an open key value, for later extraction and closing.
+} QueryCtx_InternalExecCtx;
+
+typedef struct {
+	RedisModuleCtx *redis_ctx;      // The Redis module context.
+	RedisModuleBlockedClient *bc;   // Blocked client.
+} QueryCtx_GlobalExecCtx;
+
+typedef struct {
+	QueryCtx_QueryData query_data;              // The data related to the query syntax.
+	QueryCtx_InternalExecCtx internal_exec_ctx; // The data related to internal query execution.
+	QueryCtx_GlobalExecCtx global_exec_ctx;     // The data rlated to global redis execution.
+	GraphContext *gc;                           // The GraphContext associated with this query's graph.
 } QueryCtx;
 
 /* On invocation, set an exception handler, returning 0 from this macro.
@@ -30,8 +46,8 @@ typedef struct {
 #define SET_EXCEPTION_HANDLER()                                         \
    ({                                                                   \
 	QueryCtx *ctx = pthread_getspecific(_tlsQueryCtxKey);               \
-	if(!ctx->breakpoint) ctx->breakpoint = rm_malloc(sizeof(jmp_buf));  \
-	setjmp(*ctx->breakpoint);                                           \
+	if(!ctx->internal_exec_ctx.breakpoint) ctx->internal_exec_ctx.breakpoint = rm_malloc(sizeof(jmp_buf));  \
+	setjmp(*ctx->internal_exec_ctx.breakpoint);                                           \
 })
 
 /* Instantiate the thread-local QueryCtx on module load. */
@@ -47,6 +63,8 @@ void QueryCtx_RaiseRuntimeException(void);
 void QueryCtx_EmitException(void);
 
 /* Setters */
+/* Sets the global execution context */
+void QueryCtx_SetGlobalExecCtx(CommandCtx *cmd_ctx);
 /* Set the provided AST for access through the QueryCtx. */
 void QueryCtx_SetAST(AST *ast);
 /* Set the error message for this query. */
@@ -67,6 +85,23 @@ Graph *QueryCtx_GetGraph(void);
 GraphContext *QueryCtx_GetGraphCtx(void);
 /* Retrieve the Redis module context. */
 RedisModuleCtx *QueryCtx_GetRedisModuleCtx(void);
+
+/* Starts a locking flow before commiting changes in the graph and Redis keyspace.
+ * Locking flow is:
+ * 1. LOCK GIL
+ * 2. Key open with `write` flag
+ * 3. Graph R/W lock with write flag
+ * This method returns false if the key has changed from the current graph,
+ * and sets the relevant error message. */
+bool QueryCtx_LockForCommit(void);
+
+/* Starts an ulocking flow and notifies Redis after commiting changes in the graph and Redis keyspace.
+ * Unlocking flow is:
+ * 1. Replicate verbatim
+ * 2. Unlock graph R/W lock
+ * 3. Close key
+ * 4. Unlock GIL */
+void QueryCtx_NotifyCommitAndUnlock(void);
 
 /* Compute and return elapsed query execution time. */
 double QueryCtx_GetExecutionTime(void);

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -19,7 +19,7 @@ extern pthread_key_t _tlsQueryCtxKey;  // Thread local storage query context key
 typedef struct {
 	AST *ast;       // The scoped AST associated with this query.
 	rax *params;    // Query parameters.
-	char *query;    // Query string.
+	const char *query;    // Query string.
 } QueryCtx_QueryData;
 
 typedef struct {
@@ -32,6 +32,7 @@ typedef struct {
 typedef struct {
 	RedisModuleCtx *redis_ctx;      // The Redis module context.
 	RedisModuleBlockedClient *bc;   // Blocked client.
+	const char *command_name;       // Command name.
 } QueryCtx_GlobalExecCtx;
 
 typedef struct {

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -65,7 +65,7 @@ void QueryCtx_EmitException(void);
 
 /* Setters */
 /* Sets the global execution context */
-void QueryCtx_SetGlobalExecCtx(CommandCtx *cmd_ctx);
+void QueryCtx_SetGlobalExecutionCtx(CommandCtx *cmd_ctx);
 /* Set the provided AST for access through the QueryCtx. */
 void QueryCtx_SetAST(AST *ast);
 /* Set the error message for this query. */
@@ -98,11 +98,11 @@ bool QueryCtx_LockForCommit(void);
 
 /* Starts an ulocking flow and notifies Redis after commiting changes in the graph and Redis keyspace.
  * Unlocking flow is:
- * 1. Replicate verbatim
+ * 1. Replicate.
  * 2. Unlock graph R/W lock
  * 3. Close key
  * 4. Unlock GIL */
-void QueryCtx_NotifyCommitAndUnlock(void);
+void QueryCtx_UnlockCommit(void);
 
 /* Compute and return elapsed query execution time. */
 double QueryCtx_GetExecutionTime(void);


### PR DESCRIPTION
this PR solves the preamble RDB issue.
for every write query the flow as follows:
```
LOCK GIL
Key open with `write` flag
Graph R/W lock with write flag
Commit changes in graph
Replicate verbatim
Unlock graph R/W lock
Close key
Unlock GIL
```

This PR also provides runtime exception mechanism in case of:
1. graph deletion during write query
2. graph replacement with other value during write query
