### PR TITLE
use grb_extract for the first multiplication

### DIFF
--- a/src/arithmetic/algebraic_expression.h
+++ b/src/arithmetic/algebraic_expression.h
@@ -21,6 +21,12 @@ typedef enum {
 
 #define AL_EXP_ALL (AL_EXP_ADD | AL_EXP_MUL | AL_EXP_POW | AL_EXP_TRANSPOSE)
 
+// Type of operand.
+typedef enum {
+    AL_OPERAND_MATRIX,
+    AL_OPERAND_VECTOR,
+} AlgebraicExpressionOperandType;
+
 // Type of node within an algebraic expression
 typedef enum {
 	AL_OPERAND,
@@ -35,10 +41,12 @@ struct AlgebraicExpression {
         struct {
             bool diagonal;          // Diagonal matrix.
 		    GrB_Matrix matrix;      // Matrix operand.
+		    GrB_Vector vector;      // Vector operand.
             const char *src;        // Alias given to operand's rows (src node).
             const char *dest;       // Alias given to operand's columns (destination node).
             const char *edge;       // Alias given to operand (edge).
-            const char *label;      // Label attached to matrix.
+            const char *label;      // Label attached to operand.
+            AlgebraicExpressionOperandType type;   // Type of node, either an operation or an operand.
         } operand;
 		struct {
 			AL_EXP_OP op;                       // Operation: `*`,`+`,`transpose`
@@ -69,7 +77,15 @@ AlgebraicExpression *AlgebraicExpression_NewOperation
 );
 
 // Create a new AlgebraicExpression operand node.
-AlgebraicExpression *AlgebraicExpression_NewOperand
+AlgebraicExpression *AlgebraicExpression_NewVectorOperand
+(
+    GrB_Vector vec,     // Vector.
+    const char *src,    // Operand row domain (src node).
+    const char *dest    // Operand column domain (destination node).
+);
+
+// Create a new AlgebraicExpression operand node.
+AlgebraicExpression *AlgebraicExpression_NewMatrixOperand
 (
     GrB_Matrix mat,     // Matrix.
     bool diagonal,      // Is operand a diagonal matrix?
@@ -171,8 +187,24 @@ AlgebraicExpression *AlgebraicExpression_RemoveRightmostNode
 );
 
 // Multiply expression to the left by operand
+// v * (exp)
+void AlgebraicExpression_VectorMultiplyToTheLeft
+(
+    AlgebraicExpression **root,
+    GrB_Vector v
+);
+
+// Multiply expression to the right by operand
+// (exp) * v
+void AlgebraicExpression_VectorMultiplyToTheRight
+(
+    AlgebraicExpression **root,
+	GrB_Vector m
+);
+
+// Multiply expression to the left by operand
 // m * (exp)
-void AlgebraicExpression_MultiplyToTheLeft
+void AlgebraicExpression_MatrixMultiplyToTheLeft
 (
     AlgebraicExpression **root,
     GrB_Matrix m
@@ -180,7 +212,7 @@ void AlgebraicExpression_MultiplyToTheLeft
 
 // Multiply expression to the right by operand
 // (exp) * m
-void AlgebraicExpression_MultiplyToTheRight
+void AlgebraicExpression_MatrixMultiplyToTheRight
 (
     AlgebraicExpression **root,
 	GrB_Matrix m

--- a/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
@@ -185,7 +185,7 @@ static AlgebraicExpression *_AlgebraicExpression_OperandFromNode
 	if(n->labelID == GRAPH_UNKNOWN_LABEL) mat = Graph_GetZeroMatrix(g);
 	else mat = Graph_GetLabelMatrix(g, n->labelID);
 
-	return AlgebraicExpression_NewOperand(mat, diagonal, n->alias, n->alias, NULL, n->label);
+	return AlgebraicExpression_NewMatrixOperand(mat, diagonal, n->alias, n->alias, NULL, n->label);
 }
 
 static AlgebraicExpression *_AlgebraicExpression_OperandFromEdge
@@ -216,21 +216,21 @@ static AlgebraicExpression *_AlgebraicExpression_OperandFromEdge
 	 * in this case we want to use the identity matrix
 	 * f * I  = f */
 	if(!var_len_traversal && e->minHops == 0) {
-		root = AlgebraicExpression_NewOperand(IDENTITY_MATRIX, true, src, dest, edge, "I");
+		root = AlgebraicExpression_NewMatrixOperand(IDENTITY_MATRIX, true, src, dest, edge, "I");
 	} else {
 		uint reltype_count = array_len(e->reltypeIDs);
 		switch(reltype_count) {
 		case 0: // No relationship types specified; use the full adjacency matrix
-			root = AlgebraicExpression_NewOperand(GrB_NULL, false, src, dest, edge, NULL);
+			root = AlgebraicExpression_NewMatrixOperand(GrB_NULL, false, src, dest, edge, NULL);
 			break;
 		case 1: // One relationship type
-			root = AlgebraicExpression_NewOperand(GrB_NULL, false, src, dest, edge, e->reltypes[0]);
+			root = AlgebraicExpression_NewMatrixOperand(GrB_NULL, false, src, dest, edge, e->reltypes[0]);
 			break;
 		default: // Multiple edge type: -[:A|:B]->
 			add = AlgebraicExpression_NewOperation(AL_EXP_ADD);
 			for(uint i = 0; i < reltype_count; i++) {
-				AlgebraicExpression *operand = AlgebraicExpression_NewOperand(GrB_NULL, false, src, dest,
-																			  edge, e->reltypes[i]);
+				AlgebraicExpression *operand = AlgebraicExpression_NewMatrixOperand(GrB_NULL, false, src, dest,
+																					edge, e->reltypes[i]);
 				AlgebraicExpression_AddChild(add, operand);
 			}
 			root = add;

--- a/src/arithmetic/algebraic_expression/algebraic_expression_debug.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_debug.c
@@ -63,7 +63,7 @@ AlgebraicExpression *_AlgebraicExpression_FromString
 				m = (GrB_Matrix)raxFind(matrices, (unsigned char *)alias, strlen(alias));
 				assert(m && "Missing matrix");
 			}
-			root = AlgebraicExpression_NewOperand(m, false, alias, alias, NULL, NULL);
+			root = AlgebraicExpression_NewMatrixOperand(m, false, alias, alias, NULL, NULL);
 			break;
 		}
 	}
@@ -119,6 +119,7 @@ static void _AlgebraicExpression_PrintTree
 		break;
 	case AL_OPERAND:
 		if(exp->operand.edge) alias = exp->operand.edge;
+		else if(exp->operand.label) alias = exp->operand.label;
 		else alias = exp->operand.src;
 		printf("%s\n", alias);
 	default:

--- a/src/arithmetic/algebraic_expression/utils.c
+++ b/src/arithmetic/algebraic_expression/utils.c
@@ -219,7 +219,7 @@ void _AlgebraicExpression_FetchOperands(AlgebraicExpression *exp, const GraphCon
 		}
 		break;
 	case AL_OPERAND:
-		if(exp->operand.matrix == GrB_NULL) {
+		if(exp->operand.type == AL_OPERAND_MATRIX && exp->operand.matrix == GrB_NULL) {
 			label = exp->operand.label;
 			if(label == NULL) {
 				m = Graph_GetAdjacencyMatrix(g);

--- a/src/execution_plan/ops/op_conditional_traverse.h
+++ b/src/execution_plan/ops/op_conditional_traverse.h
@@ -20,7 +20,7 @@ typedef struct {
 	int destNodeIdx;            // Index into record.
 	int *edgeRelationTypes;     // One or more relation types.
 	int edgeRelationCount;      // length of edgeRelationTypes.
-	GrB_Matrix F;               // Filter matrix.
+    GrB_Vector f;               // Filter vector.
 	GrB_Matrix M;               // Algebraic expression result.
     bool setEdge;               // Edge needs to be set.
 	Edge *edges;                // Discovered edges.

--- a/src/execution_plan/ops/op_expand_into.h
+++ b/src/execution_plan/ops/op_expand_into.h
@@ -16,7 +16,7 @@ typedef struct {
 	OpBase op;
 	Graph *graph;
 	AlgebraicExpression *ae;
-	GrB_Matrix F;               // Filter matrix.
+	GrB_Vector f;               // Filter vector.
 	GrB_Matrix M;               // Algebraic expression result.
 	int *edgeRelationTypes;     // One or more relation types.
 	int edgeRelationCount;      // length of edgeRelationTypes.

--- a/tests/unit/test_algebraic_expression.cpp
+++ b/tests/unit/test_algebraic_expression.cpp
@@ -305,7 +305,7 @@ TEST_F(AlgebraicExpressionTest, AlgebraicExpression_New) {
     const char *edge = "edge";
     const char *label = "label";
 
-    AlgebraicExpression *operand = AlgebraicExpression_NewOperand(matrix, diagonal, src, dest, edge, label);
+    AlgebraicExpression *operand = AlgebraicExpression_NewMatrixOperand(matrix, diagonal, src, dest, edge, label);
     ASSERT_EQ(operand->type, AL_OPERAND);
     ASSERT_EQ(operand->operand.matrix, matrix);
     ASSERT_EQ(operand->operand.diagonal, diagonal);
@@ -657,12 +657,12 @@ TEST_F(AlgebraicExpressionTest, ExpTransform_AB_Times_C_Plus_D) {
 	GrB_Matrix_new(&D, GrB_BOOL, 2, 2);
 
     // A*B*(C+D) -> A*B*C + A*B*D
-	AlgebraicExpression *exp = AlgebraicExpression_NewOperand(C, false, NULL, NULL, NULL, NULL);
+	AlgebraicExpression *exp = AlgebraicExpression_NewMatrixOperand(C, false, NULL, NULL, NULL, NULL);
 
 	// A*B*(C+D)
 	AlgebraicExpression_AddToTheRight(&exp, D);
-    AlgebraicExpression_MultiplyToTheLeft(&exp, B);
-    AlgebraicExpression_MultiplyToTheLeft(&exp, A);
+    AlgebraicExpression_MatrixMultiplyToTheLeft(&exp, B);
+    AlgebraicExpression_MatrixMultiplyToTheLeft(&exp, A);
 	AlgebraicExpression_Optimize(&exp);
 
 	// Verifications

--- a/tests/unit/test_traversal_ordering.cpp
+++ b/tests/unit/test_traversal_ordering.cpp
@@ -93,9 +93,9 @@ TEST_F(TraversalOrderingTest, TransposeFree) {
 	QueryGraph_ConnectNodes(qg, C, D, CD);
 
 	AlgebraicExpression *set[3];
-	AlgebraicExpression *ExpAB = AlgebraicExpression_NewOperand(GrB_NULL, false, "A", "B", NULL, NULL);
-	AlgebraicExpression *ExpBC = AlgebraicExpression_NewOperand(GrB_NULL, false, "B", "C", NULL, NULL);
-	AlgebraicExpression *ExpCD = AlgebraicExpression_NewOperand(GrB_NULL, false, "C", "D", NULL, NULL);
+	AlgebraicExpression *ExpAB = AlgebraicExpression_NewMatrixOperand(GrB_NULL, false, "A", "B", NULL, NULL);
+	AlgebraicExpression *ExpBC = AlgebraicExpression_NewMatrixOperand(GrB_NULL, false, "B", "C", NULL, NULL);
+	AlgebraicExpression *ExpCD = AlgebraicExpression_NewMatrixOperand(GrB_NULL, false, "C", "D", NULL, NULL);
 
 	// { [CD], [BC], [AB] }
 	set[0] = ExpCD;
@@ -197,9 +197,9 @@ TEST_F(TraversalOrderingTest, FilterFirst) {
 	QueryGraph_ConnectNodes(qg, C, D, CD);
 
 	AlgebraicExpression *set[3];
-    AlgebraicExpression *ExpAB = AlgebraicExpression_NewOperand(GrB_NULL, false, "A", "B", NULL, NULL);
-	AlgebraicExpression *ExpBC = AlgebraicExpression_NewOperand(GrB_NULL, false, "B", "C", NULL, NULL);
-	AlgebraicExpression *ExpCD = AlgebraicExpression_NewOperand(GrB_NULL, false, "C", "D", NULL, NULL);
+    AlgebraicExpression *ExpAB = AlgebraicExpression_NewMatrixOperand(GrB_NULL, false, "A", "B", NULL, NULL);
+	AlgebraicExpression *ExpBC = AlgebraicExpression_NewMatrixOperand(GrB_NULL, false, "B", "C", NULL, NULL);
+	AlgebraicExpression *ExpCD = AlgebraicExpression_NewMatrixOperand(GrB_NULL, false, "C", "D", NULL, NULL);
 
 	// { [AB], [BC], [CD] }
 	set[0] = ExpAB;


### PR DESCRIPTION
From old conversations with Tim, I've been told that when performing A *B where each row of A has a single value, (A is being used to pick out rows from B) it is better to use `GrB_extract` instead of `GrB_mxm`

This PR switches from filter matrix `f` to filter vector