### PR TITLE
fixed ast mapping for path filter

### DIFF
--- a/src/ast/ast_build_reference_map.c
+++ b/src/ast/ast_build_reference_map.c
@@ -2,6 +2,9 @@
 #include "../util/arr.h"
 #include <assert.h>
 
+// Forward declerations:
+static void _AST_MapReferencedEntitiesInPath(AST *ast, const cypher_astnode_t *path);
+
 // Adds an identifier or an alias to the reference map.
 static inline void _AST_UpdateRefMap(AST *ast, const char *name) {
 	raxInsert(ast->referenced_entities, (unsigned char *)name, strlen(name), NULL, NULL);
@@ -21,6 +24,9 @@ static void _AST_MapExpression(AST *ast, const cypher_astnode_t *exp) {
 		assert(cypher_astnode_type(exp) == CYPHER_AST_IDENTIFIER);
 		const char *identifier_name = cypher_ast_identifier_get_name(exp);
 		_AST_UpdateRefMap(ast, identifier_name);
+	} else if(type == CYPHER_AST_PATTERN_PATH) {
+		// In case of pattern filter.
+		_AST_MapReferencedEntitiesInPath(ast, exp);
 	} else {
 		// Recurse over children.
 		uint child_count = cypher_astnode_nchildren(exp);

--- a/tests/flow/test_path_filter.py
+++ b/tests/flow/test_path_filter.py
@@ -10,16 +10,18 @@ sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../../')
 from demo import QueryInfo
 
 GRAPH_ID = "G"
+redis_con = None
 redis_graph = None
 
 class testPathFilter(FlowTestsBase):
     def __init__(self):
         super(testPathFilter, self).__init__()
-        global redis_graph
+        global redis_con
         redis_con = self.env.getConnection()
-        redis_graph = Graph(GRAPH_ID, redis_con)
-        
+
     def setUp(self):
+        global redis_graph
+        redis_graph = Graph(GRAPH_ID, redis_con)
         self.env.flush()
 
     def test00_simple_path_filter(self):
@@ -31,7 +33,7 @@ class testPathFilter(FlowTestsBase):
         redis_graph.add_edge(edge01)
         redis_graph.flush()
 
-        query = "MATCH(n:L) WHERE (n)-[:R]->(:L) RETURN n"
+        query = "MATCH (n:L) WHERE (n)-[:R]->(:L) RETURN n"
         result_set = redis_graph.query(query)
         expected_results = [[node0]]
         query_info = QueryInfo(query = query, description="Tests simple path filter", expected_result = expected_results)
@@ -46,7 +48,7 @@ class testPathFilter(FlowTestsBase):
         redis_graph.add_edge(edge01)
         redis_graph.flush()
 
-        query = "MATCH(n:L) WHERE NOT (n)-[:R]->(:L) RETURN n"
+        query = "MATCH (n:L) WHERE NOT (n)-[:R]->(:L) RETURN n"
         result_set = redis_graph.query(query)
         expected_results = [[node1]]
         query_info = QueryInfo(query = query, description="Tests simple negated path filter", expected_result = expected_results)
@@ -61,7 +63,7 @@ class testPathFilter(FlowTestsBase):
         redis_graph.add_edge(edge01)
         redis_graph.flush()
 
-        query = "MATCH(n:L) WHERE (n)-[:R]->(:L) OR n.x=1 RETURN n"
+        query = "MATCH (n:L) WHERE (n)-[:R]->(:L) OR n.x=1 RETURN n"
         result_set = redis_graph.query(query)
         expected_results = [[node0],[node1]]
         query_info = QueryInfo(query = query, description="Tests OR condition with simple filter and path filter", expected_result = expected_results)
@@ -76,7 +78,7 @@ class testPathFilter(FlowTestsBase):
         redis_graph.add_edge(edge01)
         redis_graph.flush()
 
-        query = "MATCH(n:L) WHERE (n)-[:R]->(:L) OR NOT (n)-[:R]->(:L) RETURN n"
+        query = "MATCH (n:L) WHERE (n)-[:R]->(:L) OR NOT (n)-[:R]->(:L) RETURN n"
         result_set = redis_graph.query(query)
         expected_results = [[node0],[node1]]
         query_info = QueryInfo(query = query, description="Tests OR condition with path and negated path filters", expected_result = expected_results)
@@ -91,7 +93,7 @@ class testPathFilter(FlowTestsBase):
         redis_graph.add_edge(edge01)
         redis_graph.flush()
 
-        query = "MATCH(n:L) WHERE (n)-[:R]->(:L) OR (n.x=1 AND NOT (n)-[:R]->(:L)) RETURN n"
+        query = "MATCH (n:L) WHERE (n)-[:R]->(:L) OR (n.x=1 AND NOT (n)-[:R]->(:L)) RETURN n"
         result_set = redis_graph.query(query)
         expected_results = [[node0],[node1]]
         query_info = QueryInfo(query = query, description="Tests AND condition with simple filter and negated path filter", expected_result = expected_results)
@@ -106,13 +108,13 @@ class testPathFilter(FlowTestsBase):
         redis_graph.add_edge(edge01)
         redis_graph.flush()
 
-        query = "MATCH(n:L) WHERE (n)-[:R]->(:L) OR (n.x=1 AND (n.x = 2 OR NOT (n)-[:R]->(:L))) RETURN n"
+        query = "MATCH (n:L) WHERE (n)-[:R]->(:L) OR (n.x=1 AND (n.x = 2 OR NOT (n)-[:R]->(:L))) RETURN n"
         result_set = redis_graph.query(query)
         expected_results = [[node0],[node1]]
         query_info = QueryInfo(query = query, description="Tests AND condition with simple filter and nested OR", expected_result = expected_results)
         self._assert_resultset_and_expected_mutually_included(result_set, query_info)
     
-    def test04_test_level_2_nesting_logical_operators_over_path_filters(self):
+    def test06_test_level_2_nesting_logical_operators_over_path_filters(self):
         node0 = Node(node_id=0, label="L")
         node1 = Node(node_id=1, label="L", properties={'x':1})
         node2 = Node(node_id=2, label="L2")
@@ -125,13 +127,13 @@ class testPathFilter(FlowTestsBase):
         redis_graph.add_edge(edge12)
         redis_graph.flush()
 
-        query = "MATCH(n:L) WHERE (n)-[:R]->(:L) OR (n.x=1 AND ((n)-[:R2]->(:L2) OR (n)-[:R]->(:L))) RETURN n"
+        query = "MATCH (n:L) WHERE (n)-[:R]->(:L) OR (n.x=1 AND ((n)-[:R2]->(:L2) OR (n)-[:R]->(:L))) RETURN n"
         result_set = redis_graph.query(query)
         expected_results = [[node0],[node1]]
         query_info = QueryInfo(query = query, description="Tests AND condition with simple filter and nested OR", expected_result = expected_results)
         self._assert_resultset_and_expected_mutually_included(result_set, query_info)
 
-    def test05_test_edge_filters(self):
+    def test07_test_edge_filters(self):
         node0 = Node(node_id=0, label="L")
         node1 = Node(node_id=1, label="L")
         node2 = Node(node_id=2, label="L")

--- a/tests/flow/test_path_filter.py
+++ b/tests/flow/test_path_filter.py
@@ -130,3 +130,22 @@ class testPathFilter(FlowTestsBase):
         expected_results = [[node0],[node1]]
         query_info = QueryInfo(query = query, description="Tests AND condition with simple filter and nested OR", expected_result = expected_results)
         self._assert_resultset_and_expected_mutually_included(result_set, query_info)
+
+    def test05_test_edge_filters(self):
+        node0 = Node(node_id=0, label="L")
+        node1 = Node(node_id=1, label="L")
+        node2 = Node(node_id=2, label="L")
+        edge01 = Edge(src_node=node0, dest_node=node1, relation="R", properties={'x':1})
+        edge12 = Edge(src_node=node1, dest_node=node2, relation="R")
+        redis_graph.add_node(node0)
+        redis_graph.add_node(node1)
+        redis_graph.add_node(node2)
+        redis_graph.add_edge(edge01)
+        redis_graph.add_edge(edge12)
+        redis_graph.flush()
+
+        query = "MATCH (n:L) WHERE (n)-[:R {x:1}]->() RETURN n"
+        result_set = redis_graph.query(query)
+        expected_results = [[node0]]
+        query_info = QueryInfo(query = query, description="Tests pattern filter edge conditions", expected_result = expected_results)
+        self._assert_resultset_and_expected_mutually_included(result_set, query_info)


### PR DESCRIPTION
this PR fixes a crash caused by not referencing path filter entities 
queries like `MATCH (n) WHERE (n)-[:R {prop:1}]->() RETURN n` causes crash