### PR TITLE
intoduced fpClone in OpBase

### DIFF
--- a/src/execution_plan/ops/op.c
+++ b/src/execution_plan/ops/op.c
@@ -16,7 +16,8 @@ rax *ExecutionPlan_GetMappings(const struct ExecutionPlan *plan);
 void ExecutionPlan_ReturnRecord(struct ExecutionPlan *plan, Record r);
 
 void OpBase_Init(OpBase *op, OPType type, const char *name, fpInit init, fpConsume consume,
-				 fpReset reset, fpToString toString, fpFree free, bool writer, const struct ExecutionPlan *plan) {
+				 fpReset reset, fpToString toString, fpClone clone, fpFree free, bool writer,
+				 const struct ExecutionPlan *plan) {
 
 	op->type = type;
 	op->name = name;
@@ -37,6 +38,7 @@ void OpBase_Init(OpBase *op, OPType type, const char *name, fpInit init, fpConsu
 	op->consume = consume;
 	op->reset = reset;
 	op->toString = toString;
+	op->clone = clone;
 	op->free = free;
 }
 
@@ -151,6 +153,11 @@ Record OpBase_CloneRecord(Record r) {
 
 inline void OpBase_DeleteRecord(Record r) {
 	ExecutionPlan_ReturnRecord(r->owner, r);
+}
+
+OpBase *OpBase_Clone(const struct ExecutionPlan *plan, const OpBase *op) {
+	if(op->clone) return op->clone(plan, op);
+	return NULL;
 }
 
 void OpBase_Free(OpBase *op) {

--- a/src/execution_plan/ops/op.h
+++ b/src/execution_plan/ops/op.h
@@ -60,12 +60,14 @@ typedef enum {
 } OpResult;
 
 struct OpBase;
+struct ExecutionPlan;
 
 typedef void (*fpFree)(struct OpBase *);
 typedef OpResult(*fpInit)(struct OpBase *);
 typedef Record(*fpConsume)(struct OpBase *);
 typedef OpResult(*fpReset)(struct OpBase *);
 typedef int (*fpToString)(const struct OpBase *, char *, uint);
+typedef struct OpBase *(*fpClone)(const struct ExecutionPlan *, const struct OpBase *);
 
 // Execution plan operation statistics.
 typedef struct {
@@ -73,13 +75,12 @@ typedef struct {
 	double profileExecTime;     // Operation total execution time in ms.
 }  OpStats;
 
-struct ExecutionPlan;
-
 struct OpBase {
 	OPType type;                // Type of operation.
 	fpInit init;                // Called once before execution.
 	fpFree free;                // Free operation.
 	fpReset reset;              // Reset operation state.
+	fpClone clone;              // Operation clone.
 	fpConsume consume;          // Produce next record.
 	fpConsume profile;          // Profiled version of consume.
 	fpToString toString;        // Operation string representation.
@@ -98,12 +99,15 @@ typedef struct OpBase OpBase;
 
 // Initialize op.
 void OpBase_Init(OpBase *op, OPType type, const char *name, fpInit init, fpConsume consume,
-				 fpReset reset, fpToString toString, fpFree free, bool writer, const struct ExecutionPlan *plan);
+				 fpReset reset, fpToString toString, fpClone, fpFree free, bool writer,
+				 const struct ExecutionPlan *plan);
 void OpBase_Free(OpBase *op);       // Free op.
 Record OpBase_Consume(OpBase *op);  // Consume op.
 Record OpBase_Profile(OpBase *op);  // Profile op.
 
 int OpBase_ToString(const OpBase *op, char *buff, uint buff_len);
+
+OpBase *OpBase_Clone(const struct ExecutionPlan *plan, const OpBase *op);
 
 /* If an operation holds the sole reference to a Record it is evaluating,
  * that reference should be tracked so that it may be freed in the event of a run-time error. */

--- a/src/execution_plan/ops/op_aggregate.c
+++ b/src/execution_plan/ops/op_aggregate.c
@@ -211,7 +211,7 @@ OpBase *NewAggregateOp(const ExecutionPlan *plan, AR_ExpNode **exps, bool should
 	op->should_cache_records = should_cache_records;
 
 	OpBase_Init((OpBase *)op, OPType_AGGREGATE, "Aggregate", AggregateInit, AggregateConsume,
-				AggregateReset, NULL, AggregateFree, false, plan);
+				AggregateReset, NULL, NULL, AggregateFree, false, plan);
 
 	for(uint i = 0; i < op->exp_count; i ++) {
 		// The projected record will associate values with their resolved name

--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -27,7 +27,7 @@ OpBase *NewAllNodeScanOp(const ExecutionPlan *plan, const QGNode *n) {
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_ALL_NODE_SCAN, "All Node Scan", AllNodeScanInit,
-				AllNodeScanConsume, AllNodeScanReset, AllNodeScanToString, AllNodeScanFree, false, plan);
+				AllNodeScanConsume, AllNodeScanReset, AllNodeScanToString, NULL, AllNodeScanFree, false, plan);
 	op->nodeRecIdx = OpBase_Modifies((OpBase *)op, n->alias);
 	return (OpBase *)op;
 }

--- a/src/execution_plan/ops/op_apply.c
+++ b/src/execution_plan/ops/op_apply.c
@@ -19,7 +19,7 @@ OpBase *NewApplyOp(const ExecutionPlan *plan) {
 	op->rhs_records = array_new(Record, 32);
 
 	// Set our Op operations
-	OpBase_Init((OpBase *)op, OPType_APPLY, "Apply", NULL, ApplyConsume, ApplyReset, NULL,
+	OpBase_Init((OpBase *)op, OPType_APPLY, "Apply", NULL, ApplyConsume, ApplyReset, NULL, NULL,
 				ApplyFree, false, plan);
 
 	return (OpBase *)op;

--- a/src/execution_plan/ops/op_apply_multiplexer.c
+++ b/src/execution_plan/ops/op_apply_multiplexer.c
@@ -27,11 +27,11 @@ OpBase *NewApplyMultiplexerOp(ExecutionPlan *plan, AST_Operator boolean_operator
 	if(boolean_operator == OP_OR) {
 		OpBase_Init((OpBase *)op, OPType_OR_APPLY_MULTIPLEXER, "OR Apply Multiplexer",
 					OpApplyMultiplexerInit,
-					OrMultiplexer_Consume, OpApplyMultiplexerReset, NULL, OpApplyMultiplexerFree, false, plan);
+					OrMultiplexer_Consume, OpApplyMultiplexerReset, NULL, NULL, OpApplyMultiplexerFree, false, plan);
 	} else if(boolean_operator == OP_AND) {
 		OpBase_Init((OpBase *)op, OPType_AND_APPLY_MULTIPLEXER, "AND Apply Multiplexer",
 					OpApplyMultiplexerInit,
-					AndMultiplexer_Consume, OpApplyMultiplexerReset, NULL, OpApplyMultiplexerFree, false, plan);
+					AndMultiplexer_Consume, OpApplyMultiplexerReset, NULL, NULL, OpApplyMultiplexerFree, false, plan);
 	} else {
 		assert("apply multiplexer boolean operator should be AND or OR only" && false);
 	}

--- a/src/execution_plan/ops/op_argument.c
+++ b/src/execution_plan/ops/op_argument.c
@@ -17,7 +17,7 @@ OpBase *NewArgumentOp(const ExecutionPlan *plan, const char **variables) {
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_ARGUMENT, "Argument", NULL,
-				ArgumentConsume, ArgumentReset, NULL, ArgumentFree, false, plan);
+				ArgumentConsume, ArgumentReset, NULL, NULL, ArgumentFree, false, plan);
 
 	uint variable_count = array_len(variables);
 	for(uint i = 0; i < variable_count; i ++) {

--- a/src/execution_plan/ops/op_cartesian_product.c
+++ b/src/execution_plan/ops/op_cartesian_product.c
@@ -19,7 +19,7 @@ OpBase *NewCartesianProductOp(const ExecutionPlan *plan) {
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_CARTESIAN_PRODUCT, "Cartesian Product", CartesianProductInit,
-				CartesianProductConsume, CartesianProductReset, NULL, CartesianProductFree, false, plan);
+				CartesianProductConsume, CartesianProductReset, NULL, NULL, CartesianProductFree, false, plan);
 	return (OpBase *)op;
 }
 

--- a/src/execution_plan/ops/op_cond_var_len_traverse.c
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.c
@@ -89,7 +89,7 @@ OpBase *NewCondVarLenTraverseOp(const ExecutionPlan *plan, Graph *g, AlgebraicEx
 
 	OpBase_Init((OpBase *)op, OPType_CONDITIONAL_VAR_LEN_TRAVERSE,
 				"Conditional Variable Length Traverse", NULL, CondVarLenTraverseConsume, CondVarLenTraverseReset,
-				CondVarLenTraverseToString, CondVarLenTraverseFree, false, plan);
+				CondVarLenTraverseToString, NULL, CondVarLenTraverseFree, false, plan);
 
 	assert(OpBase_Aware((OpBase *)op, AlgebraicExpression_Source(ae), &op->srcNodeIdx));
 	op->destNodeIdx = OpBase_Modifies((OpBase *)op, AlgebraicExpression_Destination(ae));

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -136,7 +136,7 @@ OpBase *NewCondTraverseOp(const ExecutionPlan *plan, Graph *g, AlgebraicExpressi
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_CONDITIONAL_TRAVERSE, "Conditional Traverse", NULL,
-				CondTraverseConsume, CondTraverseReset, CondTraverseToString, CondTraverseFree, false, plan);
+				CondTraverseConsume, CondTraverseReset, CondTraverseToString, NULL, CondTraverseFree, false, plan);
 
 	assert(OpBase_Aware((OpBase *)op, AlgebraicExpression_Source(ae), &op->srcNodeIdx));
 	op->destNodeIdx = OpBase_Modifies((OpBase *)op, AlgebraicExpression_Destination(ae));

--- a/src/execution_plan/ops/op_create.c
+++ b/src/execution_plan/ops/op_create.c
@@ -22,7 +22,7 @@ OpBase *NewCreateOp(const ExecutionPlan *plan, ResultSetStatistics *stats, NodeC
 	op->pending = NewPendingCreationsContainer(stats, nodes, edges); // Prepare all creation variables.
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_CREATE, "Create", NULL, CreateConsume,
-				NULL, NULL, CreateFree, true, plan);
+				NULL, NULL, NULL, CreateFree, true, plan);
 
 	uint node_blueprint_count = array_len(nodes);
 	uint edge_blueprint_count = array_len(edges);

