### PR TITLE
Emit error on the attempted creation of a composite index

### DIFF
--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -18,6 +18,15 @@ static void _index_operation(RedisModuleCtx *ctx, GraphContext *gc,
 	Index *idx = NULL;
 
 	if(cypher_astnode_type(index_op) == CYPHER_AST_CREATE_NODE_PROPS_INDEX) {
+		if(cypher_ast_create_node_props_index_nprops(index_op) > 1) {
+			// Reply with error if the query specifies multiple properties to index.
+			// TODO Remove this limitation when composite indexes are added.
+			char *error;
+			asprintf(&error, "RedisGraph does not currently support composite indexes.");
+			QueryCtx_SetError(error);
+			return;
+		}
+
 		// Retrieve strings from AST node
 		const char *label = cypher_ast_label_get_name(cypher_ast_create_node_props_index_get_label(
 														  index_op));

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -182,3 +182,14 @@ class testQueryValidationFlow(FlowTestsBase):
             # Expecting an error.
             assert("Encountered unhandled type" in e.message)
             pass
+
+    # Verify that an error is emitted when a query tries to create a multi-field index.
+    def test17_composite_index_construction(self):
+        try:
+            query = """CREATE INDEX ON :A(prop1,prop2)"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError as e:
+            # Expecting an error.
+            assert("composite indexes" in e.message)
+            pass


### PR DESCRIPTION
Given a query like:
`CREATE INDEX ON :Label(prop1,prop2)`

We would previously create an index on `prop1` and disregard `prop2`.

This construction is intended to create a composite index, which we do not currently have support for. This PR adds an error message to convey this when receiving such a query.