### PR TITLE
added mutex per matrix

### DIFF
--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -65,8 +65,8 @@ struct Graph {
 	GrB_Matrix *relations;              // Relation matrices.
 	GrB_Matrix *_relations_map;         // Maps from (relation, row, col) to edge id.
 	GrB_Matrix _zero_matrix;            // Zero matrix.
+	rax *_matrices_mutex;               // Matrices mutex map.
 	pthread_mutex_t _writers_mutex;     // Mutex restrict single writer.
-	pthread_mutex_t _mutex;             // Mutex for accessing critical sections.
 	pthread_rwlock_t _rwlock;           // Read-write lock scoped to this specific graph
 	bool _writelocked;                  // true if the read-write lock was acquired by a writer
 	SyncMatrixFunc SynchronizeMatrix;   // Function pointer to matrix synchronization routine.

--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -51,21 +51,27 @@ typedef enum {
 	DISABLED,
 } MATRIX_POLICY;
 
+// Forward declaration of RG_Matrix type. Internal to graph.
+typedef struct {
+	GrB_Matrix grb_matrix;              // Underlying GrB_Matrix.
+	pthread_mutex_t mutex;              // Lock.
+} _RG_Matrix;
+typedef _RG_Matrix *RG_Matrix;
+
 // Forward declaration of Graph struct
 typedef struct Graph Graph;
 // typedef for synchronization function pointer
-typedef void (*SyncMatrixFunc)(const Graph *, GrB_Matrix);
+typedef void (*SyncMatrixFunc)(const Graph *, RG_Matrix);
 
 struct Graph {
 	DataBlock *nodes;                   // Graph nodes stored in blocks.
 	DataBlock *edges;                   // Graph edges stored in blocks.
-	GrB_Matrix adjacency_matrix;        // Adjacency matrix, holds all graph connections.
-	GrB_Matrix _t_adjacency_matrix;     // Transposed Adjacency matrix.
-	GrB_Matrix *labels;                 // Label matrices.
-	GrB_Matrix *relations;              // Relation matrices.
-	GrB_Matrix *_relations_map;         // Maps from (relation, row, col) to edge id.
-	GrB_Matrix _zero_matrix;            // Zero matrix.
-	rax *_matrices_mutex;               // Matrices mutex map.
+	RG_Matrix adjacency_matrix;         // Adjacency matrix, holds all graph connections.
+	RG_Matrix _t_adjacency_matrix;      // Transposed Adjacency matrix.
+	RG_Matrix *labels;                  // Label matrices.
+	RG_Matrix *relations;               // Relation matrices.
+	RG_Matrix *_relations_map;          // Maps from (relation, row, col) to edge id.
+	RG_Matrix _zero_matrix;             // Zero matrix.
 	pthread_mutex_t _writers_mutex;     // Mutex restrict single writer.
 	pthread_rwlock_t _rwlock;           // Read-write lock scoped to this specific graph
 	bool _writelocked;                  // true if the read-write lock was acquired by a writer

--- a/src/graph/serializers/encoder/encode_graph.c
+++ b/src/graph/serializers/encoder/encode_graph.c
@@ -193,7 +193,7 @@ void _RdbSaveEdges(RedisModuleIO *rdb, const Graph *g, char **string_mapping) {
 		NodeID src;
 		NodeID dest;
 		EdgeID edgeID;
-		GrB_Matrix M = g->_relations_map[r];
+		GrB_Matrix M = Graph_GetRelationMap(g, r);
 		GxB_MatrixTupleIter *it;
 		GxB_MatrixTupleIter_new(&it, M);
 		bool depleted = false;

--- a/tests/unit/test_graph.cpp
+++ b/tests/unit/test_graph.cpp
@@ -311,10 +311,10 @@ TEST_F(GraphTest, NewGraph) {
 	GrB_Index ncols, nrows, nvals;
 	Graph *g = Graph_New(GRAPH_DEFAULT_NODE_CAP, GRAPH_DEFAULT_EDGE_CAP);
 	Graph_AcquireWriteLock(g);
-
-	ASSERT_EQ(GrB_Matrix_ncols(&ncols, g->adjacency_matrix), GrB_SUCCESS);
-	ASSERT_EQ(GrB_Matrix_nrows(&nrows, g->adjacency_matrix), GrB_SUCCESS);
-	ASSERT_EQ(GrB_Matrix_nvals(&nvals, g->adjacency_matrix), GrB_SUCCESS);
+	GrB_Matrix adj_matrix = g->adjacency_matrix->grb_matrix;
+	ASSERT_EQ(GrB_Matrix_ncols(&ncols, adj_matrix), GrB_SUCCESS);
+	ASSERT_EQ(GrB_Matrix_nrows(&nrows, adj_matrix), GrB_SUCCESS);
+	ASSERT_EQ(GrB_Matrix_nvals(&nvals, adj_matrix), GrB_SUCCESS);
 
 	ASSERT_TRUE(g->nodes != NULL);
 	ASSERT_TRUE(g->relations != NULL);


### PR DESCRIPTION
This PR adds:
1. Mutex per matrix, which removed the entire graph mutex.
2. A temporary workaround for solving #890 by always locking the matrix. This solves a read-after-write dependency, which can be violated by the previous code at `graph.c`. The current state of our GraphBLAS extension methods is unaware if a matrix with pending updates did flush the updates or not. Currently, in `GB_Wait`, a matrix removes its`GB_Pending` object, before applying the changes it holds. This can expose an unstable state of the matrix during the execution of `GB_Wait`. On the one hand, the matrix is without pending changes. On the other hand, the pending changes are in progress or will be applied by `GB_Wait`. Our GxB method only checks if pending changes exist, and have no notion if they were flushed. The previous code locked the matrix only if it did have pending changes. The workaround always locks the matrix before it checks for pending changes. 