### PR TITLE
added default values for agg funcs

### DIFF
--- a/src/arithmetic/agg_funcs.c
+++ b/src/arithmetic/agg_funcs.c
@@ -194,6 +194,7 @@ void __agg_maxCtxFree(AggCtx *ctx) {
 
 void *__agg_maxCtxNew() {
 	__agg_maxCtx *ac = rm_malloc(sizeof(__agg_maxCtx));
+	ac->max = SI_NullVal();
 	ac->init = false;
 	return ac;
 }
@@ -238,6 +239,7 @@ int __agg_minReduceNext(AggCtx *ctx) {
 
 void *__agg_minCtxNew() {
 	__agg_minCtx *ac = rm_malloc(sizeof(__agg_minCtx));
+	ac->min = SI_NullVal();
 	ac->init = false;
 	return ac;
 }
@@ -370,6 +372,11 @@ int __agg_percDistinctStep(AggCtx *ctx, SIValue *argv, int argc) {
 int __agg_percDiscReduceNext(AggCtx *ctx) {
 	__agg_percCtx *ac = Agg_FuncCtx(ctx);
 
+	if(ac->count == 0) {
+		Agg_SetResult(ctx, SI_NullVal());
+		return AGG_OK;
+	}
+
 	QSORT(double, ac->values, ac->count, ISLT);
 
 	// If ac->percentile == 0, employing this formula would give an index of -1
@@ -384,6 +391,11 @@ int __agg_percContReduceNext(AggCtx *ctx) {
 	__agg_percCtx *ac = Agg_FuncCtx(ctx);
 
 	QSORT(double, ac->values, ac->count, ISLT);
+
+	if(ac->count == 0) {
+		Agg_SetResult(ctx, SI_NullVal());
+		return AGG_OK;
+	}
 
 	if(ac->percentile == 1.0 || ac->count == 1) {
 		Agg_SetResult(ctx, SI_DoubleVal(ac->values[ac->count - 1]));

--- a/tests/flow/test_results.py
+++ b/tests/flow/test_results.py
@@ -112,3 +112,46 @@ class testResultSetFlow(FlowTestsBase):
         self.env.assertEqual(result.header, expected_header)
         # Verify that 3 columns are returned
         self.env.assertEqual(len(result.result_set[0]), 3)
+
+    # Tests for aggregation functions default values. Fix for issue 767.
+    def test07_agg_func_default_values(self):
+        # Test for aggregation over non existing node properties.
+        # Max default value is null.
+        query = """MATCH (a) return max(a.missing_field)"""
+        result = graph.query(query)
+        self.env.assertEqual(None, result.result_set[0][0])
+        
+        # Min default value is null.
+        query = """MATCH (a) return min(a.missing_field)"""
+        result = graph.query(query)
+        self.env.assertEqual(None, result.result_set[0][0])
+
+        # Count default value is 0.
+        query = """MATCH (a) return count(a.missing_field)"""
+        result = graph.query(query)
+        self.env.assertEqual(0, result.result_set[0][0])
+
+        # Avarage default value is 0.
+        query = """MATCH (a) return avg(a.missing_field)"""
+        result = graph.query(query)
+        self.env.assertEqual(0, result.result_set[0][0])
+
+         # Collect default value is an empty array.
+        query = """MATCH (a) return collect(a.missing_field)"""
+        result = graph.query(query)
+        self.env.assertEqual([], result.result_set[0][0])
+
+        # StdDev default value is 0.
+        query = """MATCH (a) return stdev(a.missing_field)"""
+        result = graph.query(query)
+        self.env.assertEqual(0, result.result_set[0][0])
+
+        # percentileCont default value is null.
+        query = """MATCH (a) return percentileCont(a.missing_field, 0.1)"""
+        result = graph.query(query)
+        self.env.assertEqual(None, result.result_set[0][0])
+
+        # percentileDisc default value is null.
+        query = """MATCH (a) return percentileDisc(a.missing_field, 0.1)"""
+        result = graph.query(query)
+        self.env.assertEqual(None, result.result_set[0][0])


### PR DESCRIPTION
This PR solves the #767 server crash by adding default values to aggregation functions. Aggregation function should have a default value if every argument that it receives is invalid (null).
added flow test for aggregation functions default values.