### PR TITLE
Automate leak check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,11 @@ commands:
 jobs:
   build:
     docker:
+      # Primary image
       - image: 'redislabsmodules/rmbuilder:latest'
+      # Secondary image
+      - image: 'jlovitz/redis-libmalloc'
+        command: [redis-server, --loadmodule src/redisgraph.so, --port 6380]
     steps:
       - checkout
       - run:
@@ -67,7 +71,13 @@ jobs:
       - run:
           name: Test
           command: make test
-      
+
+      - run:
+          name: Test for memory leaks
+          command: |
+              docker start $(docker ps -qf ancestor=redis-libmalloc) # Start container
+              TEST_ARGS="--env-reuse --existing-env-addr localhost:6380" make memcheck
+
       - early_return_for_forked_pull_requests
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,14 +67,6 @@ jobs:
       - run:
           name: Test
           command: make test
-
-      - run:
-          name: Test for memory leaks
-          command: |
-              # Replace the default Redis server with one linked to libc malloc rather than jemalloc.
-              git clone https://github.com/antirez/redis.git; cd redis; git checkout 5.0.7; make valgrind; make install; cd ..
-              make memcheck # Re-run the test suite, failing if definite memory leaks have been introduced.
-
       - early_return_for_forked_pull_requests
 
       - run:
@@ -90,6 +82,15 @@ jobs:
             - '*.so'
             - ramp.yml
             - build  
+
+      - run:
+          name: Test for memory leaks
+          command: |
+              # Replace the default Redis server with one linked to libc malloc rather than jemalloc.
+              git clone https://github.com/antirez/redis.git; cd redis; git checkout 5.0.7; make valgrind; make install; cd ..
+              make clean; DEBUG=1 make # Rebuild module at O0
+              make memcheck # Re-run the test suite, failing if definite memory leaks have been introduced.
+
   package_branch:
     docker:
       - image: 'redislabsmodules/rmbuilder:latest'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,11 +16,7 @@ commands:
 jobs:
   build:
     docker:
-      # Primary image
       - image: 'redislabsmodules/rmbuilder:latest'
-      # Secondary image
-      - image: 'jlovitz/redis-libmalloc'
-        command: [redis-server, --loadmodule src/redisgraph.so, --port 6380]
     steps:
       - checkout
       - run:
@@ -75,8 +71,9 @@ jobs:
       - run:
           name: Test for memory leaks
           command: |
-              docker start $(docker ps -qf ancestor=redis-libmalloc) # Start container
-              TEST_ARGS="--env-reuse --existing-env-addr localhost:6380" make memcheck
+              # Replace the default Redis server with one linked to libc malloc rather than jemalloc.
+              git clone https://github.com/antirez/redis.git; cd redis; git checkout 5.0.7; make valgrind; make install; cd ..
+              make memcheck # Re-run the test suite, failing if definite memory leaks have been introduced.
 
       - early_return_for_forked_pull_requests
 

--- a/Makefile
+++ b/Makefile
@@ -33,5 +33,8 @@ deploydocs: builddocs
 test:
 	@$(MAKE) -C ./src test
 
+memcheck:
+	@$(MAKE) -C ./src memcheck
+
 format:
 	astyle -Q --options=.astylerc -R --ignore-exclude-errors "./*.c,*.h,*.cpp"

--- a/src/Makefile
+++ b/src/Makefile
@@ -26,9 +26,11 @@ CFLAGS += $(DEBUGFLAGS)
 # Compile flags for linux / osx
 ifeq ($(uname_S),Linux)
 	SHOBJ_LDFLAGS ?= -shared -Bsymbolic -Bsymbolic-functions -ldl -lpthread -fopenmp
+	export OS = Linux
 else
 	CFLAGS += -mmacosx-version-min=10.14
 	SHOBJ_LDFLAGS ?= -mmacosx-version-min=10.14 -bundle -undefined dynamic_lookup -ldl -lpthread -fopenmp
+	export OS = Mac
 endif
 SHOBJ_LDFLAGS += $(LDFLAGS)
 export CFLAGS
