### PR TITLE
annotate named paths within match clause

### DIFF
--- a/tests/tck/features/MatchAcceptance.feature
+++ b/tests/tck/features/MatchAcceptance.feature
@@ -390,8 +390,6 @@ Feature: MatchAcceptance
       | <(:A {name: 'A'})-[:KNOWS]->(:B {name: 'B'})-[:KNOWS]->(:C {name: 'C'})> |
     And no side effects
 
-@crash
-@skip
   Scenario: Do not return anything because path length does not match
     Given an empty graph
     And having executed:
@@ -408,8 +406,6 @@ Feature: MatchAcceptance
       | x |
     And no side effects
 
-@crash
-@skip
   Scenario: Pass the path length test
     Given an empty graph
     And having executed:


### PR DESCRIPTION
MATCH p = ()-[]->() WHERE length(p) = 1 RETURN p
@DvirDukhan we should improve `_annotate_projected_named_path`
By extracting all named path once for each AST segment.