--- a/src/execution_plan/ops/op_delete.c
+++ b/src/execution_plan/ops/op_delete.c
@@ -57,7 +57,7 @@ OpBase *NewDeleteOp(const ExecutionPlan *plan, AR_ExpNode **exps, ResultSetStati
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_DELETE, "Delete", NULL, DeleteConsume,
-				NULL, NULL, DeleteFree, true, plan);
+				NULL, NULL, NULL, DeleteFree, true, plan);
 
 	return (OpBase *)op;
 }

--- a/src/execution_plan/ops/op_distinct.c
+++ b/src/execution_plan/ops/op_distinct.c
@@ -17,7 +17,7 @@ OpBase *NewDistinctOp(const ExecutionPlan *plan) {
 	op->found = raxNew();
 
 	OpBase_Init((OpBase *)op, OPType_DISTINCT, "Distinct", NULL, DistinctConsume,
-				NULL, NULL, DistinctFree, false, plan);
+				NULL, NULL, NULL, DistinctFree, false, plan);
 
 	return (OpBase *)op;
 }

--- a/src/execution_plan/ops/op_expand_into.c
+++ b/src/execution_plan/ops/op_expand_into.c
@@ -106,7 +106,7 @@ OpBase *NewExpandIntoOp(const ExecutionPlan *plan, Graph *g, AlgebraicExpression
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_EXPAND_INTO, "Expand Into", NULL, ExpandIntoConsume,
-				ExpandIntoReset, ExpandIntoToString, ExpandIntoFree, false, plan);
+				ExpandIntoReset, ExpandIntoToString, NULL, ExpandIntoFree, false, plan);
 
 	// Make sure that all entities are represented in Record
 	op->edgeIdx = IDENTIFIER_NOT_FOUND;

