### PR TITLE
Support float inputs for modulo computations

### DIFF
--- a/src/arithmetic/numeric_funcs/numeric_funcs.c
+++ b/src/arithmetic/numeric_funcs/numeric_funcs.c
@@ -149,7 +149,7 @@ void Register_NumericFuncs() {
 	AR_RegFunc(func_desc);
 
 	types = array_new(SIType, 1);
-	types = array_append(types, (T_INT64 | T_NULL));
+	types = array_append(types, (SI_NUMERIC | T_NULL));
 	func_desc = AR_FuncDescNew("mod", AR_MODULO, 2, 2, types, true);
 	AR_RegFunc(func_desc);
 
@@ -187,3 +187,4 @@ void Register_NumericFuncs() {
 	func_desc = AR_FuncDescNew("tointeger", AR_TOINTEGER, 1, 1, types, true);
 	AR_RegFunc(func_desc);
 }
+

--- a/src/value.c
+++ b/src/value.c
@@ -391,10 +391,17 @@ SIValue SIValue_Divide(const SIValue a, const SIValue b) {
 	return SI_DoubleVal(SI_GET_NUMERIC(a) / (double)SI_GET_NUMERIC(b));
 }
 
-SIValue SIValue_Modulo(const SIValue a, const SIValue b) {
-	// Since C % operator requires integer inputs, we need to validate this.
-	assert(SI_TYPE(a) & SI_TYPE(b) & T_INT64);
-	return SI_LongVal(a.longval % b.longval);
+// Calculate a mod n for integer and floating-point inputs.
+SIValue SIValue_Modulo(const SIValue a, const SIValue n) {
+	bool inputs_are_integers = SI_TYPE(a) & SI_TYPE(n) & T_INT64;
+	switch(inputs_are_integers) {
+	case true:
+		// The modulo machine instruction may be used if a and n are both integers.
+		return SI_LongVal(a.longval % n.longval);
+	case false:
+		// Otherwise, use the library function fmod to calculate the modulo and return a double.
+		return SI_DoubleVal(fmod(SI_GET_NUMERIC(a), SI_GET_NUMERIC(n)));
+	}
 }
 
 int SIArray_Compare(SIValue arrayA, SIValue arrayB, int *disjointOrNull) {

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -166,3 +166,40 @@ class testFunctionCallsFlow(FlowTestsBase):
         actual_result = graph.query(query)
         expected_result = [[3]]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    def test10_modulo_inputs(self):
+        # Validate modulo with integer inputs.
+        query = "RETURN 5 % 2"
+        actual_result = graph.query(query)
+        expected_result = [[1]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        # Validate modulo with a floating-point dividend.
+        query = "RETURN 5.5 % 2"
+        actual_result = graph.query(query)
+        expected_result = [[1.5]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        # Validate modulo with a floating-point divisor.
+        query = "RETURN 5 % 2.5"
+        actual_result = graph.query(query)
+        expected_result = [[0]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        # Validate modulo with both a floating-point dividen and a floating-point divisor.
+        query = "RETURN 5.5 % 2.5"
+        actual_result = graph.query(query)
+        expected_result = [[0.5]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        # Validate modulo with negative integer inputs.
+        query = "RETURN -5 % -2"
+        actual_result = graph.query(query)
+        expected_result = [[-1]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        # Validate modulo with negative floating-point inputs.
+        query = "RETURN -5.5 % -2.5"
+        actual_result = graph.query(query)
+        expected_result = [[-0.5]]
+        self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
Update the modulo function to accept floating-point arguments.

Required for the LDBC benchmark.