### PR TITLE
coalesce now returns a copy

### DIFF
--- a/src/arithmetic/conditional_funcs/conditional_funcs.c
+++ b/src/arithmetic/conditional_funcs/conditional_funcs.c
@@ -55,7 +55,14 @@ SIValue AR_CASEWHEN(SIValue *argv, int argc) {
 // Coalesce - return the first value which is not null. Defaults to null.
 SIValue AR_COALESCE(SIValue *argv, int argc) {
 	for(int i = 0; i < argc; i++)
-		if(!SIValue_IsNull(argv[i])) return SI_CloneValue(argv[i]);
+		if(!SIValue_IsNull(argv[i])) {
+			/* Avoid double free, since the value is propagated and will be free twice:
+			 * 1. Argument array free.
+			 * 2. Record free. */
+			SIValue copy = argv[i];
+			SIValue_MakeVolatile(argv + i);
+			return copy;
+		}
 	return SI_NullVal();
 }
 

--- a/src/arithmetic/conditional_funcs/conditional_funcs.c
+++ b/src/arithmetic/conditional_funcs/conditional_funcs.c
@@ -55,7 +55,7 @@ SIValue AR_CASEWHEN(SIValue *argv, int argc) {
 // Coalesce - return the first value which is not null. Defaults to null.
 SIValue AR_COALESCE(SIValue *argv, int argc) {
 	for(int i = 0; i < argc; i++)
-		if(!SIValue_IsNull(argv[i])) return argv[i];
+		if(!SIValue_IsNull(argv[i])) return SI_CloneValue(argv[i]);
 	return SI_NullVal();
 }
 


### PR DESCRIPTION
This PR fixes a double-free issue caused by `coalesce` invocation, over a `toString` function result value (`coalesce(toString(x))`).
The first free is called over the `coalesce` parameters array at `_AR_EXP_EvaluateFunctionCall` in the `cleanup` section where every intermediate result calculated by a nested function is freed. In this case, the result of `toString` was freed.
The second free was called from record free.
I changed `coalesce` to return a copy.