### PR TITLE
push down transpose operations

### DIFF
--- a/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
@@ -514,7 +514,6 @@ AlgebraicExpression **AlgebraicExpression_FromQueryGraph
 		uint sub_count = array_len(sub_exps);
 		for(uint i = 0; i < sub_count; i++) {
 			AlgebraicExpression *exp = sub_exps[i];
-			AlgebraicExpression_Optimize(&exp);
 			// Add constructed expression to return value.
 			exps = array_append(exps, exp);
 		}

--- a/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
@@ -291,7 +291,8 @@ static void _AlgebraicExpression_PushDownTranspose(AlgebraicExpression *root) {
 				 * Transpose(A + B) = Transpose(A) + Transpose(B)
 				 * Transpose(A * B) = Transpose(B) * Transpose(A) */
 				AlgebraicExpression_Transpose(child);
-				// Replace Transpose root with transposed expression.
+				/* Replace Transpose root with transposed expression.
+				 * Remove root only child. */
 				_AlgebraicExpression_OperationRemoveRightmostChild(root);
 				_AlgebraicExpression_InplaceRepurpose(root, child);
 

--- a/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
@@ -296,7 +296,7 @@ static void _AlgebraicExpression_PushDownTranspose(AlgebraicExpression *root) {
 				_AlgebraicExpression_OperationRemoveRightmostChild(root);
 				_AlgebraicExpression_InplaceRepurpose(root, child);
 
-				/* Note, there's need to dig deep into `root` sub-expression
+				/* Note, there's no need to dig deep into `root` sub-expression
 				 * looking for additional transpose nodes, as calling
 				 * AlgebraicExpression_Transpose will remove all of those. */
 			}

--- a/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
@@ -235,6 +235,80 @@ static void _AlgebraicExpression_FlattenMultiplications(AlgebraicExpression *roo
 	}
 }
 
+/* Push down transpose operations to the point where they are applied to individual operands
+ * once this optimization is applied there shouldn't be instances of transpose acting on
+ * operation nodes such as multiplication and addition.
+ *
+ * Consider Exp = Transpose(A + B)
+ *
+ *           (transpose)
+ *               (+)
+ *         (A)          (B)
+ *
+ * PushDownTranspose will transform Exp to: Transpose(A) + Transpose(B)
+ *
+ *                (+)
+ *    (transpose)     (transpose)
+ *         (A)            (B)
+ *
+ * Another example, Exp = Transpose(A * B)
+ *
+ *           (transpose)
+ *               (*)
+ *         (A)          (B)
+ *
+ * Would become Transpose(B) * Transpose(A)
+ *
+ *                (*)
+ *    (transpose)     (transpose)
+ *         (B)            (A)
+ * */
+static void _AlgebraicExpression_PushDownTranspose(AlgebraicExpression *root) {
+	uint i = 0;
+	uint child_count = 0;
+	AlgebraicExpression *child = NULL;
+
+	switch(root->type) {
+	case AL_OPERAND:
+		break;  // Nothing to be done.
+
+	case AL_OPERATION:
+		switch(root->operation.op) {
+		case AL_EXP_ADD:    // Fall through.
+		case AL_EXP_MUL:    // Fall through.
+		case AL_EXP_POW:    // Fall through.
+			child_count = AlgebraicExpression_ChildCount(root);
+			for(; i < child_count; i++) {
+				AlgebraicExpression *child = root->operation.children[i];
+				_AlgebraicExpression_PushDownTranspose(child);
+			}
+			break;
+
+		case AL_EXP_TRANSPOSE:
+			child = root->operation.children[0];
+			if(child->type == AL_OPERATION) {
+				/* Transpose operation:
+				 * Transpose(A + B) = Transpose(A) + Transpose(B)
+				 * Transpose(A * B) = Transpose(B) * Transpose(A) */
+				AlgebraicExpression_Transpose(child);
+				// Replace Transpose root with transposed expression.
+				_AlgebraicExpression_OperationRemoveRightmostChild(root);
+				_AlgebraicExpression_InplaceRepurpose(root, child);
+
+				/* Note, there's need to dig deep into `root` sub-expression
+				 * looking for additional transpose nodes, as calling
+				 * AlgebraicExpression_Transpose will remove all of those. */
+			}
+			break;
+		default:
+			assert("Unknown operation" && false);
+		}
+		break;  // Break out of case AL_OPERATION.
+	default:
+		assert("Unknown algebraic expression node type" && false);
+	}
+}
+
 //------------------------------------------------------------------------------
 // AlgebraicExpression optimizations
 //------------------------------------------------------------------------------