--- a/src/execution_plan/ops/op_filter.c
+++ b/src/execution_plan/ops/op_filter.c
@@ -16,7 +16,7 @@ OpBase *NewFilterOp(const ExecutionPlan *plan, FT_FilterNode *filterTree) {
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_FILTER, "Filter", NULL, FilterConsume,
-				NULL, NULL, FilterFree, false, plan);
+				NULL, NULL, NULL, FilterFree, false, plan);
 
 	return (OpBase *)op;
 }

--- a/src/execution_plan/ops/op_index_scan.c
+++ b/src/execution_plan/ops/op_index_scan.c
@@ -29,7 +29,7 @@ OpBase *NewIndexScanOp(const ExecutionPlan *plan, Graph *g, const QGNode *n, RSI
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_INDEX_SCAN, "Index Scan", IndexScanInit, IndexScanConsume,
-				IndexScanReset, IndexScanToString, IndexScanFree, false, plan);
+				IndexScanReset, IndexScanToString, NULL, IndexScanFree, false, plan);
 
 	op->nodeRecIdx = OpBase_Modifies((OpBase *)op, n->alias);
 	return (OpBase *)op;

--- a/src/execution_plan/ops/op_join.c
+++ b/src/execution_plan/ops/op_join.c
@@ -16,7 +16,7 @@ OpBase *NewJoinOp(const ExecutionPlan *plan) {
 	op->stream = NULL;
 
 	// Set our Op operations
-	OpBase_Init((OpBase *)op, OPType_JOIN, "Join", JoinInit, JoinConsume, NULL, NULL, NULL, false,
+	OpBase_Init((OpBase *)op, OPType_JOIN, "Join", JoinInit, JoinConsume, NULL, NULL, NULL, NULL, false,
 				plan);
 
 	return (OpBase *)op;

--- a/src/execution_plan/ops/op_limit.c
+++ b/src/execution_plan/ops/op_limit.c
@@ -17,7 +17,7 @@ OpBase *NewLimitOp(const ExecutionPlan *plan, unsigned int l) {
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_LIMIT, "Limit", NULL, LimitConsume,
-				LimitReset, NULL, NULL, false, plan);
+				LimitReset, NULL, NULL, NULL, false, plan);
 
 	return (OpBase *)op;
 }

