### PR TITLE
merge create when performing distinction, should take into account me…

### DIFF
--- a/src/execution_plan/ops/op_merge_create.c
+++ b/src/execution_plan/ops/op_merge_create.c
@@ -130,8 +130,24 @@ static bool _CreateEntities(OpMergeCreate *op, Record r) {
 		PendingProperties *converted_properties = NULL;
 		if(map) converted_properties = ConvertPropertyMap(r, map);
 
-		/* Update the hash code with this entity. */
+		/* Update the hash code with this entity, an edge is represented by its
+		 * relation, properties and nodes.
+		 * Note that unbounded nodes were already presented to the hash.
+		 * Incase node has its internal entity set, this means the node has been retrieved from the graph
+		 * i.e. bounded node. */
 		_IncrementalHashEntity(op->hash_state, e->reltypes[0], converted_properties);
+		if(src_node->entity != NULL) {
+			EntityID id = ENTITY_GET_ID(src_node);
+			void *data = &id;
+			size_t len = sizeof(id);
+			assert(XXH64_update(op->hash_state, data, len) != XXH_ERROR);
+		}
+		if(dest_node->entity != NULL) {
+			EntityID id = ENTITY_GET_ID(dest_node);
+			void *data = &id;
+			size_t len = sizeof(id);
+			assert(XXH64_update(op->hash_state, data, len) != XXH_ERROR);
+		}
 
 		/* Save edge for later insertion. */
 		op->pending.created_edges = array_append(op->pending.created_edges, newEdge);

--- a/tests/flow/test_graph_merge.py
+++ b/tests/flow/test_graph_merge.py
@@ -311,6 +311,17 @@ class testGraphMergeFlow(FlowTestsBase):
         self.env.assertEquals(result.properties_set, 4)
         self.env.assertEquals(result.result_set, expected)
 
+        # Connect 'c' to both 'a' and 'b' via a Friend relation
+        # One thing to note here is that both `c` and `x` are bounded, which means
+        # our current merge distinct validation inspect the created edge only using its relationship, properties and bounded
+        # nodes! as such the first created edge is different from the second one (due to changes in the destination node).
+        query = """MATCH (c:Person {name: 'c'}) MATCH (x:Person) WHERE x.name in ['a', 'b'] WITH c, x MERGE(c)-[:FRIEND]->(x)"""
+        result = graph_2.query(query)
+        self.env.assertEquals(result.labels_added, 0)
+        self.env.assertEquals(result.nodes_created, 0)
+        self.env.assertEquals(result.properties_set, 0)
+        self.env.assertEquals(result.relationships_created, 2)
+
         # Verify function calls in MERGE do not recreate existing entities
         query = """UNWIND ['A', 'B'] AS names MERGE (a:Person {name: toLower(names)}) RETURN a.name"""
         expected = [['a'], ['b']]


### PR DESCRIPTION
…rged edge bounded nodes

Test case:

```
GRAPH.QUERY g "CREATE (:User {id: 12}), (:User {fbid: 562}), (:User {fbid: 561})"

GRAPH.QUERY g "UNWIND [561, 562] AS f MATCH (u:User {id: 12}) MATCH (uu:User) WHERE uu.fbid = f WITH u, uu MERGE(uu)-[:friend]->(u)"
```