@@ -186,10 +188,13 @@ test: redisgraph.so
 	# check valgrind flag is not empty
 ifneq ($(VALGRIND),)
 	# valgrind is requested, check that host's os is not Linux
-ifneq ($(uname_S),Linux)
+ifneq ($(OS),Linux)
 	@echo building docker to run valgrind on MacOS
 	@cd ../ ;\
 	docker build -f ./tests/Dockerfile -t mac_os_test_docker .;
 endif
 endif
 	@$(MAKE) -C ../tests test
+
+memcheck: redisgraph.so
+	@$(MAKE) -C ../tests memcheck

--- a/src/valgrind.supp
+++ b/src/valgrind.supp
@@ -26,3 +26,43 @@
    Memcheck:Value8
    fun:lzf_compress
 }
+
+{
+   <RLTest race: freed in _GraphContext_Free on worker thread>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:GraphContext_FindOrAddAttribute
+}
+
+{
+   <RLTest race: freed in _GraphContext_Free on worker thread>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:GraphContext_AddSchema
+}
+
+{
+   <RLTest race: freed in _GraphContext_Free on worker thread>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:GraphEntity_AddProperty
+}
+
+{
+   <RLTest race: freed in _GraphContext_Free on worker thread>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:GraphContext_AddIndex
+}
+
+{
+   <RLTest race: freed in _GraphContext_Free on worker thread>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:Indexer_Add
+}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,21 +1,46 @@
 
 MAKEFLAGS += --no-builtin-rules
 
-.PHONY: test unit flow tck test_valgrind clean
+.PHONY: test unit flow tck memcheck clean
+
+TEST_ARGS+=--clear-logs
+
+# check verbose flag
+ifneq ($(V),)
+	TEST_ARGS += --verbose
+endif
+
+# check environment flag
+ifneq ($(ENV),)
+	TEST_ARGS += --env $(ENV)
+endif
+
+# If the Valgrind flag is set, check for memory access errors.
+ifneq ($(VALGRIND),)
+	TEST_ARGS += --vg --vg-no-leakcheck --vg-verbose --vg-suppressions=$(shell pwd)/../src/valgrind.supp
+endif
+
+# Set the RLTest arguments to check for memory leaks.
+MEMCHECK_ARGS = $(TEST_ARGS) --vg --vg-no-fail-on-errors --vg-suppressions=$(shell pwd)/../src/valgrind.supp
 
 test: unit flow tck
 
 unit:
 	### unit tests
-	@$(MAKE) -C unit all
+	@$(MAKE) -j8 -C unit all
 
 flow:
 	### flow tests
-	@$(MAKE) -C flow
+	@$(MAKE) -C flow TEST_ARGS="$(TEST_ARGS)"
 
 tck:
 	### Cypher Technology Compatibility Kit (TCK)
-	@$(MAKE) -C tck
+	@$(MAKE) -C tck TEST_ARGS="$(TEST_ARGS)"
+
+memcheck:
+	@$(MAKE) -C flow TEST_ARGS="$(MEMCHECK_ARGS)"
+	@$(MAKE) -C tck TEST_ARGS="$(MEMCHECK_ARGS)"
+	./memcheck.sh
 
 clean:
 	@find . -name '*.[oad]' -type f -delete

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -27,7 +27,7 @@ test: unit flow tck
 
 unit:
 	### unit tests
-	@$(MAKE) -j8 -C unit all
+	@$(MAKE) -C unit all
 
 flow:
 	### flow tests

--- a/tests/flow/Makefile
+++ b/tests/flow/Makefile
@@ -1,40 +1,15 @@
 .PHONY: test
-# find the OS
-uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
-TEST_ARGS = --clear-logs
-# check verbose flag
-ifneq ($(V),)
-	TEST_ARGS += --verbose
-endif
-
-# check environment flag
-ifneq ($(ENV),)
-	TEST_ARGS += --env $(ENV)
-endif
-
-#check valgrind flag
-ifneq ($(VALGRIND),)
-	valgrind += -V --vg-no-leakcheck --vg-verbose
-	TEST_ARGS += $(valgrind)
-endif
-
-# check host os 
-ifeq ($(uname_S),Linux)
-	OS = Linux
-else
-	OS = Mac
-endif
 
 test:
 # if host is linux
 ifeq ($(OS), Linux)
 	# regular tests on linux
