### PR TITLE
Remove crash tags from OPTIONAL tests

### DIFF
--- a/tests/tck/features/TriadicSelection.feature
+++ b/tests/tck/features/TriadicSelection.feature
@@ -47,7 +47,6 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is not a friend
     Given the binary-tree-1 graph
@@ -67,7 +66,6 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is not a friend with different relationship type
     Given the binary-tree-1 graph
@@ -87,7 +85,6 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is not a friend with superset of relationship type
     Given the binary-tree-1 graph
@@ -106,7 +103,6 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is not a friend with implicit subset of relationship type
     Given the binary-tree-1 graph
@@ -131,7 +127,6 @@ Feature: TriadicSelection
       | 'c42'  |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is not a friend with explicit subset of relationship type
     Given the binary-tree-1 graph
@@ -156,7 +151,6 @@ Feature: TriadicSelection
       | 'c42'  |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is not a friend with same labels
     Given the binary-tree-2 graph
@@ -174,7 +168,6 @@ Feature: TriadicSelection
       | 'c21'  |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is not a friend with different labels
     Given the binary-tree-2 graph
@@ -191,7 +184,6 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is not a friend with implicit subset of labels
     Given the binary-tree-2 graph
@@ -209,7 +201,6 @@ Feature: TriadicSelection
       | 'c21'  |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is not a friend with implicit superset of labels
     Given the binary-tree-2 graph
@@ -229,7 +220,6 @@ Feature: TriadicSelection
       | 'c22'  |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is a friend
     Given the binary-tree-2 graph
@@ -245,7 +235,6 @@ Feature: TriadicSelection
       | 'b2'   |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is a friend with different relationship type
     Given the binary-tree-1 graph
@@ -261,7 +250,6 @@ Feature: TriadicSelection
       | 'b3'   |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is a friend with superset of relationship type
     Given the binary-tree-1 graph
@@ -278,7 +266,6 @@ Feature: TriadicSelection
       | 'b3'   |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is a friend with implicit subset of relationship type
     Given the binary-tree-1 graph
@@ -295,7 +282,6 @@ Feature: TriadicSelection
       | 'b2'   |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is a friend with explicit subset of relationship type
     Given the binary-tree-1 graph
@@ -312,7 +298,6 @@ Feature: TriadicSelection
       | 'b2'   |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is a friend with same labels
     Given the binary-tree-2 graph
@@ -328,7 +313,6 @@ Feature: TriadicSelection
       | 'b2'   |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is a friend with different labels
     Given the binary-tree-2 graph
@@ -343,7 +327,6 @@ Feature: TriadicSelection
       | c.name |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is a friend with implicit subset of labels
     Given the binary-tree-2 graph
@@ -359,7 +342,6 @@ Feature: TriadicSelection
       | 'b2'   |
     And no side effects
 
-@crash
 @skip
   Scenario: Handling triadic friend of a friend that is a friend with implicit superset of labels
     Given the binary-tree-2 graph


### PR DESCRIPTION
These crashes were fixed by the OPTIONAL validation.