### PR TITLE
Filter placement updates

### DIFF
--- a/src/execution_plan/execution_plan.h
+++ b/src/execution_plan/execution_plan.h
@@ -64,7 +64,7 @@ OpBase **ExecutionPlan_LocateOps(OpBase *root, OPType type);
 
 /* Find the earliest operation on the ExecutionPlan at which all
  * references are resolved. */
-OpBase *ExecutionPlan_LocateReferences(OpBase *root, rax *references);
+OpBase *ExecutionPlan_LocateReferences(OpBase *root, rax *references_to_resolve);
 
 /* Populate a rax with all aliases that have been resolved by the given operation
  * and its children. These are the bound variables at this point in execution, and

--- a/src/execution_plan/execution_plan.h
+++ b/src/execution_plan/execution_plan.h
@@ -62,9 +62,10 @@ OpBase *ExecutionPlan_LocateLastOp(OpBase *root, OPType type);
  * Returns an array of operations. */
 OpBase **ExecutionPlan_LocateOps(OpBase *root, OPType type);
 
-/* Find the earliest operation on the ExecutionPlan at which all
- * references are resolved. */
-OpBase *ExecutionPlan_LocateReferences(OpBase *root, rax *references_to_resolve);
+/* Find the earliest operation above the provided recurse_limit, if any,
+ * at which all references are resolved. */
+OpBase *ExecutionPlan_LocateReferences(OpBase *root, const OpBase *recurse_limit,
+									   rax *references_to_resolve);
 
 /* Populate a rax with all aliases that have been resolved by the given operation
  * and its children. These are the bound variables at this point in execution, and

--- a/tests/tck/features/WithAcceptance.feature
+++ b/tests/tck/features/WithAcceptance.feature
@@ -245,8 +245,6 @@ Feature: WithAcceptance
             | 'B'  |
         And no side effects
 
-@crash
-    @skip
     Scenario: WHERE on a DISTINCT column
         Given an empty graph
         And having executed:


### PR DESCRIPTION
This is a rather more complicated PR, but I think it was overdue - the old logic was very clunky!

The changes to `_ExecutionPlan_LocateReferences` are largely a logical refactor, though some changes there were necessary regardless.

The changes to where `_ExecutionPlan_PlaceFilterOps` is called are required to handle aliased WITH entities. Both of the following are valid:
```
UNWIND [1,2,3] AS a WITH a WHERE a = 1 RETURN a
UNWIND [1,2,3] AS a WITH a AS e WHERE e = 1 RETURN e
```
But previously we would crash on the second form. Now both work properly.