### PR TITLE
Reintroduce logic for freeing memory on run-time errors

### DIFF
--- a/src/execution_plan/ops/op.c
+++ b/src/execution_plan/ops/op.c
@@ -29,7 +29,6 @@ void OpBase_Init(OpBase *op, OPType type, const char *name, fpInit init, fpConsu
 	op->parent = NULL;
 	op->stats = NULL;
 	op->op_initialized = false;
-	op->dangling_records = NULL;
 	op->modifies = NULL;
 	op->writer = writer;
 
@@ -126,17 +125,6 @@ Record OpBase_Profile(OpBase *op) {
 	return r;
 }
 
-void OpBase_AddVolatileRecord(OpBase *op, const Record r) {
-	if(op->dangling_records == NULL) op->dangling_records = array_new(Record, 1);
-	op->dangling_records = array_append(op->dangling_records, r);
-}
-
-void OpBase_RemoveVolatileRecords(OpBase *op) {
-	if(!op->dangling_records) return;
-
-	array_clear(op->dangling_records);
-}
-
 bool OpBase_IsWriter(OpBase *op) {
 	return op->writer;
 }
@@ -166,14 +154,6 @@ void OpBase_Free(OpBase *op) {
 	if(op->children) rm_free(op->children);
 	if(op->modifies) array_free(op->modifies);
 	if(op->stats) rm_free(op->stats);
-	// If we are storing dangling references to Records, free them now.
-	if(op->dangling_records) {
-		uint count = array_len(op->dangling_records);
-		for(uint i = 0; i < count; i ++) {
-			OpBase_DeleteRecord(op->dangling_records[i]);
-		}
-		array_free(op->dangling_records);
-	}
 	rm_free(op);
 }
 

--- a/src/execution_plan/ops/op.h
+++ b/src/execution_plan/ops/op.h
@@ -93,7 +93,6 @@ struct OpBase {
 	struct OpBase **children;   // Child operations.
 	const char **modifies;      // List of entities this op modifies.
 	OpStats *stats;             // Profiling statistics.
-	Record *dangling_records;   // Records allocated by this operation that must be freed.
 	struct OpBase *parent;      // Parent operations.
 	const struct ExecutionPlan *plan; // ExecutionPlan this operation is part of.
 	bool writer;             // Indicates this is a writer operation.
@@ -111,13 +110,6 @@ Record OpBase_Profile(OpBase *op);  // Profile op.
 int OpBase_ToString(const OpBase *op, char *buff, uint buff_len);
 
 OpBase *OpBase_Clone(const struct ExecutionPlan *plan, const OpBase *op);
-
-/* If an operation holds the sole reference to a Record it is evaluating,
- * that reference should be tracked so that it may be freed in the event of a run-time error. */
-void OpBase_AddVolatileRecord(OpBase *op, const Record r);
-/* No errors were encountered while processing these Records; the references
- * may be released. */
-void OpBase_RemoveVolatileRecords(OpBase *op);
 
 /* Mark alias as being modified by operation.
  * Returns the ID associated with alias. */

--- a/src/execution_plan/ops/op_project.c
+++ b/src/execution_plan/ops/op_project.c
@@ -52,6 +52,9 @@ static Record ProjectConsume(OpBase *opBase) {
 	}
 
 	Record projection = OpBase_CreateRecord(opBase);
+	// Track the inherited Record and the newly-allocated Record so that they may be freed if execution fails.
+	OpBase_AddVolatileRecord(opBase, r);
+	OpBase_AddVolatileRecord(opBase, projection);
 
 	for(uint i = 0; i < op->exp_count; i++) {
 		AR_ExpNode *exp = op->exps[i];
@@ -66,6 +69,7 @@ static Record ProjectConsume(OpBase *opBase) {
 		Record_Add(projection, rec_idx, v);
 	}
 
+	OpBase_RemoveVolatileRecords(opBase); // No exceptions encountered, Records are not dangling.
 	OpBase_DeleteRecord(r);
 	return projection;
 }

--- a/src/execution_plan/ops/op_project.c
+++ b/src/execution_plan/ops/op_project.c
@@ -52,9 +52,6 @@ static Record ProjectConsume(OpBase *opBase) {
 	}
 
 	Record projection = OpBase_CreateRecord(opBase);
-	// Track the inherited Record and the newly-allocated Record so that they may be freed if execution fails.
-	OpBase_AddVolatileRecord(opBase, r);
-	OpBase_AddVolatileRecord(opBase, projection);
 
 	for(uint i = 0; i < op->exp_count; i++) {
 		AR_ExpNode *exp = op->exps[i];
@@ -69,7 +66,6 @@ static Record ProjectConsume(OpBase *opBase) {
 		Record_Add(projection, rec_idx, v);
 	}
 
-	OpBase_RemoveVolatileRecords(opBase); // No exceptions encountered, Records are not dangling.
 	OpBase_DeleteRecord(r);
 	return projection;
 }

--- a/src/execution_plan/ops/op_project.c
+++ b/src/execution_plan/ops/op_project.c
@@ -20,6 +20,8 @@ OpBase *NewProjectOp(const ExecutionPlan *plan, AR_ExpNode **exps) {
 	op->singleResponse = false;
 	op->exp_count = array_len(exps);
 	op->record_offsets = array_new(uint, op->exp_count);
+	op->r = NULL;
+	op->projection = NULL;
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_PROJECT, "Project", NULL, ProjectConsume,
@@ -37,25 +39,24 @@ OpBase *NewProjectOp(const ExecutionPlan *plan, AR_ExpNode **exps) {
 
 static Record ProjectConsume(OpBase *opBase) {
 	OpProject *op = (OpProject *)opBase;
-	Record r = NULL;
 
 	if(op->op.childCount) {
 		OpBase *child = op->op.children[0];
-		r = OpBase_Consume(child);
-		if(!r) return NULL;
+		op->r = OpBase_Consume(child);
+		if(!op->r) return NULL;
 	} else {
 		// QUERY: RETURN 1+2
 		// Return a single record followed by NULL on the second call.
 		if(op->singleResponse) return NULL;
 		op->singleResponse = true;
-		r = OpBase_CreateRecord(opBase);
+		op->r = OpBase_CreateRecord(opBase);
 	}
 
-	Record projection = OpBase_CreateRecord(opBase);
+	op->projection = OpBase_CreateRecord(opBase);
 
 	for(uint i = 0; i < op->exp_count; i++) {
 		AR_ExpNode *exp = op->exps[i];
-		SIValue v = AR_EXP_Evaluate(exp, r);
+		SIValue v = AR_EXP_Evaluate(exp, op->r);
 		int rec_idx = op->record_offsets[i];
 		/* Persisting a value is only necessary here if 'v' refers to a scalar held in Record 'r'.
 		 * Graph entities don't need to be persisted here as Record_Add will copy them internally.
@@ -63,10 +64,15 @@ static Record ProjectConsume(OpBase *opBase) {
 		 * MATCH (a) WITH toUpper(a.name) AS e RETURN e
 		 * TODO This is a rare case; the logic of when to persist can be improved.  */
 		if(!(v.type & SI_GRAPHENTITY)) SIValue_Persist(&v);
-		Record_Add(projection, rec_idx, v);
+		Record_Add(op->projection, rec_idx, v);
 	}
 
-	OpBase_DeleteRecord(r);
+	OpBase_DeleteRecord(op->r);
+	op->r = NULL;
+
+	// Emit the projected Record once.
+	Record projection = op->projection;
+	op->projection = NULL;
 	return projection;
 }
 
@@ -82,6 +88,16 @@ static void ProjectFree(OpBase *ctx) {
 	if(op->record_offsets) {
 		array_free(op->record_offsets);
 		op->record_offsets = NULL;
+	}
+
+	if(op->r) {
+		OpBase_DeleteRecord(op->r);
+		op->r = NULL;
+	}
+
+	if(op->projection) {
+		OpBase_DeleteRecord(op->projection);
+		op->projection = NULL;
 	}
 }
 

--- a/src/execution_plan/ops/op_project.h
+++ b/src/execution_plan/ops/op_project.h
@@ -12,6 +12,8 @@
 
 typedef struct {
 	OpBase op;
+	Record r;                       // Input Record being read from (stored to free if we encounter an error).
+	Record projection;              // Record projected by this operation (stored to free if we encounter an error).
 	AR_ExpNode **exps;              // Projected expressions (including order exps).
 	uint *record_offsets;           // Record IDs corresponding to each projection (including order exps).
 	bool singleResponse;            // When no child operations, return NULL after a first response.

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -178,8 +178,6 @@ static Record UpdateConsume(OpBase *opBase) {
 	while((r = OpBase_Consume(child))) {
 		/* Evaluate each update expression and store result
 		 * for later execution. */
-		// Track the inherited Record and the newly-allocated Record so that they may be freed if execution fails.
-		OpBase_AddVolatileRecord(opBase, r);
 		EntityUpdateEvalCtx *update_expression = op->update_expressions;
 		for(uint i = 0; i < op->update_expressions_count; i++, update_expression++) {
 			SIValue new_value = SI_CloneValue(AR_EXP_Evaluate(update_expression->exp, r));
@@ -198,7 +196,6 @@ static Record UpdateConsume(OpBase *opBase) {
 			// Record not going to be used, discard.
 			OpBase_DeleteRecord(r);
 		}
-		OpBase_RemoveVolatileRecords(opBase); // No exceptions encountered, Records are not dangling.
 	}
 
 	/* Done reading, we're not going to call consume any longer


### PR DESCRIPTION
This logic used to be here; it must have been accidentally deleted at some point.

Ensures that we can free all memory allocated for a Record in the event of a run-time error.