--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -93,8 +93,8 @@ OpBase *NewMergeOp(const ExecutionPlan *plan, EntityUpdateEvalCtx *on_match,
 	op->stats = stats;
 	op->on_match = on_match;
 	// Set our Op operations
-	OpBase_Init((OpBase *)op, OPType_MERGE, "Merge", MergeInit, MergeConsume, NULL, NULL, MergeFree,
-				true, plan);
+	OpBase_Init((OpBase *)op, OPType_MERGE, "Merge", MergeInit, MergeConsume, NULL, NULL, NULL,
+				MergeFree, true, plan);
 
 	if(op->on_match) {
 		// If we have ON MATCH directives, set the appropriate record IDs of entities to be updated.

--- a/src/execution_plan/ops/op_merge_create.c
+++ b/src/execution_plan/ops/op_merge_create.c
@@ -60,7 +60,7 @@ OpBase *NewMergeCreateOp(const ExecutionPlan *plan, ResultSetStatistics *stats,
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_MERGE_CREATE, "MergeCreate", NULL, MergeCreateConsume,
-				NULL, NULL, MergeCreateFree, true, plan);
+				NULL, NULL, NULL, MergeCreateFree, true, plan);
 
 	uint node_blueprint_count = array_len(nodes);
 	uint edge_blueprint_count = array_len(edges);

--- a/src/execution_plan/ops/op_node_by_id_seek.c
+++ b/src/execution_plan/ops/op_node_by_id_seek.c
@@ -43,7 +43,7 @@ OpBase *NewNodeByIdSeekOp(const ExecutionPlan *plan, const QGNode *n, UnsignedRa
 	op->currentId = op->minId;
 
 	OpBase_Init((OpBase *)op, OPType_NODE_BY_ID_SEEK, "NodeByIdSeek", NodeByIdSeekInit,
-				NodeByIdSeekConsume, NodeByIdSeekReset, NodeByIdSeekToString, NodeByIdSeekFree, false, plan);
+				NodeByIdSeekConsume, NodeByIdSeekReset, NodeByIdSeekToString, NULL, NodeByIdSeekFree, false, plan);
 
 	op->nodeRecIdx = OpBase_Modifies((OpBase *)op, n->alias);
 

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -33,8 +33,8 @@ OpBase *NewNodeByLabelScanOp(const ExecutionPlan *plan, const QGNode *n) {
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_NODE_BY_LABEL_SCAN, "Node By Label Scan", NodeByLabelScanInit,
-				NodeByLabelScanConsume, NodeByLabelScanReset, NodeByLabelScanToString, NodeByLabelScanFree, false,
-				plan);
+				NodeByLabelScanConsume, NodeByLabelScanReset, NodeByLabelScanToString, NULL, NodeByLabelScanFree,
+				false, plan);
 
 	op->nodeRecIdx = OpBase_Modifies((OpBase *)op, n->alias);
 

