### PR TITLE
Always free emptied space on AlgebraicExpression replacement

### DIFF
--- a/src/arithmetic/algebraic_expression/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression.c
@@ -321,8 +321,6 @@ AlgebraicExpression *AlgebraicExpression_RemoveLeftmostNode
 			if(child_count == 1) {
 				AlgebraicExpression *replacement = _AlgebraicExpression_OperationRemoveRightmostChild(prev);
 				_AlgebraicExpression_InplaceRepurpose(prev, replacement);
-				// Free replacement as it has been copied.
-				rm_free(replacement);
 			} else {
 				assert("for the timebing, we should not be here" && false);
 			}
@@ -363,8 +361,6 @@ AlgebraicExpression *AlgebraicExpression_RemoveRightmostNode
 		if(child_count == 1) {
 			AlgebraicExpression *replacement = _AlgebraicExpression_OperationRemoveRightmostChild(prev);
 			_AlgebraicExpression_InplaceRepurpose(prev, replacement);
-			// Free replacement as it has been copied.
-			rm_free(replacement);
 		}
 	}
 	return current;
@@ -464,3 +460,4 @@ void AlgebraicExpression_Free
 	}
 	rm_free(root);
 }
+

--- a/src/arithmetic/algebraic_expression/utils.c
+++ b/src/arithmetic/algebraic_expression/utils.c
@@ -31,6 +31,8 @@ void _AlgebraicExpression_InplaceRepurpose
 
 	// Replace.
 	memcpy(exp, replacement, sizeof(AlgebraicExpression));
+	// Free the memory of the migrated replacement.
+	rm_free(replacement);
 }
 
 // Removes the rightmost direct child node of root.
@@ -240,3 +242,4 @@ void _AlgebraicExpression_FetchOperands(AlgebraicExpression *exp, const GraphCon
 		break;
 	}
 }
+


### PR DESCRIPTION
The function `_AlgebraicExpression_TransposeTranspose`, invoked by queries like:
`MATCH (b)-[rel:X]-(a) WHERE a.name = 'Andres' RETURN a`
Had a memory leak when replacing nodes in the expression tree.
This PR moves the responsibility for that free into `_AlgebraicExpression_InplaceRepurpose`.