@@ -243,6 +317,7 @@ void AlgebraicExpression_Optimize
 	AlgebraicExpression **exp
 ) {
 	assert(exp);
+	_AlgebraicExpression_PushDownTranspose(*exp);
 	_AlgebraicExpression_MulOverSum(exp);
 	_AlgebraicExpression_FlattenMultiplications(*exp);
 }

--- a/tests/flow/test_bidirectional_traversals.py
+++ b/tests/flow/test_bidirectional_traversals.py
@@ -278,3 +278,35 @@ class testBidirectionalTraversals(FlowTestsBase):
                            ['v3', 'v2'],
                            ['v3', 'v3']]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    def test11_bidirectional_multiple_edge_type(self):
+        # Construct a simple graph:
+        # (a)-[E1]->(b), (c)-[E2]->(d)
+
+        g = Graph("multi_edge_type", redis_con)
+
+        a = Node(properties={'val': 'a'})
+        b = Node(properties={'val': 'b'})
+        c = Node(properties={'val': 'c'})
+        d = Node(properties={'val': 'd'})
+        g.add_node(a)
+        g.add_node(b)
+        g.add_node(c)
+        g.add_node(d)
+
+        ab = Edge(a, "E1", b)
+        cd = Edge(c, "E2", d)
+        g.add_edge(ab)
+        g.add_edge(cd)
+
+        g.flush()
+
+        query = """MATCH (a)-[:E1|:E2]-(z) RETURN a.val, z.val ORDER BY a.val, z.val"""
+        actual_result = g.query(query)
+
+        expected_result = [['a', 'b'],
+                           ['b', 'a'],
+                           ['c', 'd'],
+                           ['d', 'c']]
+
+        self.env.assertEquals(actual_result.result_set, expected_result)

--- a/tests/flow/test_relation_patterns.py
+++ b/tests/flow/test_relation_patterns.py
@@ -227,3 +227,37 @@ class testRelationPattern(FlowTestsBase):
         actual_result = redis_graph.query(query)
         expected_result = [[1]]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    def test07_transposed_multi_hop(self):
+        redis_con = self.env.getConnection()
+        g = Graph("tran_multi_hop", redis_con)
+
+        # (a)-[R]->(b)-[R]->(c)<-[R]-(d)<-[R]-(e)
+        a = Node(properties={"val": 'a'})
+        b = Node(properties={"val": 'b'})
+        c = Node(properties={"val": 'c'})
+        d = Node(properties={"val": 'd'})
+        e = Node(properties={"val": 'e'})
+        
+        g.add_node(a)
+        g.add_node(b)
+        g.add_node(c)
+        g.add_node(d)
+        g.add_node(e)
+
+        ab = Edge(a, "R", b)
+        bc = Edge(b, "R", c)
+        ed = Edge(e, "R", d)
+        dc = Edge(d, "R", c)
+
+        g.add_edge(ab)
+        g.add_edge(bc)
+        g.add_edge(ed)
+        g.add_edge(dc)
+
+        g.flush()
+
+        q = """MATCH (a)-[*2]->(b)<-[*2]-(c) RETURN a.val, b.val, c.val ORDER BY a.val, b.val, c.val"""
+        actual_result = g.query(q)
+        expected_result = [['a', 'c', 'a'], ['a', 'c', 'e'], ['e', 'c', 'a'], ['e', 'c', 'e']]
+        self.env.assertEquals(actual_result.result_set, expected_result)

--- a/tests/unit/test_algebraic_expression.cpp
+++ b/tests/unit/test_algebraic_expression.cpp
@@ -195,6 +195,7 @@ class AlgebraicExpressionTest: public ::testing::Test {
 
         uint exp_count = array_len(ae);
         for(uint i = 0; i < exp_count; i++) {
+            AlgebraicExpression_Optimize(ae + i);
             _AlgebraicExpression_FetchOperands(ae[i], gc, g);
         }
 


### PR DESCRIPTION
#1017 

We want to evaluate an expression where `transpose` operations are applied to operands,
this PR introduce an optimisation which pushes down transpose operations applied to other operation nodes, e.g. Add and Mul down to their individual operands.

```
Transpose(A + B) => Transpose(A) + Transpose(B)
Transpose(A * B) => Transpose(B) * Transpose(A)
```