--- a/src/execution_plan/ops/op_procedure_call.c
+++ b/src/execution_plan/ops/op_procedure_call.c
@@ -84,7 +84,7 @@ OpBase *NewProcCallOp(const ExecutionPlan *plan, const char *proc_name, AR_ExpNo
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_PROC_CALL, "ProcedureCall", NULL, ProcCallConsume,
-				ProcCallReset, NULL, ProcCallFree, !op->procedure->readOnly, plan);
+				ProcCallReset, NULL, NULL, ProcCallFree, !op->procedure->readOnly, plan);
 
 	// Set modifiers.
 	for(uint i = 0; i < yield_count; i ++) {

--- a/src/execution_plan/ops/op_project.c
+++ b/src/execution_plan/ops/op_project.c
@@ -23,7 +23,7 @@ OpBase *NewProjectOp(const ExecutionPlan *plan, AR_ExpNode **exps) {
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_PROJECT, "Project", NULL, ProjectConsume,
-				NULL, NULL, ProjectFree, false, plan);
+				NULL, NULL, NULL, ProjectFree, false, plan);
 
 	for(uint i = 0; i < op->exp_count; i ++) {
 		// The projected record will associate values with their resolved name

--- a/src/execution_plan/ops/op_results.c
+++ b/src/execution_plan/ops/op_results.c
@@ -17,7 +17,7 @@ OpBase *NewResultsOp(const ExecutionPlan *plan, ResultSet *result_set) {
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_RESULTS, "Results", NULL, ResultsConsume,
-				NULL, NULL, NULL, false, plan);
+				NULL, NULL, NULL, NULL, false, plan);
 
 	return (OpBase *)op;
 }

--- a/src/execution_plan/ops/op_semi_apply.c
+++ b/src/execution_plan/ops/op_semi_apply.c
@@ -29,10 +29,10 @@ OpBase *NewSemiApplyOp(ExecutionPlan *plan, bool anti) {
 	// Set our Op operations
 	if(anti) {
 		OpBase_Init((OpBase *)op, OpType_ANTI_SEMI_APPLY, "Anti Semi Apply", SemiApplyInit,
-					AntiSemiApplyConsume, SemiApplyReset, NULL, SemiApplyFree, false, plan);
+					AntiSemiApplyConsume, SemiApplyReset, NULL, NULL, SemiApplyFree, false, plan);
 	} else {
 		OpBase_Init((OpBase *)op, OPType_SEMI_APPLY, "Semi Apply", SemiApplyInit, SemiApplyConsume,
-					SemiApplyReset, NULL, SemiApplyFree, false, plan);
+					SemiApplyReset, NULL, NULL, SemiApplyFree, false, plan);
 	}
 	return (OpBase *) op;
 }

