### PR TITLE
Use all cores for compiling unit test files

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -35,7 +35,7 @@ test: unit flow tck
 
 unit:
 	### unit tests
-	@$(MAKE) --jobs=$(JOBS) -C unit all
+	@$(MAKE) --jobs=$(JOBS) --max-load=$(JOBS) -C unit all
 
 flow:
 	### flow tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -3,6 +3,14 @@ MAKEFLAGS += --no-builtin-rules
 
 .PHONY: test unit flow tck memcheck clean
 
+# Set number of threads.
+JOBS =
+ifeq ($(OS),Linux)
+	JOBS = $(shell grep -c ^processor /proc/cpuinfo)
+else
+	JOBS = $(shell sysctl -n hw.logicalcpu_max)
+endif
+
 TEST_ARGS+=--clear-logs
 
 # check verbose flag
@@ -27,7 +35,7 @@ test: unit flow tck
 
 unit:
 	### unit tests
-	@$(MAKE) -C unit all
+	@$(MAKE) --jobs=$(JOBS) -C unit all
 
 flow:
 	### flow tests


### PR DESCRIPTION
Save a bit of time in testing (same logic we use for GraphBLAS compilation).