### PR TITLE
Leak testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,8 @@ deploydocs: builddocs
 test:
 	@$(MAKE) -C ./src test
 
+memcheck:
+	@$(MAKE) -C ./src memcheck
+
 format:
 	astyle -Q --options=.astylerc -R --ignore-exclude-errors "./*.c,*.h,*.cpp"

--- a/src/Makefile
+++ b/src/Makefile
@@ -192,3 +192,6 @@ ifneq ($(uname_S),Linux)
 endif
 endif
 	@$(MAKE) -C ../tests test
+
+memcheck: redisgraph.so
+	@$(MAKE) -C ../tests memcheck

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -17,6 +17,16 @@ tck:
 	### Cypher Technology Compatibility Kit (TCK)
 	@$(MAKE) -C tck
 
+# TODO Temporary solution which assumes that 'redis-server' is on the path and has been compiled with jemalloc profiling enabled.
+# It would be preferable to instantiate a server through RLTest.
+memcheck:
+	JE_MALLOC_CONF="prof:true,prof_leak:true,lg_prof_sample:0,prof_final:true" LD_PRELOAD="$(shell find .. -name "*.so")" redis-server --loadmodule ../src/redisgraph.so &
+	@sleep 1
+	@redis-cli ping
+	@$(MAKE) TEST_ARGS+=--env-reuse flow
+	@$(MAKE) TEST_ARGS+=--env-reuse tck
+	redis-cli flushall && redis-cli shutdown
+
 clean:
 	@find . -name '*.[oad]' -type f -delete
 	@find . -name '*.run' -type f -delete

--- a/tests/flow/Makefile
+++ b/tests/flow/Makefile
@@ -14,7 +14,7 @@ endif
 
 #check valgrind flag
 ifneq ($(VALGRIND),)
-	valgrind += -V --vg-no-leakcheck --vg-verbose
+	valgrind += -V --vg-no-leakcheck --vg-verbose --env-reuse
 	TEST_ARGS += $(valgrind)
 endif
 
@@ -29,12 +29,12 @@ test:
 # if host is linux
 ifeq ($(OS), Linux)
 	# regular tests on linux
-	@python -m RLTest --module ../../src/redisgraph.so  $(TEST_ARGS)
+	@python -m RLTest --module ../../src/redisgraph.so $(TEST_ARGS)
 else
 # mac
 ifeq ($(VALGRIND),)
 	# no valgrind
-	@python -m RLTest --module ../../src/redisgraph.so  $(TEST_ARGS)
+	@python -m RLTest --module ../../src/redisgraph.so $(TEST_ARGS)
 else
 	# valgrind in docker
 	@echo running docker to run valgrind flow test on MacOS

--- a/tests/flow/Makefile
+++ b/tests/flow/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test
 # find the OS
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
-TEST_ARGS = --clear-logs
+override TEST_ARGS += --clear-logs
 # check verbose flag
 ifneq ($(V),)
 	TEST_ARGS += --verbose

--- a/tests/tck/Makefile
+++ b/tests/tck/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test
 # find the OS
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
-TEST_ARGS = 
+override TEST_ARGS += --clear-logs
 # check verbose flag
 ifneq ($(V),)
 	TEST_ARGS += --verbose


### PR DESCRIPTION
WIP branch - does not yet contain automation or RLTest integrations.

Requires `redis-server` to be built with an additional jemalloc argument. I've currently set up the fork https://github.com/jeffreylovitz/redis so that this can be accomplished like so:
```
make distclean
JEMALLOC_CONF_FLAGS=--enable-prof make
sudo make install
```
(I doubt that antirez would like this build format, so will wait until we discuss before opening a PR.)

The `make memcheck` directive for RedisGraph will instantiate a server and run the flow and TCK tests, outputting a heap file that can be introspected on using the `jeprof` tool (found at `redis/deps/jemalloc/bin/jeprof`).

For introspection, you can get an interactive jeprof shell with:
`jeprof --show_bytes $(which redis-server) tests/jeprof.*.heap`
Other commands will build text outputs or visualizations similarly.