### PR TITLE
Validate arity per-command rather than globally

### DIFF
--- a/src/commands/cmd_dispatcher.c
+++ b/src/commands/cmd_dispatcher.c
@@ -12,6 +12,22 @@
 // Command handler function pointer.
 typedef void(*Command_Handler)(void *args);
 
+// Return true if the command has a valid number of arguments.
+static inline bool _validate_command_arity(GRAPH_Commands cmd, int arity) {
+	switch(cmd) {
+	case CMD_QUERY:
+	case CMD_EXPLAIN:
+	case CMD_PROFILE:
+		// Expect a command, graph name, a query, and optionally a "--compact" flag.
+		return arity >= 3 && arity <= 4;
+	case CMD_SLOWLOG:
+		// Expect just a command and graph name.
+		return arity == 2;
+	default:
+		assert("encountered unhandled query type" && false);
+	}
+}
+
 // Get command handler.
 static Command_Handler get_command_handler(GRAPH_Commands cmd) {
 	switch(cmd) {
@@ -42,13 +58,12 @@ static GRAPH_Commands determine_command(const char *cmd_name) {
 
 int CommandDispatch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	CommandCtx *context;
-	// TODO: get number of arguments form command.
-	if(argc < 2) return RedisModule_WrongArity(ctx);
 
 	RedisModuleString *graph_name = argv[1];
 	RedisModuleString *query = (argc > 2) ? argv[2] : NULL;
 	const char *command_name = RedisModule_StringPtrLen(argv[0], NULL);
 	GRAPH_Commands cmd = determine_command(command_name);
+	if(_validate_command_arity(cmd, argc) == false) return RedisModule_WrongArity(ctx);
 	Command_Handler handler = get_command_handler(cmd);
 	GraphContext *gc = GraphContext_Retrieve(ctx, graph_name, true, true);
 
@@ -73,3 +88,4 @@ int CommandDispatch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
 	return REDISMODULE_OK;
 }
+

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -8,12 +8,14 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from base import FlowTestsBase
 
+redis_con = None
 redis_graph = None
 
 class testQueryValidationFlow(FlowTestsBase):
 
     def __init__(self):
         self.env = Env()
+        global redis_con
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph("G", redis_con)
@@ -182,4 +184,15 @@ class testQueryValidationFlow(FlowTestsBase):
         except redis.exceptions.ResponseError as e:
             # Expecting an error.
             assert("Encountered unhandled type" in e.message)
+            pass
+
+    # Validate that the module fails properly with incorrect argument counts.
+    def test17_query_arity(self):
+        # Call GRAPH.QUERY with a missing query argument.
+        try:
+            res = redis_con.execute_command("GRAPH.QUERY", "G")
+            assert(False)
+        except redis.exceptions.ResponseError as e:
+            # Expecting an error.
+            assert("wrong number of arguments" in e.message)
             pass


### PR DESCRIPTION
Resolves issue causing enterprise QA failure.