### PR TITLE
single source shortest path, Bellman-Ford

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -39,6 +39,8 @@ export CFLAGS
 SOURCEDIR=$(shell pwd -P)
 CC_SOURCES = $(wildcard $(SOURCEDIR)/*.c)
 CC_SOURCES += $(wildcard $(SOURCEDIR)/algorithms/*.c)
+CC_SOURCES += $(wildcard $(SOURCEDIR)/algorithms/LAGraph/*.c)
+CC_SOURCES += $(wildcard $(SOURCEDIR)/algorithms/LAGraph/Utility/*.c)
 CC_SOURCES += $(wildcard $(SOURCEDIR)/arithmetic/*.c)
 CC_SOURCES += $(wildcard $(SOURCEDIR)/arithmetic/path_funcs/*.c)
 CC_SOURCES += $(wildcard $(SOURCEDIR)/arithmetic/list_funcs/*.c)

--- a/src/algorithms/LAGraph/LAGraph.h
+++ b/src/algorithms/LAGraph/LAGraph.h
@@ -1,0 +1,49 @@
+//------------------------------------------------------------------------------
+// LAGraph.h:  include file for user applications that use LAGraph
+//------------------------------------------------------------------------------
+
+/*
+    LAGraph:  graph algorithms based on GraphBLAS
+    Copyright 2019 LAGraph Contributors.
+    (see Contributors.txt for a full list of Contributors; see
+    ContributionInstructions.txt for information on how you can Contribute to
+    this project).
+    All Rights Reserved.
+    NO WARRANTY. THIS MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. THE LAGRAPH
+    CONTRIBUTORS MAKE NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+    AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR
+    PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF
+    THE MATERIAL. THE CONTRIBUTORS DO NOT MAKE ANY WARRANTY OF ANY KIND WITH
+    RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+    Released under a BSD license, please see the LICENSE file distributed with
+    this Software or contact permission@sei.cmu.edu for full terms.
+    Created, in part, with funding and support from the United States
+    Government.  (see Acknowledgments.txt file).
+    This program includes and/or can make use of certain third party source
+    code, object code, documentation and other files ("Third Party Software").
+    See LICENSE file for more details.
+*/
+
+#pragma once
+
+#include "../../../deps/GraphBLAS/Include/GraphBLAS.h"
+
+GrB_Info LAGraph_Vector_isequal    // return GrB_SUCCESS if successful
+(
+    bool *result,           // true if A == B, false if A != B or error
+    GrB_Vector A,
+    GrB_Vector B,
+    GrB_BinaryOp userop     // for A and B with arbitrary user-defined types.
+                            // Ignored if A and B are of built-in types or
+                            // LAGraph_ComplexFP64.
+) ;
+
+GrB_Info LAGraph_Vector_isall      // return GrB_SUCCESS if successful
+(
+    bool *result,           // true if A == B, false if A != B or error
+    GrB_Vector A,
+    GrB_Vector B,
+    GrB_BinaryOp op         // GrB_EQ_<type>, for the type of A and B,
+                            // to check for equality.  Or use any desired
+                            // operator.  The operator should return GrB_BOOL.
+) ;

--- a/src/algorithms/LAGraph/Utility/LAGraph_Vector_isall.c
+++ b/src/algorithms/LAGraph/Utility/LAGraph_Vector_isall.c
@@ -1,0 +1,110 @@
+//------------------------------------------------------------------------------
+// LAGraph_Vector_isall: check two vectors
+//------------------------------------------------------------------------------
+
+/*
+    LAGraph:  graph algorithms based on GraphBLAS
+
+    Copyright 2019 LAGraph Contributors.
+
+    (see Contributors.txt for a full list of Contributors; see
+    ContributionInstructions.txt for information on how you can Contribute to
+    this project).
+
+    All Rights Reserved.
+
+    NO WARRANTY. THIS MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. THE LAGRAPH
+    CONTRIBUTORS MAKE NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+    AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR
+    PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF
+    THE MATERIAL. THE CONTRIBUTORS DO NOT MAKE ANY WARRANTY OF ANY KIND WITH
+    RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+
+    Released under a BSD license, please see the LICENSE file distributed with
+    this Software or contact permission@sei.cmu.edu for full terms.
+
+    Created, in part, with funding and support from the United States
+    Government.  (see Acknowledgments.txt file).
+
+    This program includes and/or can make use of certain third party source
+    code, object code, documentation and other files ("Third Party Software").
+    See LICENSE file for more details.
+
+*/
+
+//------------------------------------------------------------------------------
+
+// LAGraph_Vector_isall: check two vectors, contributed by Tim Davis, Texas A&M
+
+// Applies a binary operator to two vectors A and B, and returns result = true
+// if the pattern of A and B are identical, and if the result of C = A op B is
+// true for all entries in C.
+
+// See also LAGraph_isall for matrices.
+
+#include "../LAGraph.h"
+
+#define FREE_ALL    \
+    GrB_free (&C) ; \
+
+GrB_Info LAGraph_Vector_isall      // return GrB_SUCCESS if successful
+(
+	bool *result,           // true if A == B, false if A != B or error
+	GrB_Vector A,
+	GrB_Vector B,
+	GrB_BinaryOp op         // GrB_EQ_<type>, for the type of A and B,
+	// to check for equality.  Or use any desired
+	// operator.  The operator should return GrB_BOOL.
+) {
+
+	GrB_Info info ;
+	GrB_Vector C = NULL ;
+	GrB_Monoid monoid = NULL ;
+	GrB_Index nrows1, nrows2, nvals, nvals1, nvals2 ;
+
+	// check inputs
+	if(result == NULL) {
+		// error: required parameter, result, is NULL
+		return (GrB_NULL_POINTER) ;
+	}
+	(*result) = false ;
+
+	// check the size of A and B
+	GrB_Vector_size(&nrows1, A) ;
+	GrB_Vector_size(&nrows2, B) ;
+	if(nrows1 != nrows2) {
+		// # of rows differ
+		// printf ("LAGraph_isall: rows differ\n") ;
+		return (GrB_SUCCESS) ;
+	}
+
+	// check the # entries in A and B
+	GrB_Vector_nvals(&nvals1, A) ;
+	GrB_Vector_nvals(&nvals2, B) ;
+	if(nvals1 != nvals2) {
+		// # of entries differ
+		// printf ("LAGraph_isall: nvals differ\n") ;
+		return (GrB_SUCCESS) ;
+	}
+
+	// C = A .* B, where the pattern of C is the intersection of A and B
+	GrB_Vector_new(&C, GrB_BOOL, nrows1) ;
+	GrB_eWiseMult(C, NULL, NULL, op, A, B, NULL) ;
+
+	// ensure C has the same number of entries as A and B
+	GrB_Vector_nvals(&nvals, C) ;
+	if(nvals != nvals1) {
+		// pattern of A and B are different
+		GrB_free(&C) ;
+		return (GrB_SUCCESS) ;
+	}
+
+	// result = and (C)
+	GrB_reduce(result, NULL, GxB_LAND_BOOL_MONOID, C, NULL) ;
+
+	// printf ("isall : %d\n", *result) ;
+
+	// free workspace and return result
+	GrB_free(&C) ;
+	return (GrB_SUCCESS) ;
+}

--- a/src/algorithms/LAGraph/Utility/LAGraph_Vector_isequal.c
+++ b/src/algorithms/LAGraph/Utility/LAGraph_Vector_isequal.c
@@ -1,0 +1,104 @@
+//------------------------------------------------------------------------------
+// LAGraph_Vector_isequal: check two vectors for exact equality
+//------------------------------------------------------------------------------
+
+/*
+    LAGraph:  graph algorithms based on GraphBLAS
+
+    Copyright 2019 LAGraph Contributors.
+
+    (see Contributors.txt for a full list of Contributors; see
+    ContributionInstructions.txt for information on how you can Contribute to
+    this project).
+
+    All Rights Reserved.
+
+    NO WARRANTY. THIS MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. THE LAGRAPH
+    CONTRIBUTORS MAKE NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+    AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR
+    PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF
+    THE MATERIAL. THE CONTRIBUTORS DO NOT MAKE ANY WARRANTY OF ANY KIND WITH
+    RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+
+    Released under a BSD license, please see the LICENSE file distributed with
+    this Software or contact permission@sei.cmu.edu for full terms.
+
+    Created, in part, with funding and support from the United States
+    Government.  (see Acknowledgments.txt file).
+
+    This program includes and/or can make use of certain third party source
+    code, object code, documentation and other files ("Third Party Software").
+    See LICENSE file for more details.
+
+*/
+
+//------------------------------------------------------------------------------
+
+// LAGraph_Vector_isequal, contributed by Tim Davis, Texas A&M
+
+// Checks if two vectors are identically equal (same size,
+// type, pattern, size, and values).  Checking for the same type requires the
+// GxB_Vector_type function, which is an extension in SuiteSparse:GraphBLAS.
+// For the standard API, there is no way to determine the type of a vector.
+
+// See also LAGraph_isequal.
+
+// TODO: add GrB_Vector_Type to the GraphBLAS spec.
+
+// For both methods, if the two vectors are GrB_FP32, GrB_FP64, or
+// LAGraph_ComplexFP64, and have NaNs, then these functions will return false,
+// since NaN == NaN is false.  To check for NaN equality (like
+// isequalwithequalnans in MATLAB), use LAGraph_isall with a user-defined
+// operator f(x,y) that returns true if x and y are both NaN.
+
+#include "../LAGraph.h"
+
+GrB_Info LAGraph_Vector_isequal    // return GrB_SUCCESS if successful
+(
+	bool *result,           // true if A == B, false if A != B or error
+	GrB_Vector A,
+	GrB_Vector B,
+	GrB_BinaryOp userop     // for A and B with arbitrary user-defined types.
+	// Ignored if A and B are of built-in types or
+	// LAGraph_ComplexFP64.
+) {
+
+	GrB_Info info ;
+	GrB_Type atype, btype ;
+	GrB_BinaryOp op ;
+
+	// check inputs
+	if(result == NULL) {
+		// error: required parameter, result, is NULL
+		return (GrB_NULL_POINTER) ;
+	}
+	(*result) = false ;
+
+	// check the type of A and B
+	GxB_Vector_type(&atype, A) ;
+	GxB_Vector_type(&btype, B) ;
+	if(atype != btype) {
+		// types differ
+		return (GrB_SUCCESS) ;
+	}
+
+	// select the comparator operator
+	if(atype == GrB_BOOL) op = GrB_EQ_BOOL   ;
+	else if(atype == GrB_INT8) op = GrB_EQ_INT8   ;
+	else if(atype == GrB_INT16) op = GrB_EQ_INT16  ;
+	else if(atype == GrB_INT32) op = GrB_EQ_INT32  ;
+	else if(atype == GrB_INT64) op = GrB_EQ_INT64  ;
+	else if(atype == GrB_UINT8) op = GrB_EQ_UINT8  ;
+	else if(atype == GrB_UINT16) op = GrB_EQ_UINT16 ;
+	else if(atype == GrB_UINT32) op = GrB_EQ_UINT32 ;
+	else if(atype == GrB_UINT64) op = GrB_EQ_UINT64 ;
+	else if(atype == GrB_FP32) op = GrB_EQ_FP32   ;
+	else if(atype == GrB_FP64) op = GrB_EQ_FP64   ;
+	else op = userop ;
+
+	// check the size, pattern, and values of A and B
+	LAGraph_Vector_isall(result, A, B, op) ;
+
+	// return result
+	return (GrB_SUCCESS) ;
+}

--- a/src/algorithms/LAGraph_BF_full.c
+++ b/src/algorithms/LAGraph_BF_full.c
@@ -1,0 +1,354 @@
+//------------------------------------------------------------------------------
+// LAGraph_BF_full.c: Bellman-Ford single-source shortest paths, returns tree
+//------------------------------------------------------------------------------
+
+/*
+    LAGraph:  graph algorithms based on GraphBLAS
+
+    Copyright 2019 LAGraph Contributors.
+
+    (see Contributors.txt for a full list of Contributors; see
+    ContributionInstructions.txt for information on how you can Contribute to
+    this project).
+
+    All Rights Reserved.
+
+    NO WARRANTY. THIS MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. THE LAGRAPH
+    CONTRIBUTORS MAKE NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+    AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR
+    PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF
+    THE MATERIAL. THE CONTRIBUTORS DO NOT MAKE ANY WARRANTY OF ANY KIND WITH
+    RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+
+    Released under a BSD license, please see the LICENSE file distributed with
+    this Software or contact permission@sei.cmu.edu for full terms.
+
+    Created, in part, with funding and support from the United States
+    Government.  (see Acknowledgments.txt file).
+
+    This program includes and/or can make use of certain third party source
+    code, object code, documentation and other files ("Third Party Software").
+    See LICENSE file for more details.
+
+*/
+
+//------------------------------------------------------------------------------
+
+// LAGraph_BF_full: Bellman-Ford single source shortest paths, returning both
+// the path lengths and the shortest-path tree.  contributed by Jinhao Chen and
+// Tim Davis, Texas A&M.
+
+// LAGraph_BF_full performs a Bellman-Ford to find out shortest path, parent
+// nodes along the path and the hops (number of edges) in the path from given
+// source vertex s in the range of [0, n) on graph given as matrix A with size
+// n*n. The sparse matrix A has entry A(i, j) if there is an edge from vertex i
+// to vertex j with weight w, then A(i, j) = w.
+
+// TODO: think about the return values
+
+// LAGraph_BF_full returns GrB_SUCCESS regardless of existence of negative-
+// weight cycle. However, the GrB_Vector d(k), pi(k) and h(k)  (i.e.,
+// *pd_output, *ppi_output and *ph_output respectively) will be NULL when
+// negative-weight cycle detected. Otherwise, the vector d has d(k) as the
+// shortest distance from s to k. pi(k) = p+1, where p is the parent node of
+// k-th node in the shortest path. In particular, pi(s) = 0. h(k) = hop(s, k),
+// the number of edges from s to k in the shortest path.
+
+//------------------------------------------------------------------------------
+
+#include "../../deps/GraphBLAS/Include/GraphBLAS.h"
+#include "../util/rmalloc.h"
+#include "LAGraph/LAGraph.h"
+
+#define FREE_ALL                       \
+{                                      \
+    GrB_free(&d);                      \
+    GrB_free(&dtmp);                   \
+    GrB_free(&dfrontier);              \
+    GrB_free(&Atmp);                   \
+    GrB_free(&BF_Tuple3);              \
+    GrB_free(&BF_lMIN_Tuple3);         \
+    GrB_free(&BF_PLUSrhs_Tuple3);      \
+    GrB_free(&BF_EQ_Tuple3);           \
+    GrB_free(&BF_lMIN_Tuple3_Monoid);  \
+    GrB_free(&BF_lMIN_PLUSrhs_Tuple3); \
+    rm_free (I);                       \
+    rm_free (J);                       \
+    rm_free (w);                       \
+    rm_free (W);                       \
+    rm_free (h);                       \
+    rm_free (pi);                      \
+}
+
+//------------------------------------------------------------------------------
+// data type for each entry of the adjacent matrix A and "distance" vector d;
+// <INFINITY,INFINITY,INFINITY> corresponds to nonexistence of a path, and
+// the value  <0, 0, NULL> corresponds to a path from a vertex to itself
+//------------------------------------------------------------------------------
+typedef struct {
+	double w;    // w  corresponds to a path weight.
+	GrB_Index h; // h  corresponds to a path size or number of hops.
+	GrB_Index pi;// pi corresponds to the penultimate vertex along a path.
+	// vertex indexed as 1, 2, 3, ... , V, and pi = 0 (as nil)
+	// for u=v, and pi = UINT64_MAX (as inf) for (u,v) not in E
+}
+BF_Tuple3_struct;
+
+//------------------------------------------------------------------------------
+// 2 binary functions, z=f(x,y), where Tuple3xTuple3 -> Tuple3
+//------------------------------------------------------------------------------
+void BF_lMIN
+(
+	void *z,
+	const void *x,
+	const void *y
+) {
+
+	BF_Tuple3_struct *_z = z;
+	const BF_Tuple3_struct *_x = x;
+	const BF_Tuple3_struct *_y = y;
+
+	if(_x->w < _y->w
+	   || (_x->w == _y->w && _x->h < _y->h)
+	   || (_x->w == _y->w && _x->h == _y->h && _x->pi < _y->pi)) {
+		if(_z != _x) {
+			*_z = *_x;
+		}
+	} else {
+		*_z = *_y;
+	}
+}
+
+void BF_PLUSrhs
+(
+	void *z,
+	const void *x,
+	const void *y
+) {
+
+	BF_Tuple3_struct *_z = z;
+	const BF_Tuple3_struct *_x = x;
+	const BF_Tuple3_struct *_y = y;
+
+	_z->w = _x->w + _y->w;
+	_z->h = _x->h + _y->h;
+	// TODO: enablr GxB_NO_MAX in GB_control.h
+	if(_x->pi != UINT64_MAX && _y->pi != 0) {
+		_z->pi = _y->pi;
+	} else {
+		_z->pi = _x->pi;
+	}
+}
+
+void BF_EQ
+(
+	void *z,
+	const void *x,
+	const void *y
+) {
+
+	bool *_z = z;
+	const BF_Tuple3_struct *_x = x;
+	const BF_Tuple3_struct *_y = y;
+
+	if(_x->w == _y->w && _x->h == _y->h && _x->pi == _y->pi) {
+		*_z = true;
+	} else {
+		*_z = false;
+	}
+}
+
+// Given a n-by-n adjacency matrix A and a source vertex s.
+// If there is no negative-weight cycle reachable from s, return the distances
+// of shortest paths from s and parents along the paths as vector d. Otherwise,
+// returns d=NULL if there is a negtive-weight cycle.
+// pd_output is pointer to a GrB_Vector, where the i-th entry is d(s,i), the
+//   sum of edges length in the shortest path
+// ppi_output is pointer to a GrB_Vector, where the i-th entry is pi(i), the
+//   parent of i-th vertex in the shortest path
+// ph_output is pointer to a GrB_Vector, where the i-th entry is h(s,i), the
+//   number of edges from s to i in the shortest path
+// A has zeros on diagonal and weights on corresponding entries of edges
+// s is given index for source vertex
+GrB_Info LAGraph_BF_full
+(
+	GrB_Vector *pd_output,      //the pointer to the vector of distance
+	GrB_Vector *ppi_output,     //the pointer to the vector of parent
+	GrB_Vector *ph_output,       //the pointer to the vector of hops
+	const GrB_Matrix A,         //matrix for the graph
+	const GrB_Index s           //given index of the source
+) {
+	// tmp vector to store distance vector after n (i.e., V) loops
+	GrB_Vector d = NULL, dtmp = NULL, dfrontier = NULL;
+	GrB_Matrix Atmp = NULL;
+	GrB_Type BF_Tuple3;
+
+	GrB_BinaryOp BF_lMIN_Tuple3;
+	GrB_BinaryOp BF_PLUSrhs_Tuple3;
+	GrB_BinaryOp BF_EQ_Tuple3;
+
+	GrB_Monoid BF_lMIN_Tuple3_Monoid;
+	GrB_Semiring BF_lMIN_PLUSrhs_Tuple3;
+
+	GrB_Index nrows, ncols, n, nz;  // n = # of row/col, nz = # of nnz in graph
+	GrB_Index *I = NULL, *J = NULL; // for col/row indices of entries from A
+	GrB_Index *h = NULL, *pi = NULL;
+	double *w = NULL;
+	BF_Tuple3_struct *W = NULL;
+
+	if(A == NULL || pd_output == NULL ||
+	   ppi_output == NULL || ph_output == NULL) {
+		// required argument is missing
+		// LAGRAPH_ERROR("required arguments are NULL", GrB_NULL_POINTER) ;
+		return GrB_NULL_POINTER;
+	}
+
+	*pd_output  = NULL;
+	*ppi_output = NULL;
+	*ph_output  = NULL;
+	GrB_Matrix_nrows(&nrows, A) ;
+	GrB_Matrix_ncols(&ncols, A) ;
+	GrB_Matrix_nvals(&nz, A);
+	if(nrows != ncols) {
+		// A must be square
+		// LAGRAPH_ERROR("A must be square", GrB_INVALID_VALUE) ;
+		return GrB_INVALID_VALUE;
+	}
+	n = nrows;
+
+	if(s >= n || s < 0) {
+		// LAGRAPH_ERROR("invalid value for source vertex s", GrB_INVALID_VALUE);
+		return GrB_INVALID_VALUE;
+	}
+	//--------------------------------------------------------------------------
+	// create all GrB_Type GrB_BinaryOp GrB_Monoid and GrB_Semiring
+	//--------------------------------------------------------------------------
+	// GrB_Type
+	GrB_Type_new(&BF_Tuple3, sizeof(BF_Tuple3_struct));
+
+	// GrB_BinaryOp
+	GrB_BinaryOp_new(&BF_EQ_Tuple3, &BF_EQ, GrB_BOOL, BF_Tuple3, BF_Tuple3);
+	GrB_BinaryOp_new(&BF_lMIN_Tuple3, &BF_lMIN, BF_Tuple3, BF_Tuple3, BF_Tuple3);
+	GrB_BinaryOp_new(&BF_PLUSrhs_Tuple3, &BF_PLUSrhs, BF_Tuple3, BF_Tuple3, BF_Tuple3);
+
+	// GrB_Monoid
+	BF_Tuple3_struct BF_identity = (BF_Tuple3_struct) {
+		.w = INFINITY,
+		.h = UINT64_MAX, .pi = UINT64_MAX
+	};
+	GrB_Monoid_new_UDT(&BF_lMIN_Tuple3_Monoid, BF_lMIN_Tuple3, &BF_identity);
+
+	//GrB_Semiring
+	GrB_Semiring_new(&BF_lMIN_PLUSrhs_Tuple3, BF_lMIN_Tuple3_Monoid, BF_PLUSrhs_Tuple3);
+
+	//--------------------------------------------------------------------------
+	// allocate arrays used for tuplets
+	//--------------------------------------------------------------------------
+	I = rm_malloc(sizeof(GrB_Index) * nz) ;
+	J = rm_malloc(sizeof(GrB_Index) * nz) ;
+	w = rm_malloc(sizeof(double) * nz) ;
+	W = rm_malloc(sizeof(BF_Tuple3_struct) * nz) ;
+	if(I == NULL || J == NULL || w == NULL || W == NULL) {
+		// LAGRAPH_ERROR("out of memory", GrB_OUT_OF_MEMORY) ;
+		return GrB_OUT_OF_MEMORY;
+	}
+
+	//--------------------------------------------------------------------------
+	// create matrix Atmp based on A, while its entries become BF_Tuple3 type
+	//--------------------------------------------------------------------------
+	GrB_Matrix_extractTuples_FP64(I, J, w, &nz, A);
+	int nthreads = 1;
+	GxB_get(GxB_NTHREADS, &nthreads);
+
+	#pragma omp parallel for num_threads(nthreads) schedule(static)
+	for(GrB_Index k = 0; k < nz; k++) {
+		// if(w[k] == 0) {            //diagonal entries
+		if(I[k] == J[k]) {            //diagonal entries
+			W[k] = (BF_Tuple3_struct) {
+				.w = 0, .h = 0, .pi = 0
+			};
+		} else {
+			W[k] = (BF_Tuple3_struct) {
+				.w = w[k], .h = 1, .pi = I[k] + 1
+			};
+		}
+	}
+	GrB_Matrix_new(&Atmp, BF_Tuple3, n, n);
+	GrB_Matrix_build_UDT(Atmp, I, J, W, nz, BF_lMIN_Tuple3);
+
+//--------------------------------------------------------------------------
+// create and initialize "distance" vector d
+//--------------------------------------------------------------------------
+	GrB_Vector_new(&d, BF_Tuple3, n);
+// initial distance from s to itself
+	BF_Tuple3_struct d0 = (BF_Tuple3_struct) {
+		.w = 0, .h = 0, .pi = 0
+	};
+	GrB_Vector_setElement_UDT(d, &d0, s);
+
+//--------------------------------------------------------------------------
+// start the Bellman Ford process
+//--------------------------------------------------------------------------
+// copy d to dtmp and dfrontier in order to create a same size of vector
+	GrB_Vector_dup(&dtmp, d);
+	GrB_Vector_dup(&dfrontier, d);
+	bool same = false;          // variable indicating if d == dtmp
+	int64_t iter = 0;           // number of iterations
+
+// terminate when no new path is found or more than V-1 loops
+	while(!same && iter < n - 1) {
+		// execute semiring on d and A, and save the result to dtmp
+		GrB_vxm(dfrontier, GrB_NULL, GrB_NULL, BF_lMIN_PLUSrhs_Tuple3, dfrontier, Atmp, GrB_NULL);
+
+		// dtmp[i] = min(d[i], dfrontier[i]).
+		GrB_eWiseAdd_Vector_BinaryOp(dtmp, GrB_NULL, GrB_NULL, BF_lMIN_Tuple3, d, dfrontier, GrB_NULL);
+
+		LAGraph_Vector_isequal(&same, dtmp, d, BF_EQ_Tuple3);
+		if(!same) {
+			GrB_Vector ttmp = dtmp;
+			dtmp = d;
+			d = ttmp;
+		}
+		iter ++;
+	}
+
+// check for negative-weight cycle only when there was a new path in the
+// last loop, otherwise, there can't be a negative-weight cycle.
+	if(!same) {
+		// execute semiring again to check for negative-weight cycle
+		GrB_vxm(dtmp, GrB_NULL, GrB_NULL, BF_lMIN_PLUSrhs_Tuple3, d, Atmp, GrB_NULL);
+
+		// if d != dtmp, then there is a negative-weight cycle in the graph
+		LAGraph_Vector_isequal(&same, dtmp, d, BF_EQ_Tuple3);
+		if(!same) {
+			// printf("A negative-weight cycle found. \n");
+			FREE_ALL;
+			return (GrB_SUCCESS) ;
+		}
+	}
+
+//--------------------------------------------------------------------------
+// extract tuple from "distance" vector d and create GrB_Vectors for output
+//--------------------------------------------------------------------------
+	GrB_Vector_extractTuples_UDT(I, (void *) W, &n, d);
+	h  = rm_malloc(sizeof(GrB_Index) * n) ;
+	pi = rm_malloc(sizeof(GrB_Index) * n) ;
+	if(w == NULL || h == NULL || pi == NULL) {
+		// LAGRAPH_ERROR("out of memory", GrB_OUT_OF_MEMORY) ;
+		return GrB_OUT_OF_MEMORY;
+	}
+
+	for(GrB_Index k = 0; k < n; k++) {
+		w [k] = W[k].w ;
+		h [k] = W[k].h ;
+		pi[k] = W[k].pi;
+	}
+	GrB_Vector_new(pd_output,  GrB_FP64,   n);
+	GrB_Vector_new(ppi_output, GrB_UINT64, n);
+	GrB_Vector_new(ph_output,  GrB_UINT64, n);
+	GrB_Vector_build_FP64(*pd_output, I, w, n, GrB_MIN_FP64);
+	GrB_Vector_build_UINT64(*ppi_output, I, pi, n, GrB_MIN_UINT64);
+	GrB_Vector_build_UINT64(*ph_output, I, h, n, GrB_MIN_UINT64);
+	FREE_ALL;
+	return (GrB_SUCCESS) ;
+}

--- a/src/algorithms/LAGraph_BF_full.h
+++ b/src/algorithms/LAGraph_BF_full.h
@@ -1,0 +1,70 @@
+//------------------------------------------------------------------------------
+// LAGraph_BF_full.c: Bellman-Ford single-source shortest paths, returns tree
+//------------------------------------------------------------------------------
+
+/*
+    LAGraph:  graph algorithms based on GraphBLAS
+
+    Copyright 2019 LAGraph Contributors.
+
+    (see Contributors.txt for a full list of Contributors; see
+    ContributionInstructions.txt for information on how you can Contribute to
+    this project).
+
+    All Rights Reserved.
+
+    NO WARRANTY. THIS MATERIAL IS FURNISHED ON AN "AS-IS" BASIS. THE LAGRAPH
+    CONTRIBUTORS MAKE NO WARRANTIES OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+    AS TO ANY MATTER INCLUDING, BUT NOT LIMITED TO, WARRANTY OF FITNESS FOR
+    PURPOSE OR MERCHANTABILITY, EXCLUSIVITY, OR RESULTS OBTAINED FROM USE OF
+    THE MATERIAL. THE CONTRIBUTORS DO NOT MAKE ANY WARRANTY OF ANY KIND WITH
+    RESPECT TO FREEDOM FROM PATENT, TRADEMARK, OR COPYRIGHT INFRINGEMENT.
+
+    Released under a BSD license, please see the LICENSE file distributed with
+    this Software or contact permission@sei.cmu.edu for full terms.
+
+    Created, in part, with funding and support from the United States
+    Government.  (see Acknowledgments.txt file).
+
+    This program includes and/or can make use of certain third party source
+    code, object code, documentation and other files ("Third Party Software").
+    See LICENSE file for more details.
+
+*/
+
+//------------------------------------------------------------------------------
+
+// LAGraph_BF_full: Bellman-Ford single source shortest paths, returning both
+// the path lengths and the shortest-path tree.  contributed by Jinhao Chen and
+// Tim Davis, Texas A&M.
+
+// LAGraph_BF_full performs a Bellman-Ford to find out shortest path, parent
+// nodes along the path and the hops (number of edges) in the path from given
+// source vertex s in the range of [0, n) on graph given as matrix A with size
+// n*n. The sparse matrix A has entry A(i, j) if there is an edge from vertex i
+// to vertex j with weight w, then A(i, j) = w.
+
+// TODO: think about the return values
+
+// LAGraph_BF_full returns GrB_SUCCESS regardless of existence of negative-
+// weight cycle. However, the GrB_Vector d(k), pi(k) and h(k)  (i.e.,
+// *pd_output, *ppi_output and *ph_output respectively) will be NULL when
+// negative-weight cycle detected. Otherwise, the vector d has d(k) as the
+// shortest distance from s to k. pi(k) = p+1, where p is the parent node of
+// k-th node in the shortest path. In particular, pi(s) = 0. h(k) = hop(s, k),
+// the number of edges from s to k in the shortest path.
+
+//------------------------------------------------------------------------------
+
+#pragma once
+
+#include "../../deps/GraphBLAS/Include/GraphBLAS.h"
+
+GrB_Info LAGraph_BF_full
+(
+	GrB_Vector *pd_output,      //the pointer to the vector of distance
+	GrB_Vector *ppi_output,     //the pointer to the vector of parent
+	GrB_Vector *ph_output,       //the pointer to the vector of hops
+	const GrB_Matrix A,         //matrix for the graph
+	const GrB_Index s           //given index of the source
+);

--- a/src/algorithms/algorithms.h
+++ b/src/algorithms/algorithms.h
@@ -12,5 +12,6 @@
 #include "./all_paths.h"
 #include "./detect_cycle.h"
 #include "./longest_path.h"
+#include "./LAGraph_BF_full.h"
 
 #endif

--- a/src/datatypes/array.c
+++ b/src/datatypes/array.c
@@ -73,6 +73,10 @@ XXH64_hash_t SIArray_HashCode(SIValue siarray) {
 	return hashCode;
 }
 
+void SIArray_Reverse(SIValue siarray) {
+	array_reverse(siarray.array);
+}
+
 void SIArray_Free(SIValue siarray) {
 	uint arrayLen = SIArray_Length(siarray);
 	for(uint i = 0; i < arrayLen; i++) {

--- a/src/datatypes/array.h
+++ b/src/datatypes/array.h
@@ -59,6 +59,13 @@ void SIArray_ToString(SIValue list, char **buf, size_t *bufferLen, size_t *bytes
 XXH64_hash_t SIArray_HashCode(SIValue siarray);
 
 /**
+ * @brief  Reverse the order of the array.
+ * @param  siarray: SIArray.
+ * @retval None
+ */
+void SIArray_Reverse(SIValue siarray);
+
+/**
   * @brief  delete an array
   * @param  siarray:
   * @retval None

--- a/src/procedures/proc_shortest_path.c
+++ b/src/procedures/proc_shortest_path.c
@@ -1,0 +1,291 @@
+/*
+* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+*
+* This file is available under the Redis Labs Source Available License Agreement
+*/
+
+#include "proc_shortest_path.h"
+#include "proc_ctx.h"
+#include "../query_ctx.h"
+#include "../datatypes/array.h"
+#include "../datatypes/path/path.h"
+#include "../graph/entities/node.h"
+#include "../algorithms/LAGraph_BF_full.h"
+
+// CALL algo.shortestPath(startNode, endNode, weightProperty, relationshipQuery, defaultValue)
+
+typedef struct {
+	bool pathProduced;              // Indicates if a path was produced.
+	Node *startNode;                // Start node to construct path from.
+	Node *endNode;                  // End node, path ends with this node.
+	const char *weightProperty;     // Attribute holding edge weight.
+	const char *relationship;       // Type of relationship to traverse.
+	double defaultValue;            // Use default value for edges missing weight attribute.
+	GrB_Matrix M;                   // Weights matrix.
+	SIValue *output;                // Output ["Path", path, "Cost", cost].
+} ShortestPath_Ctx;
+
+/* Construct NXN matrix M
+ * where M's main diagonal M[i,i] = 0
+ * for every edge of type `relation` connecting node i to node j
+ * W[i,j] = weight_attr of edge. */
+static GrB_Matrix _BuildWeightMatrix(const char *relation, const char *weight_attr,
+									 double default_weight) {
+
+	assert(relation && weight_attr);
+	GrB_Matrix M = GrB_NULL;
+
+	GraphContext *gc = QueryCtx_GetGraphCtx();
+	Schema *s = GraphContext_GetSchema(gc, relation, SCHEMA_EDGE);
+	if(!s) return GrB_NULL; // Relationship type doesn't exists.
+
+	Attribute_ID attr_id = GraphContext_GetAttributeID(gc, weight_attr);
+	if(attr_id == ATTRIBUTE_NOTFOUND) return GrB_NULL;  // Attribute doesn't exists.
+
+	Graph *g = QueryCtx_GetGraph();
+	GrB_Index n = Graph_RequiredMatrixDim(g);
+	GrB_Matrix R = Graph_GetRelationMatrix(g, s->id);
+
+	// TODO: enable FP64 in GB_control.h
+	GrB_Info info = GrB_Matrix_new(&M, GrB_FP64, n, n);
+	if(info != GrB_SUCCESS) return GrB_NULL;
+
+	// Extract relations out of matrix.
+	GrB_Index nz;
+	GrB_Matrix_nvals(&nz, R);
+	GrB_Index *I = rm_malloc(sizeof(GrB_Index) * nz);
+	GrB_Index *J = rm_malloc(sizeof(GrB_Index) * nz);
+	uint64_t  *X = rm_malloc(sizeof(uint64_t) * nz);
+	info = GrB_Matrix_extractTuples_UINT64(I, J, X, &nz, R);
+
+	// Process each relation.
+	for(GrB_Index i = 0; i < nz; i++) {
+		Edge e;
+		EdgeID id = X[i];
+		GrB_Index row = I[i];
+		GrB_Index col = J[i];
+		double weight = default_weight;
+
+		if(SINGLE_EDGE(id)) {
+			id = SINGLE_EDGE_ID(id);
+			Graph_GetEdge(g, id, &e);
+			SIValue *v = GraphEntity_GetProperty((GraphEntity *)&e, attr_id);
+			SIValue_ToDouble(v, &weight);   // Doesn't modifies `weight` if `v` isn't numeric.
+			GrB_Matrix_setElement_FP64(M, weight, row, col);
+		} else {
+			assert("TODO: handle multiple edges, pick min." && false);
+		}
+	}
+
+	rm_free(I);
+	rm_free(J);
+	rm_free(X);
+	return M;
+}
+
+/* Constructs a path object out of LAGraph BF output.
+ * p - parent array
+ * h - hops array
+ * s_id - source node ID
+ * t_id - destination node ID
+ * Returns path object describing the shortest path from s to t */
+static void _ConstructPath
+(
+	SIValue *path_output,   // Path object describing the shortest.
+	SIValue *cost_output,   // Cost array specifying the cost to each node.
+	GrB_Vector p,           // Parent tree.
+	GrB_Vector h,           // Hops to node i.
+	GrB_Vector d,           // Distance to node i.
+	const ShortestPath_Ctx *ctx
+) {
+
+	Node n;
+	GrB_Info info;
+	Node *t = ctx->endNode;
+	Node *s = ctx->startNode;
+	NodeID s_id = ENTITY_GET_ID(s);
+	NodeID t_id = ENTITY_GET_ID(t);
+	Graph *g = QueryCtx_GetGraph();
+	Edge *edges = array_new(Edge, 32);
+	const char *relation = ctx->relationship;
+
+	/* Determine path length M
+	 * h[t_id] = number of hops on the shortest path from `s` to `t`. */
+	uint64_t hops;
+	info = GrB_Vector_extractElement_UINT64(&hops, h, t_id);
+	assert(info == GrB_SUCCESS);
+
+	// Construct path and cost array.
+	SIValue cost = SIArray_New(hops);
+	Path *path = Path_New(hops);
+	Path_AppendNode(path, *t);
+
+	double c;
+	info = GrB_Vector_extractElement_FP64(&c, d, t_id);
+	SIArray_Append(&cost, SI_DoubleVal(c));
+
+	// Determine traversed edge type.
+	GraphContext *gc = QueryCtx_GetGraphCtx();
+	Schema *schema = GraphContext_GetSchema(gc, relation, SCHEMA_EDGE);
+	int r_id = schema->id;
+
+	while(hops) {
+		/* p[t_id] contains the source node leading to parent
+		 * on the shortest path from `s` to `t`. */
+		info = GrB_Vector_extractElement_UINT64(&s_id, p, t_id);
+		assert(info == GrB_SUCCESS);
+		s_id--; // as p is 1 index based.
+
+		// Get edge connecting src to dest.
+		Graph_GetEdgesConnectingNodes(g, s_id, t_id, r_id, &edges);
+		if(array_len(edges) > 1) {
+			// TODO: handle multiple edges.
+			assert("handle multiple edges" && false);
+		}
+
+		Path_AppendEdge(path, edges[0]);
+		array_clear(edges);
+
+		Graph_GetNode(g, s_id, &n);
+		Path_AppendNode(path, n);
+
+		info = GrB_Vector_extractElement_FP64(&c, d, s_id);
+		SIArray_Append(&cost, SI_DoubleVal(c));
+
+		// Update
+		t_id = s_id;
+		hops--;
+	}
+
+	array_free(edges);
+	// Reverse path such that source node is at the beginning.
+	Path_Reverse(path);
+	SIArray_Reverse(cost);
+
+	*path_output = SI_Path(path);
+	*cost_output = cost;
+}
+
+ProcedureResult Proc_ShortestPathInvoke(ProcedureCtx *ctx, const SIValue *args) {
+	if(array_len((SIValue *)args) != 5) return PROCEDURE_ERR;
+
+	ctx->privateData = NULL;
+
+	Node *startNode = (Node *)(args[0].ptrval);
+	Node *endNode = (Node *)(args[1].ptrval);
+	const char *weightProperty = args[2].stringval;
+	const char *relationship = args[3].stringval;
+	double defaultValue = args[4].doubleval;
+
+	GrB_Matrix M = _BuildWeightMatrix(relationship, weightProperty, defaultValue);
+	if(M == GrB_NULL) return PROCEDURE_ERR;
+
+	ShortestPath_Ctx *pdata = rm_malloc(sizeof(ShortestPath_Ctx));
+	pdata->M = M;
+	pdata->endNode = endNode;
+	pdata->startNode = startNode;
+	pdata->relationship = relationship;
+	pdata->defaultValue = defaultValue;
+	pdata->weightProperty = weightProperty;
+	pdata->pathProduced = false;
+
+	pdata->output = array_new(SIValue, 4);
+	pdata->output = array_append(pdata->output, SI_ConstStringVal("path"));
+	pdata->output = array_append(pdata->output, SI_NullVal()); // Place holder.
+	pdata->output = array_append(pdata->output, SI_ConstStringVal("cost"));
+	pdata->output = array_append(pdata->output, SI_NullVal()); // Place holder.
+
+	ctx->privateData = pdata;
+	return PROCEDURE_OK;
+}
+
+SIValue *Proc_ShortestPathStep(ProcedureCtx *ctx) {
+	assert(ctx->privateData);
+
+	SIValue *res = NULL;
+	ShortestPath_Ctx *pdata = (ShortestPath_Ctx *)ctx->privateData;
+	Node *s = pdata->startNode;
+	Node *t = pdata->endNode;
+	NodeID s_id = ENTITY_GET_ID(s);
+	NodeID t_id = ENTITY_GET_ID(t);
+	GrB_Vector d = GrB_NULL;    // Pointer to the vector of distance
+	GrB_Vector pi = GrB_NULL;   // Pointer to the vector of parent
+	GrB_Vector h = GrB_NULL;    // Pointer to the vector of hops
+
+	if(pdata->pathProduced) goto cleanup;
+	// Mark this call to Step, such that additional calls will return NULL.
+	pdata->pathProduced = true;
+
+	GrB_Info info = LAGraph_BF_full(&d, &pi, &h, pdata->M, s_id);
+
+	if(info != GrB_SUCCESS) {
+		/* Failed to run Bellman-Ford single source shortest paths.
+		 * return NULL. */
+		goto cleanup;
+	}
+
+	// Determine number of hops on shortest path.
+	uint64_t hops;
+	GrB_Vector_extractElement_UINT64(&hops, h, t_id);
+	if(hops == 0) {
+		// No path from s to t.
+		goto cleanup;
+	}
+
+	// Set result.
+	res = pdata->output;
+
+	// s and t are connected, construct PATH object.
+	SIValue path;
+	SIValue cost;
+	_ConstructPath(&path, &cost, pi, h, d, pdata);
+	pdata->output[1] = path;
+	pdata->output[3] = cost;
+
+cleanup:
+	if(d) GrB_free(&d);
+	if(pi) GrB_free(&pi);
+	if(h) GrB_free(&h);
+
+	// Mark ourselves as depleted.
+	return res;
+}
+
+ProcedureResult Proc_ShortestPathFree(ProcedureCtx *ctx) {
+	// Clean up.
+	if(ctx->privateData) {
+		ShortestPath_Ctx *pdata = ctx->privateData;
+		GrB_free(&pdata->M);
+		array_free(pdata->output);
+		rm_free(ctx->privateData);
+	}
+
+	return PROCEDURE_OK;
+}
+
+ProcedureCtx *Proc_ShortestPathCtx() {
+	void *privateData = NULL;
+	ProcedureOutput **outputs = array_new(ProcedureOutput *, 2);
+
+	ProcedureOutput *output_path = rm_malloc(sizeof(ProcedureOutput));
+	output_path->name = "path";
+	output_path->type = T_PATH;
+
+	ProcedureOutput *output_cost = rm_malloc(sizeof(ProcedureOutput));
+	output_cost->name = "cost";
+	output_cost->type = T_ARRAY;
+
+	outputs = array_append(outputs, output_path);
+	outputs = array_append(outputs, output_cost);
+
+	unsigned int ninputs = 5;    // Start node, end node, weight property, edge type, default weight.
+	ProcedureCtx *ctx = ProcCtxNew("algo.shortestPath",
+								   ninputs,
+								   outputs,
+								   Proc_ShortestPathStep,
+								   Proc_ShortestPathInvoke,
+								   Proc_ShortestPathFree,
+								   privateData,
+								   true);
+	return ctx;
+}

--- a/src/procedures/proc_shortest_path.h
+++ b/src/procedures/proc_shortest_path.h
@@ -1,0 +1,11 @@
+/*
+* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+*
+* This file is available under the Redis Labs Source Available License Agreement
+*/
+
+#pragma once
+
+#include "proc_ctx.h"
+
+ProcedureCtx *Proc_ShortestPathCtx();

--- a/src/procedures/procedure.c
+++ b/src/procedures/procedure.c
@@ -26,6 +26,7 @@ void Proc_Register() {
 
 	// Register graph algorithms.
 	_procRegister("algo.pageRank", Proc_PagerankCtx);
+	_procRegister("algo.shortestPath", Proc_ShortestPathCtx);
 
 	// Register FullText Search generator.
 	_procRegister("db.idx.fulltext.drop", Proc_FulltextDropIdxGen);

--- a/src/procedures/procedures.h
+++ b/src/procedures/procedures.h
@@ -7,6 +7,7 @@
 #include "proc_labels.h"
 #include "proc_pagerank.h"
 #include "proc_relations.h"
+#include "proc_shortest_path.h"
 #include "proc_property_keys.h"
 #include "proc_fulltext_query.h"
 #include "proc_fulltext_drop_index.h"

--- a/tests/flow/test_shortest_path.py
+++ b/tests/flow/test_shortest_path.py
@@ -1,0 +1,80 @@
+import redis
+from RLTest import Env
+from redisgraph import Graph, Node, Edge, Path
+from base import FlowTestsBase
+
+GRAPH_ID = "shortest_path_test"
+graph = None
+
+class testUnion(FlowTestsBase):
+    def __init__(self):
+        self.env = Env()
+        global graph
+
+        redis_con = self.env.getConnection()
+        graph = Graph(GRAPH_ID, redis_con)
+
+        self.populate_graph()
+
+    def populate_graph(self):
+        a = Node(label="Loc", properties={"name": "A"})
+        b = Node(label="Loc", properties={"name": "B"})
+        c = Node(label="Loc", properties={"name": "C"})
+        d = Node(label="Loc", properties={"name": "D"})
+        e = Node(label="Loc", properties={"name": "E"})
+        f = Node(label="Loc", properties={"name": "F"})
+
+        ab = Edge(a, "ROAD", b, properties={"cost": 50})
+        ac = Edge(a, "ROAD", c, properties={"cost": 60})
+        ad = Edge(a, "ROAD", d, properties={"cost": 100})
+        bd = Edge(b, "ROAD", d, properties={"cost": 40})
+        cd = Edge(c, "ROAD", d, properties={"cost": 40})
+        ce = Edge(c, "ROAD", e, properties={"cost": 80})
+        de = Edge(d, "ROAD", e, properties={"cost": 30})
+        df = Edge(d, "ROAD", f, properties={"cost": 80})
+        ef = Edge(e, "ROAD", f, properties={"cost": 40})
+        
+        global graph
+        graph.add_node(a)
+        graph.add_node(b)
+        graph.add_node(c)
+        graph.add_node(d)
+        graph.add_node(e)
+        graph.add_node(f)
+
+        graph.add_edge(ab)
+        graph.add_edge(ac)
+        graph.add_edge(ad)
+        graph.add_edge(bd)
+        graph.add_edge(cd)
+        graph.add_edge(ce)
+        graph.add_edge(de)
+        graph.add_edge(df)
+        graph.add_edge(ef)
+
+        graph.flush()
+
+    def test_shortest_path(self):
+        # Find the shotest path between a and f
+        # Path:
+        # a->b->d->e->f
+        # Costs:
+        # 0, 50, 90, 120, 160
+
+        # [(0), [0], (1), [3], (3), [6], (4), [8], (5)]
+        # [0.000000, 50.000000, 90.000000, 120.000000, 160.000000]
+                
+        # Find shortest path between a and f
+        q = """MATCH (start:Loc{name:'A'}), (end:Loc{name:'F'}) CALL algo.shortestPath(start, end, 'cost', 'ROAD', 0) YIELD path, cost RETURN path, cost"""
+        result = graph.query(q)
+        path = result.result_set[0][0]
+        cost = result.result_set[0][1]
+
+        # Extract expected path from graph.
+        q = """MATCH p = (a {name:'A'})-[ab]->(b{name:'B'})-[bd]->(d{name:'D'})-[de]->(e{name:'E'})-[ef]->(f{name:'F'}) RETURN p"""
+        result = graph.query(q)
+        expected_path = result.result_set[0][0]
+        expected_cost = [0, 50, 90, 120, 160]
+        
+        self.env.assertEquals(path, expected_path)
+        self.env.assertEquals(cost, expected_cost)


### PR DESCRIPTION
`CALL algo.shortestPath(startNode, endNode, weightProperty, relationshipQuery, defaultValue)`
There are a number of TODOs left: handle multiple edges between `a` and `b`.

The Bellman-Ford implementation is a bit different than the one you'll currently find in LAGraph,
I'll send them a PR.