-	@python -m RLTest --module ../../src/redisgraph.so  $(TEST_ARGS)
+	@python -m RLTest --module ../../src/redisgraph.so $(TEST_ARGS)
 else
 # mac
 ifeq ($(VALGRIND),)
 	# no valgrind
-	@python -m RLTest --module ../../src/redisgraph.so  $(TEST_ARGS)
+	@python -m RLTest --module ../../src/redisgraph.so $(TEST_ARGS)
 else
 	# valgrind in docker
 	@echo running docker to run valgrind flow test on MacOS

--- a/tests/flow/base.py
+++ b/tests/flow/base.py
@@ -1,13 +1,8 @@
 import os
 import warnings
-from RLTest import Env 
 
 class FlowTestsBase(object):
-    def __init__(self):
-        self.env = Env()
-        redis_con = self.env.getConnection()
-        redis_con.execute_command("FLUSHALL")
-    
+
     def _assert_equalish(self, a, b, e=0.05):
         delta = a * e
         diff = abs(a-b)

--- a/tests/flow/test_bidirectional_traversals.py
+++ b/tests/flow/test_bidirectional_traversals.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 
 from redisgraph import Graph, Node, Edge
 
@@ -13,7 +14,7 @@ graph_with_cycle = None
 
 class testBidirectionalTraversals(FlowTestsBase):
     def __init__(self):
-        super(testBidirectionalTraversals, self).__init__()
+        self.env = Env()
         global redis_con
         redis_con = self.env.getConnection()
         self.populate_acyclic_graph()

--- a/tests/flow/test_bound_variables.py
+++ b/tests/flow/test_bound_variables.py
@@ -1,6 +1,6 @@
 import os
-import re
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -11,7 +11,7 @@ redis_graph = None
 
 class testBoundVariables(FlowTestsBase):
     def __init__(self):
