### PR TITLE
fixed rename event handler. backed with test

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -105,7 +105,7 @@ static void RG_AfterForkChild() {
 static int _RenameGraphHandler(RedisModuleCtx *ctx, int type, const char *event,
 							   RedisModuleString *key_name) {
 	if(type != REDISMODULE_NOTIFY_GENERIC) return REDISMODULE_OK;
-	if(strcasecmp(event, "RENAME") == 0) {
+	if(strcasecmp(event, "RENAME_TO") == 0) {
 		RedisModuleKey *key = RedisModule_OpenKey(ctx, key_name, REDISMODULE_WRITE);
 		if(RedisModule_ModuleTypeGetType(key) == GraphContextRedisModuleType) {
 			GraphContext *gc = RedisModule_ModuleTypeGetValue(key);

--- a/tests/flow/test_rename.py
+++ b/tests/flow/test_rename.py
@@ -31,7 +31,11 @@ class testGraphRename(FlowTestsBase):
 
         graph = Graph(NEW_GRAPH_ID, redis_con)
 
+        node1 = Node(node_id=0, label="L", properties={'name':'x', 'age':1})
+        graph.add_node(node1)
+        graph.flush()
+
         query = "MATCH (n) return n"
-        expected_results = [[node0]]
+        expected_results = [[node0], [node1]]
         query_info = QueryInfo(query = query, description="Tests data is valid after renaming", expected_result = expected_results)
-        self._assert_resultset_equals_expected(graph.query(query), query_info)
+        self._assert_resultset_and_expected_mutually_included(graph.query(query), query_info)


### PR DESCRIPTION
this is a fix to PR #795 which handled the wrong type of event trigger, and missed a rename event. #795 was only validated against read-only queries, which do not execute additional keyspace manipulation, as opposed to write queries, so it missed the rename event. This PR is backed with write query test.