### PR TITLE
Use safe comparison macro for longval comparisons

### DIFF
--- a/src/value.c
+++ b/src/value.c
@@ -450,7 +450,7 @@ int SIValue_Compare(const SIValue a, const SIValue b, int *disjointOrNull) {
 		switch(a.type) {
 		case T_INT64:
 		case T_BOOL:
-			return a.longval - b.longval;
+			return SAFE_COMPARISON_RESULT(a.longval - b.longval);
 		case T_DOUBLE:
 			return SAFE_COMPARISON_RESULT(a.doubleval - b.doubleval);
 		case T_STRING:

--- a/src/value.h
+++ b/src/value.h
@@ -60,7 +60,8 @@ typedef enum {
 
 /* Build an integer return value for a comparison routine in the style of strcmp.
  * This is necessary to construct safe returns when the delta between
- * two values is < 1.0 (and would thus be rounded to 0). */
+ * two values is < 1.0 (and would thus be rounded to 0)
+ * or the delta is too large to fit in a 32-bit integer. */
 #define SAFE_COMPARISON_RESULT(a) SIGN(a)
 
 /* Returns 1 if argument is positive, -1 if argument is negative,

--- a/tests/flow/test_value_comparisons.py
+++ b/tests/flow/test_value_comparisons.py
@@ -78,6 +78,13 @@ class testValueComparison(FlowTestsBase):
         self.env.assertEquals(
             len(actual_result.result_set), expected_result_count)
 
+    # Verify that comparisons between very small and very large values are ordered properly.
+    def test_large_comparisons(self):
+        query = """UNWIND [933, 1099511628237] AS val RETURN val ORDER BY val"""
+        actual_result = redis_graph.query(query)
+        expected = [[933], [1099511628237]]
+        self.env.assertEquals(actual_result.result_set, expected)
+
     # Verify that AND conditions on true, false, and NULL values evaluate appropriately
     def test_AND_truth_tables(self):
         # Test two non-NULL values


### PR DESCRIPTION
Fixes bug reported in #775.