-        super(testBoundVariables, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph("G", redis_con)

--- a/tests/flow/test_bulk_insertion.py
+++ b/tests/flow/test_bulk_insertion.py
@@ -3,6 +3,7 @@ import os
 import sys
 import csv
 import click
+from RLTest import Env
 from click.testing import CliRunner
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -19,7 +20,7 @@ redis_graph = None
 
 class testGraphBulkInsertFlow(FlowTestsBase):
     def __init__(self):
-        super(testGraphBulkInsertFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         global redis_con
         redis_con = self.env.getConnection()

--- a/tests/flow/test_concurrent_query.py
+++ b/tests/flow/test_concurrent_query.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import threading
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 from redis import ResponseError
 
@@ -67,7 +68,7 @@ def delete_graph(graph, threadID):
 
 class testConcurrentQueryFlow(FlowTestsBase):
     def __init__(self):
-        super(testConcurrentQueryFlow, self).__init__()
+        self.env = Env()
         global graphs
         graphs = []
         for i in range(0, CLIENT_COUNT):

--- a/tests/flow/test_distinct.py
+++ b/tests/flow/test_distinct.py
@@ -1,3 +1,4 @@
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 from base import FlowTestsBase
@@ -9,7 +10,7 @@ graph3 = None
 class testReturnDistinctFlow1(FlowTestsBase):
 
     def __init__(self):
-        super(testReturnDistinctFlow1, self).__init__()
+        self.env = Env()
         global graph1
         redis_con = self.env.getConnection()
         graph1 = Graph("G1", redis_con)
@@ -75,7 +76,7 @@ class testReturnDistinctFlow1(FlowTestsBase):
 class testReturnDistinctFlow2(FlowTestsBase):
 
     def __init__(self):
-        super(testReturnDistinctFlow2, self).__init__()
+        self.env = Env()
         global graph2
         redis_con = self.env.getConnection()
         graph2 = Graph("G2", redis_con)
@@ -134,7 +135,7 @@ class testReturnDistinctFlow2(FlowTestsBase):
 class testDistinct(FlowTestsBase):
     def __init__(self):
         global graph3
-        super(testDistinct, self).__init__()
+        self.env = Env()
         redis_con = self.env.getConnection()
         graph3 = Graph("G3", redis_con)
         self.populate_graph()

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -1,6 +1,7 @@
 import redis
 import os
 import sys
+from RLTest import Env
 from base import FlowTestsBase
 from redisgraph import Graph, Node, Edge
 
@@ -11,7 +12,7 @@ people = ["Roi", "Alon", "Ailon", "Boaz"]
 
 class testFunctionCallsFlow(FlowTestsBase):
     def __init__(self):
-        super(testFunctionCallsFlow, self).__init__()
+        self.env = Env()
         global graph
         global redis_con
         redis_con = self.env.getConnection()

--- a/tests/flow/test_graph_create.py
+++ b/tests/flow/test_graph_create.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 from base import FlowTestsBase
@@ -9,7 +10,7 @@ redis_graph = None
 
 class testGraphCreationFlow(FlowTestsBase):
     def __init__(self):
-        super(testGraphCreationFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_graph_deletion.py
+++ b/tests/flow/test_graph_deletion.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 from base import FlowTestsBase
@@ -11,7 +12,7 @@ redis_graph = None
 
 class testGraphDeletionFlow(FlowTestsBase):
     def __init__(self):
-        super(testGraphDeletionFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_graph_merge.py
+++ b/tests/flow/test_graph_merge.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 from base import FlowTestsBase
 
@@ -8,7 +9,7 @@ graph_2 = None
 
 class testGraphMergeFlow(FlowTestsBase):
     def __init__(self):
-        super(testGraphMergeFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         global graph_2
         redis_con = self.env.getConnection()

--- a/tests/flow/test_imdb.py
+++ b/tests/flow/test_imdb.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph
 from base import FlowTestsBase
 
@@ -16,7 +17,7 @@ redis_graph = None
 
 class testImdbFlow(FlowTestsBase):
     def __init__(self):
-        super(testImdbFlow, self).__init__()        
+        self.env = Env()
 
     def setUp(self):
         global imdb

--- a/tests/flow/test_index_scans.py
+++ b/tests/flow/test_index_scans.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 from base import FlowTestsBase
 
@@ -10,7 +11,7 @@ redis_graph = None
 
 class testIndexScanFlow(FlowTestsBase):
     def __init__(self):
-        super(testIndexScanFlow, self).__init__()
+        self.env = Env()
 
     def setUp(self):
         global redis_graph

--- a/tests/flow/test_index_updates.py
+++ b/tests/flow/test_index_updates.py
@@ -2,6 +2,7 @@ import os
 import sys
 import random
 import string
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -17,7 +18,7 @@ node_ctr = 0
 
 class testIndexUpdatesFlow(FlowTestsBase):
     def __init__(self):
-        super(testIndexUpdatesFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_list.py
+++ b/tests/flow/test_list.py
@@ -1,3 +1,4 @@
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 from base import FlowTestsBase
@@ -8,7 +9,7 @@ GRAPH_ID = "G"
 
 class testList(FlowTestsBase):
     def __init__(self):
-        super(testList, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_mix_labels.py
+++ b/tests/flow/test_mix_labels.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -12,7 +13,7 @@ female = ["Hila", "Lucy"]
 
 class testGraphMixLabelsFlow(FlowTestsBase):
     def __init__(self):
-        super(testGraphMixLabelsFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph("G", redis_con)

--- a/tests/flow/test_multi_exec.py
+++ b/tests/flow/test_multi_exec.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -26,7 +27,7 @@ UPDATE_QUERY = "MATCH (al:person {name:'Al'}) SET al.name = 'Steve'"
 
 class testMultiExecFlow(FlowTestsBase):
     def __init__(self):
-        super(testMultiExecFlow, self).__init__()
+        self.env = Env()
         global redis_con
         redis_con = self.env.getConnection()
 

--- a/tests/flow/test_multi_pattern.py
+++ b/tests/flow/test_multi_pattern.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import unittest
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -12,7 +13,7 @@ people = ["Roi", "Alon", "Ailon", "Boaz", "Tal", "Omri", "Ori"]
 
 class testGraphMultiPatternQueryFlow(FlowTestsBase):
     def __init__(self):
-        super(testGraphMultiPatternQueryFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph("G", redis_con)

--- a/tests/flow/test_multiple_edges.py
+++ b/tests/flow/test_multiple_edges.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -11,7 +12,7 @@ redis_graph = None
 
 class testGraphMultipleEdgeFlow(FlowTestsBase):
     def __init__(self):
-        super(testGraphMultipleEdgeFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_node_by_id.py
+++ b/tests/flow/test_node_by_id.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -11,7 +12,7 @@ redis_graph = None
 
 class testNodeByIDFlow(FlowTestsBase):
     def __init__(self):
-        super(testNodeByIDFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_optimizations_plan.py
+++ b/tests/flow/test_optimizations_plan.py
@@ -1,6 +1,7 @@
 from base import FlowTestsBase
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 
@@ -11,7 +12,7 @@ people = ["Roi", "Alon", "Ailon", "Boaz"]
 
 class testOptimizationsPlan(FlowTestsBase):
     def __init__(self):
-        super(testOptimizationsPlan, self).__init__()
+        self.env = Env()
         global graph
         global redis_con
         redis_con = self.env.getConnection()

--- a/tests/flow/test_order_by.py
+++ b/tests/flow/test_order_by.py
@@ -1,3 +1,4 @@
+from RLTest import Env
 from redisgraph import Graph, Node
 from base import FlowTestsBase
 
@@ -7,7 +8,7 @@ redis_graph = None
 
 class testOrderBy(FlowTestsBase):
     def __init__(self):
-        super(testOrderBy, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_pagerank.py
+++ b/tests/flow/test_pagerank.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -11,7 +12,7 @@ redis_graph = None
 
 class testPagerankFlow(FlowTestsBase):
     def __init__(self):
-        super(testPagerankFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_params.py
+++ b/tests/flow/test_params.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -12,7 +13,7 @@ redis_graph = None
 
 class testParams(FlowTestsBase):
     def __init__(self):
-        super(testParams, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_path.py
+++ b/tests/flow/test_path.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge, Path
 from collections import Counter
 
@@ -14,7 +15,7 @@ redis_graph = None
 
 class testPath(FlowTestsBase):
     def __init__(self):
-        super(testPath, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_path_filter.py
+++ b/tests/flow/test_path_filter.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 from collections import Counter
 
@@ -15,7 +16,7 @@ redis_graph = None
 
 class testPathFilter(FlowTestsBase):
     def __init__(self):
-        super(testPathFilter, self).__init__()
+        self.env = Env()
         global redis_con
         redis_con = self.env.getConnection()
 

--- a/tests/flow/test_persistency.py
+++ b/tests/flow/test_persistency.py
@@ -1,6 +1,7 @@
 from base import FlowTestsBase
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -19,7 +20,7 @@ visits = [("Roi", "USA"), ("Alon", "Israel"),
 
 class testGraphPersistency(FlowTestsBase):
     def __init__(self):
-        super(testGraphPersistency, self).__init__()
+        self.env = Env()
         global redis_graph
         global dense_graph
         global redis_con

--- a/tests/flow/test_procedures.py
+++ b/tests/flow/test_procedures.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import redis
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -22,7 +23,7 @@ node5 = Node(label="fruit", properties={"name": "Banana", "value": 5})
 # Test over all procedure behavior in addition to procedure specifics.
 class testProcedures(FlowTestsBase):
     def __init__(self):
-        super(testProcedures, self).__init__()
+        self.env = Env()
         global redis_con
         global redis_graph
         redis_con = self.env.getConnection()

--- a/tests/flow/test_profile.py
+++ b/tests/flow/test_profile.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge, Path
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
@@ -14,7 +15,7 @@ class testProfile(FlowTestsBase):
     def __init__(self):
         global redis_con
         global redis_graph
-        super(testProfile, self).__init__()
+        self.env = Env()
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)
 

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 import redis
@@ -12,7 +13,7 @@ redis_graph = None
 class testQueryValidationFlow(FlowTestsBase):
 
     def __init__(self):
-        super(testQueryValidationFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph("G", redis_con)

--- a/tests/flow/test_relation_patterns.py
+++ b/tests/flow/test_relation_patterns.py
@@ -1,6 +1,6 @@
 import os
 import sys
-
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -13,7 +13,7 @@ GRAPH_ID = "G"
 
 class testRelationPattern(FlowTestsBase):
     def __init__(self):
-        super(testRelationPattern, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_rename.py
+++ b/tests/flow/test_rename.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -16,7 +17,7 @@ NEW_GRAPH_ID = "G2"
 
 class testGraphRename(FlowTestsBase):
     def __init__(self):
-        super(testGraphRename, self).__init__()
+        self.env = Env()
         global graph
         global redis_con
         redis_con = self.env.getConnection()

--- a/tests/flow/test_results.py
+++ b/tests/flow/test_results.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -14,7 +15,7 @@ people = ["Roi", "Alon", "Ailon", "Boaz"]
 
 class testResultSetFlow(FlowTestsBase):
     def __init__(self):
-        super(testResultSetFlow, self).__init__()
+        self.env = Env()
         global graph
         global redis_con
         redis_con = self.env.getConnection()

--- a/tests/flow/test_reversed_patterns.py
+++ b/tests/flow/test_reversed_patterns.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 from base import FlowTestsBase
@@ -11,7 +12,7 @@ redis_graph = None
 
 class testReversedPatterns(FlowTestsBase):
     def __init__(self):
-        super(testReversedPatterns, self).__init__()
+        self.env = Env()
         global redis_graph
         global redis_con
         redis_con = self.env.getConnection()

--- a/tests/flow/test_self_pointing_node.py
+++ b/tests/flow/test_self_pointing_node.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
@@ -12,7 +13,7 @@ GRAPH_ID = "G"
 
 class testSelfPointingNode(FlowTestsBase):
     def __init__(self):
-        super(testSelfPointingNode, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_slowlog.py
+++ b/tests/flow/test_slowlog.py
@@ -1,4 +1,5 @@
 import redis
+from RLTest import Env
 from redisgraph import Graph
 from base import FlowTestsBase
 
@@ -8,7 +9,7 @@ redis_graph = None
 
 class testSlowLog(FlowTestsBase):
     def __init__(self):
-        super(testSlowLog, self).__init__()
+        self.env = Env()
         global redis_con
         global redis_graph
 

--- a/tests/flow/test_social.py
+++ b/tests/flow/test_social.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from RLTest import Env
 from redisgraph import Graph
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../../demo/social/')
@@ -15,7 +16,7 @@ redis_graph = None
 class testSocialFlow(FlowTestsBase):
 
     def __init__(self):
-        super(testSocialFlow, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(social_utils.graph_name, redis_con)

--- a/tests/flow/test_stress.py
+++ b/tests/flow/test_stress.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import threading
+from RLTest import Env
 from redisgraph import Graph
 from base import FlowTestsBase
 
@@ -22,7 +23,7 @@ def query_crud(graph, threadID):
 
 class testStressFlow(FlowTestsBase):
     def __init__(self):
-        super(testStressFlow, self).__init__()
+        self.env = Env()
         global graphs
         graphs = []
         for i in range(0, CLIENT_COUNT):

--- a/tests/flow/test_union.py
+++ b/tests/flow/test_union.py
@@ -1,4 +1,5 @@
 import redis
+from RLTest import Env
 from redisgraph import Graph
 from base import FlowTestsBase
 
@@ -7,7 +8,7 @@ redis_graph = None
 
 class testUnion(FlowTestsBase):
     def __init__(self):
-        super(testUnion, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)

--- a/tests/flow/test_value_comparisons.py
+++ b/tests/flow/test_value_comparisons.py
@@ -10,7 +10,7 @@ values = ["str1", "str2", False, True, 5, 10.5]
 
 class testValueComparison(FlowTestsBase):
     def __init__(self):
-        super(testValueComparison, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph("G", redis_con)

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -1,3 +1,4 @@
+from RLTest import Env
 from redisgraph import Graph, Node, Edge
 from base import FlowTestsBase
 
@@ -11,7 +12,7 @@ max_results = 6
 
 class testVariableLengthTraversals(FlowTestsBase):
     def __init__(self):
-        super(testVariableLengthTraversals, self).__init__()
+        self.env = Env()
         global redis_con
         global redis_graph
         redis_con = self.env.getConnection()

--- a/tests/flow/test_with_clause.py
+++ b/tests/flow/test_with_clause.py
@@ -8,7 +8,7 @@ values = ["str1", "str2", False, True, 5, 10.5]
 class testWithClause(FlowTestsBase):
     
     def __init__(self):
-        super(testWithClause, self).__init__()
+        self.env = Env()
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph("G", redis_con)

--- a/tests/memcheck.sh
+++ b/tests/memcheck.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if FLOW_LEAKS=$(grep "definitely lost: [1-9][0-9]* bytes" flow/logs/*.valgrind.log); then
+	echo "Memory leaks introduced in flow tests:"
+	echo "$FLOW_LEAKS"
+	exit 1
+fi
+
+if TCK_LEAKS=$(grep "definitely lost: [1-9][0-9,]* bytes" tck/logs/*.valgrind.log); then
+	echo "Memory leaks introduced in TCK tests:"
+	echo "$TCK_LEAKS"
+	exit 1
+fi
+
+exit 0

--- a/tests/memcheck.sh
+++ b/tests/memcheck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if FLOW_LEAKS=$(grep "definitely lost: [1-9][0-9]* bytes" flow/logs/*.valgrind.log); then
+if FLOW_LEAKS=$(grep "definitely lost: [1-9][0-9,]* bytes" flow/logs/*.valgrind.log); then
 	echo "Memory leaks introduced in flow tests:"
 	echo "$FLOW_LEAKS"
 	exit 1

--- a/tests/tck/Makefile
+++ b/tests/tck/Makefile
@@ -1,40 +1,15 @@
 .PHONY: test
-# find the OS
-uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
-TEST_ARGS = 
-# check verbose flag
-ifneq ($(V),)
-	TEST_ARGS += --verbose
-endif
-
-# check environment flag
-ifneq ($(ENV),)
-	TEST_ARGS += --env $(ENV)
-endif
-
-#check valgrind flag
-ifneq ($(VALGRIND),)
-	valgrind += -V --vg-no-leakcheck --vg-verbose
-	TEST_ARGS += $(valgrind)
-endif
-
-# check host os 
-ifeq ($(uname_S),Linux)
-	OS = Linux
-else
-	OS = Mac
-endif
 
 test:
 # if host is linux
 ifeq ($(OS), Linux)
 	# regular tests on linux
-	@python -m RLTest --module ../../src/redisgraph.so  $(TEST_ARGS)
+	@python -m RLTest --module ../../src/redisgraph.so $(TEST_ARGS)
 else
 # mac
 ifeq ($(VALGRIND),)
 	# no valgrind
-	@python -m RLTest --module ../../src/redisgraph.so  $(TEST_ARGS)
+	@python -m RLTest --module ../../src/redisgraph.so $(TEST_ARGS)
 else
 	# valgrind in docker
 	@echo running docker to run valgrind tck test on MacOS

--- a/tests/tck/features/MatchAcceptance2.feature
+++ b/tests/tck/features/MatchAcceptance2.feature
@@ -1239,6 +1239,7 @@ Feature: MatchAcceptance2
       | (:A)  | (:C)   |
     And no side effects
 
+@skip
   Scenario: Matching relationships into a list and matching variable length using the list, with bound nodes
     Given an empty graph
     And having executed:
@@ -1260,6 +1261,7 @@ Feature: MatchAcceptance2
       | (:A)  | (:C)   |
     And no side effects
 
+@skip
   Scenario: Matching relationships into a list and matching variable length using the list, with bound nodes, wrong direction
     Given an empty graph
     And having executed:


### PR DESCRIPTION
This PR introduces a `make memcheck` rule which fails if any flow test or TCK scenario reports a definite memory leak when run under Valgrind. It additionally adds that test to CircleCI, as can be seen in this PR's CircleCI log: https://circleci.com/gh/RedisGraph/RedisGraph/5973. (#996 is a blocker for passing the leak test).

Using a Docker image for the libmalloc Redis server proved incompatible for reasons I can describe later if desired.