### PR TITLE
Properly handle zero-hop traversals

### DIFF
--- a/tests/tck/features/VarLengthAcceptance.feature
+++ b/tests/tck/features/VarLengthAcceptance.feature
@@ -116,7 +116,6 @@ Feature: VarLengthAcceptance
       | 'n0111' |
     And no side effects
 
-# TODO this doesn't crash when standalone, but does against a single server?
 @skip
   Scenario: Fail when asterisk operator is missing
     When executing query:
@@ -127,8 +126,6 @@ Feature: VarLengthAcceptance
       """
     Then a SyntaxError should be raised at compile time: InvalidRelationshipPattern
 
-@crash
-@skip
   Scenario: Handling single bounded variable length match 1
     When executing query:
       """
@@ -204,8 +201,6 @@ Feature: VarLengthAcceptance
       | 'n011' |
     And no side effects
 
-@crash
-@skip
   Scenario: Handling symmetrically bounded variable length match, bounds are zero
     When executing query:
       """


### PR DESCRIPTION
This case is really so dumb that I'd have been willing to introduce a validation error instead, but we do properly handle somewhat more sensible cases like:
`MATCH (a)-[:LIKES*0]->()-[:LIKES]->(c)`

Adding support here is easier than adding a complex validation. 