### PR TITLE
Only remove Distinct ops with an Aggregate child

### DIFF
--- a/src/execution_plan/optimizations/reduce_distinct.c
+++ b/src/execution_plan/optimizations/reduce_distinct.c
@@ -4,25 +4,23 @@
 * This file is available under the Redis Labs Source Available License Agreement
 */
 
-#include "reduce_filters.h"
+#include "reduce_distinct.h"
 
 void reduceDistinct(ExecutionPlan *plan) {
-	// Look for aggregate operation.
-	OpBase *aggregate = ExecutionPlan_LocateFirstOp(plan->root, OPType_AGGREGATE);
-	if(aggregate == NULL || aggregate->parent == NULL) return;
+	// Look for Distinct operations.
+	OpBase **distinct_ops = ExecutionPlan_LocateOps(plan->root, OPType_DISTINCT);
 
-	// See if there's a distinct operation following aggregate
-	if(aggregate->parent->type == OPType_DISTINCT) {
-		OpBase *distinct = aggregate->parent;
-		ExecutionPlan_RemoveOp(plan, distinct);
-		return;
-	}
-
-	// See if there's a distinct operation right before aggregate.
-	for(int i = 0; i < aggregate->childCount; i++) {
-		if(aggregate->children[i]->type == OPType_DISTINCT) {
-			ExecutionPlan_RemoveOp(plan, aggregate->children[i]);
-			return;
+	for(uint i = 0; i < array_len(distinct_ops); i++) {
+		OpBase *distinct = distinct_ops[i];
+		assert(distinct->childCount == 1);
+		if(distinct->children[0]->type == OPType_AGGREGATE) {
+			// We can remove the Distinct op if its child is an aggregate operation,
+			// as its results will inherently be unique.
+			ExecutionPlan_RemoveOp(plan, distinct);
+			OpBase_Free(distinct);
 		}
 	}
+
+	array_free(distinct_ops);
 }
+


### PR DESCRIPTION
Fix invalid removal of Distinct operations that are the child of an Aggregate op - this optimization is only valid when the Distinct operation is the _parent_ of the Aggregate. #863