### PR TITLE
allow hashing of record with unknown entries

### DIFF
--- a/src/execution_plan/record.c
+++ b/src/execution_plan/record.c
@@ -274,10 +274,16 @@ unsigned long long Record_Hash64(const Record r) {
 			break;
 
 		case REC_TYPE_UNKNOWN:
-			assert(false);
-
+			/* Record hash should be able to handle hasing of records with missing entries.
+			 * consider: UNWIND [42] AS X WITH X WHERE X > 32 WITH DISTINCT X MERGE (a {v: Z}) RETURN a
+			 * The distinct operation is aware of both `X` and `a` as a result
+			 * when distinct perform record hashing to will access both record entries:
+			 * `X` and `a` at which point `a` is not set. */
+			data = &"REC_TYPE_UNKNOWN";
+			len = strlen("REC_TYPE_UNKNOWN");
+			break;
 		default:
-			assert(false);
+			assert("Unhandled record type" && false);
 		}
 
 		res = XXH64_update(&state, data, len);

--- a/tests/tck/features/AggregationAcceptance.feature
+++ b/tests/tck/features/AggregationAcceptance.feature
@@ -420,8 +420,6 @@ Feature: AggregationAcceptance
             | 42  | 42  | {name:1} |
         And no side effects
 
-@crash
-    @skip
     Scenario: Projection during aggregation in WITH before MERGE and after WITH with predicate
         Given an empty graph
         And having executed:


### PR DESCRIPTION
`UNWIND [42] AS props WITH props WHERE props > 32 WITH DISTINCT props AS p MERGE (a:A {num: p}) RETURN a.num AS prop`