--- a/src/execution_plan/ops/op_skip.c
+++ b/src/execution_plan/ops/op_skip.c
@@ -16,8 +16,8 @@ OpBase *NewSkipOp(const ExecutionPlan *plan, unsigned int rec_to_skip) {
 	op->rec_to_skip = rec_to_skip;
 
 	// Set our Op operations
-	OpBase_Init((OpBase *)op, OPType_SKIP, "Skip", NULL, SkipConsume, SkipReset, NULL, NULL, false,
-				plan);
+	OpBase_Init((OpBase *)op, OPType_SKIP, "Skip", NULL, SkipConsume, SkipReset, NULL, NULL, NULL,
+				false, plan);
 
 	return (OpBase *)op;
 }

--- a/src/execution_plan/ops/op_sort.c
+++ b/src/execution_plan/ops/op_sort.c
@@ -34,7 +34,8 @@ static int _record_compare(Record a, Record b, const OpSort *op) {
 // Quicksort function to compare two records on a subset of fields.
 // Returns true if a is less than b.
 static bool _record_islt(Record a, Record b, const OpSort *op) {
-  return _record_compare(a, b, op) > 0; // Return true if the current left element is less than the right.
+	return _record_compare(a, b, op) >
+		   0; // Return true if the current left element is less than the right.
 }
 
 // Compares two heap record nodes.
@@ -84,7 +85,7 @@ OpBase *NewSortOp(const ExecutionPlan *plan, AR_ExpNode **exps, int *directions,
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_SORT, "Sort", NULL,
-				SortConsume, SortReset, NULL, SortFree, false, plan);
+				SortConsume, SortReset, NULL, NULL, SortFree, false, plan);
 
 	uint comparison_count = array_len(exps);
 	op->record_offsets = array_new(uint, comparison_count);
@@ -189,7 +190,7 @@ static void SortFree(OpBase *ctx) {
 		op->record_offsets = NULL;
 	}
 
-	if (op->directions) {
+	if(op->directions) {
 		array_free(op->directions);
 		op->directions = NULL;
 	}

--- a/src/execution_plan/ops/op_unwind.c
+++ b/src/execution_plan/ops/op_unwind.c
@@ -29,7 +29,7 @@ OpBase *NewUnwindOp(const ExecutionPlan *plan, AR_ExpNode *exp) {
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_UNWIND, "Unwind", UnwindInit, UnwindConsume,
-				UnwindReset, NULL, UnwindFree, false, plan);
+				UnwindReset, NULL, NULL, UnwindFree, false, plan);
 
 	op->unwindRecIdx = OpBase_Modifies((OpBase *)op, exp->resolved_name);
 	return (OpBase *)op;

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -153,7 +153,7 @@ OpBase *NewUpdateOp(const ExecutionPlan *plan, EntityUpdateEvalCtx *update_exps,
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_UPDATE, "Update", UpdateInit, UpdateConsume,
-				UpdateReset, NULL, UpdateFree, true, plan);
+				UpdateReset, NULL, NULL, UpdateFree, true, plan);
 
 	for(uint i = 0; i < op->update_expressions_count; i ++) {
 		op->update_expressions[i].record_idx = OpBase_Modifies((OpBase *)op, update_exps[i].alias);

--- a/src/execution_plan/ops/op_value_hash_join.c
+++ b/src/execution_plan/ops/op_value_hash_join.c
@@ -174,8 +174,8 @@ OpBase *NewValueHashJoin(const ExecutionPlan *plan, AR_ExpNode *lhs_exp, AR_ExpN
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_VALUE_HASH_JOIN, "Value Hash Join", ValueHashJoinInit,
-				ValueHashJoinConsume, ValueHashJoinReset, ValueHashJoinToString,
-				ValueHashJoinFree, false, plan);
+				ValueHashJoinConsume, ValueHashJoinReset, ValueHashJoinToString, NULL, ValueHashJoinFree, false,
+				plan);
 
 	op->join_value_rec_idx = OpBase_Modifies((OpBase *)op, "pivot");
 	return (OpBase *)op;


### PR DESCRIPTION
This PR introduces the `fpClone` function in `OpBase` as a building block for individual `Clone` PRs for each operation.
Currently, each operation sends `NULL` as a function pointer for this function in `OpBase_Init`

This is enabler for #907 