### PR TITLE
Fix ORDER expressions that refer to projected aliases

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -250,6 +250,7 @@ AST *AST_Build(cypher_parse_result_t *parse_result) {
 	ast->canonical_entity_names = raxNew();
 	ast->anot_ctx_collection = AST_AnnotationCtxCollection_New();
 	ast->free_root = false;
+	ast->limit = UNLIMITED;
 
 	// Retrieve the AST root node from a parsed query.
 	const cypher_astnode_t *statement = cypher_parse_result_get_root(parse_result, 0);

--- a/src/execution_plan/ops/op_project.h
+++ b/src/execution_plan/ops/op_project.h
@@ -12,11 +12,11 @@
 
 typedef struct {
 	OpBase op;
-	AR_ExpNode **exps;              // Projected expressions (including order exps).
+	AR_ExpNode **input_exps;        // Expressions to evaluate on the input Record.
+	AR_ExpNode **output_exps;       // Expressions to evaluate on the projected Record.
 	uint *record_offsets;           // Record IDs corresponding to each projection (including order exps).
 	bool singleResponse;            // When no child operations, return NULL after a first response.
-	uint exp_count;                 // Number of projected expressions.
 } OpProject;
 
-OpBase *NewProjectOp(const ExecutionPlan *plan, AR_ExpNode **exps);
+OpBase *NewProjectOp(const ExecutionPlan *plan, AR_ExpNode **input_exps, AR_ExpNode **output_exps);
 

--- a/src/execution_plan/optimizations/reduce_count.c
+++ b/src/execution_plan/optimizations/reduce_count.c
@@ -110,7 +110,7 @@ bool _reduceNodeCount(ExecutionPlan *plan) {
 	AR_ExpNode **exps = array_new(AR_ExpNode *, 1);
 	exps = array_append(exps, exp);
 
-	OpBase *opProject = NewProjectOp(opAggregate->op.plan, exps);
+	OpBase *opProject = NewProjectOp(opAggregate->op.plan, exps, NULL);
 
 	// New execution plan: "Project -> Results"
 	ExecutionPlan_RemoveOp(plan, (OpBase *)opScan);
@@ -244,7 +244,7 @@ void _reduceEdgeCount(ExecutionPlan *plan) {
 	AR_ExpNode **exps = array_new(AR_ExpNode *, 1);
 	exps = array_append(exps, exp);
 
-	OpBase *opProject = NewProjectOp(opAggregate->op.plan, exps);
+	OpBase *opProject = NewProjectOp(opAggregate->op.plan, exps, NULL);
 
 	// New execution plan: "Project -> Results"
 	ExecutionPlan_RemoveOp(plan, (OpBase *)opScan);
@@ -267,3 +267,4 @@ void reduceCount(ExecutionPlan *plan) {
 	 * then edge count will be tried to be executed upon the same execution plan */
 	if(!_reduceNodeCount(plan)) _reduceEdgeCount(plan);
 }
+

--- a/src/util/rax_extensions.c
+++ b/src/util/rax_extensions.c
@@ -21,6 +21,21 @@ bool raxIsSubset(rax *a, rax *b) {
 	return is_subset;
 }
 
+bool raxIntersects(rax *a, rax *b) {
+	raxIterator it;
+	raxStart(&it, a);
+	raxSeek(&it, "^", NULL, 0);
+	bool has_intersection = false;
+	while(raxNext(&it)) {
+		if(raxFind(b, it.key, it.key_len) != raxNotFound) {
+			has_intersection = true;
+			break;
+		}
+	}
+	raxStop(&it);
+	return has_intersection;
+}
+
 rax *raxClone(rax *orig) {
 	rax *rax = raxNew();
 

--- a/src/util/rax_extensions.h
+++ b/src/util/rax_extensions.h
@@ -13,6 +13,9 @@
 // Returns true if 'b' is a subset of 'a'.
 bool raxIsSubset(rax *a, rax *b);
 
+// Returns true if any key is found in both 'a' and 'b'.
+bool raxIntersects(rax *a, rax *b);
+
 // Duplicates a rax, performing a shallow copy of the original's values.
 rax *raxClone(rax *orig);
 

--- a/tests/flow/test_order_by.py
+++ b/tests/flow/test_order_by.py
@@ -34,3 +34,10 @@ class testOrderBy(FlowTestsBase):
         q = """MATCH (n:Person) RETURN n.id, n.name ORDER BY n.id DESC, n.name ASC LIMIT 10"""
         actual_result = redis_graph.query(q)
         self.env.assertEquals(actual_result.result_set, expected)
+
+    def test_order_by_function_on_alias(self):
+        # Validate that aliases introduced by the RETURN clause can be accessed by nested ORDER BY expressions.
+        q = """MATCH (n:Person) RETURN n.id AS id ORDER BY toInteger(id)"""
+        expected = [[622], [819], [819]]
+        actual_result = redis_graph.query(q)
+        self.env.assertEquals(actual_result.result_set, expected)

--- a/tests/flow/test_with_clause.py
+++ b/tests/flow/test_with_clause.py
@@ -105,7 +105,6 @@ class testWithClause(FlowTestsBase):
         expected = [[6, 15]]
         self.env.assertEqual(actual_result.result_set, expected)
 
-    # TODO UNWIND support needs to be extended for combinations like UNWIND...MATCH
     def test04_with_unwind_expressions(self):
         query = """UNWIND [1, 2, 3] AS x WITH x AS y RETURN y"""
         actual_result = redis_graph.query(query)
@@ -146,7 +145,6 @@ class testWithClause(FlowTestsBase):
         self.env.assertEqual(actual_result.nodes_created, 1)
         self.env.assertEqual(actual_result.properties_set, 1)
 
-        # TODO Update CREATE to accept variable arguments from UNWIND, WITH, etc
         query = """UNWIND [5] AS a WITH a AS b CREATE (:unwind_label {prop: 'some_constant'})"""
         actual_result = redis_graph.query(query)
 
@@ -217,4 +215,11 @@ class testWithClause(FlowTestsBase):
         query = """UNWIND ['scope1'] AS a WITH a AS b UNWIND ['scope2'] AS a WITH a WHERE a = 'scope2' RETURN a"""
         actual_result = redis_graph.query(query)
         expected = [['scope2']]
+        self.env.assertEqual(actual_result.result_set, expected)
+
+    # Verify that ORDER BY expressions on aliased projections work properly.
+    def test10_order_with_aliases(self):
+        query = """MATCH (a) WITH ID(a) AS id ORDER BY toInteger(id) LIMIT 3 RETURN id"""
+        actual_result = redis_graph.query(query)
+        expected = [[0], [1], [2]]
         self.env.assertEqual(actual_result.result_set, expected)

--- a/tests/tck/features/AggregationAcceptance.feature
+++ b/tests/tck/features/AggregationAcceptance.feature
@@ -111,7 +111,6 @@ Feature: AggregationAcceptance
             | (:L) | 2        |
         And no side effects
 
-    @skip
     Scenario: Sort on aggregate function and normal property
         Given an empty graph
         And having executed:

--- a/tests/tck/features/MatchAcceptance2.feature
+++ b/tests/tck/features/MatchAcceptance2.feature
@@ -1078,8 +1078,6 @@ Feature: MatchAcceptance2
       | [:T2] |
     And no side effects
 
-@crash
-@skip
   Scenario: Matching using a relationship that is already bound, in conjunction with aggregation and ORDER BY
     Given an empty graph
     And having executed:
@@ -1142,7 +1140,6 @@ Feature: MatchAcceptance2
       | (:A) | [:T] | (:B) |
     And no side effects
 
-@skip
   Scenario: Matching with LIMIT, then matching again using a relationship and node that are both already bound along with an additional predicate
     Given an empty graph
     And having executed:

--- a/tests/tck/features/OrderByAcceptance.feature
+++ b/tests/tck/features/OrderByAcceptance.feature
@@ -89,7 +89,6 @@ Feature: OrderByAcceptance
             | 1 |
         And no side effects
 
-    @skip
     Scenario: Renaming columns before ORDER BY should return results in ascending order
         And having executed:
             """


### PR DESCRIPTION
This PR fixes a number of currently unmanaged ORDER expressions. Specifically, the LDBC benchmark has a number of queries of the form:
`MATCH (n) RETURN n.id AS id ORDER BY toInteger(id)`
Which currently triggers:
`Record_GetEntryIdx: Assertion 'idx != raxNotFound && "ERR: tried to resolve unexpected alias"' failed.`