### PR TITLE
Fix crash in accessing realiased entities in ORDER BY expressions

### DIFF
--- a/tests/tck/features/MatchAcceptance2.feature
+++ b/tests/tck/features/MatchAcceptance2.feature
@@ -1080,8 +1080,6 @@ Feature: MatchAcceptance2
       | [:T2] |
     And no side effects
 
-@crash
-@skip
   Scenario: Matching using a relationship that is already bound, in conjunction with aggregation and ORDER BY
     Given an empty graph
     And having executed:


### PR DESCRIPTION
Handling for queries like:
`MATCH (original_name) RETURN original_name AS alias ORDER BY alias.val`
The `AR_ExpNode` produced for the RETURN clause will have its `original_name` as its internal entity alias, but the one produced for ORDER BY will have `alias`.

Both operate in the same loop on the Record passed _into_ the Project op, however, which has no knowledge of `alias`.

This fix aligns the internal aliases in ORDER BY `AR_ExpNode`s before building the Project op. It feels like a somewhat clumsy solution to me, so let me know if you can think of better alternatives!