### PR TITLE
Union bugfixes

### DIFF
--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -694,7 +694,7 @@ void ExecutionPlan_PopulateExecutionPlan(ExecutionPlan *plan) {
 	}
 }
 
-ExecutionPlan *ExecutionPlan_UnionPlans(AST *ast) {
+static ExecutionPlan *_ExecutionPlan_UnionPlans(AST *ast) {
 	uint end_offset = 0;
 	uint start_offset = 0;
 	uint clause_count = cypher_ast_query_nclauses(ast->root);
@@ -787,7 +787,7 @@ ExecutionPlan *NewExecutionPlan(void) {
 	uint clause_count = cypher_ast_query_nclauses(ast->root);
 
 	/* Handle UNION if there are any. */
-	if(AST_ContainsClause(ast, CYPHER_AST_UNION)) return ExecutionPlan_UnionPlans(ast);
+	if(AST_ContainsClause(ast, CYPHER_AST_UNION)) return _ExecutionPlan_UnionPlans(ast);
 
 	uint start_offset = 0;
 	uint end_offset = 0;

--- a/tests/flow/test_union.py
+++ b/tests/flow/test_union.py
@@ -1,6 +1,6 @@
 import redis
 from RLTest import Env
-from redisgraph import Graph
+from redisgraph import Graph, Node, Edge
 from base import FlowTestsBase
 
 GRAPH_ID = "union_test"
@@ -12,27 +12,50 @@ class testUnion(FlowTestsBase):
         global redis_graph
         redis_con = self.env.getConnection()
         redis_graph = Graph(GRAPH_ID, redis_con)
+        self.populate_graph()
 
-    def test_union(self):
+    def populate_graph(self):
+        global redis_graph
+        # Construct a graph with the form:
+        # (v1)-[:E1]->(v2)-[:E2]->(v3)
+        node_props = ['v1', 'v2', 'v3']
+
+        nodes = {}
+        for idx, v in enumerate(node_props):
+            node = Node(label="L", properties={"v": v})
+            nodes[v] = node
+            redis_graph.add_node(node)
+
+        edge = Edge(nodes['v1'], "E1", nodes['v2'], properties={"v": True})
+        redis_graph.add_edge(edge)
+
+        edge = Edge(nodes['v2'], "E2", nodes['v3'], properties={"v": False})
+        redis_graph.add_edge(edge)
+
+        redis_graph.flush()
+
+    def test01_union(self):
         q = """RETURN 1 as one UNION ALL RETURN 1 as one"""
         result = redis_graph.query(q)
         # Expecting 2 identical records.
         self.env.assertEquals(len(result.result_set), 2)
+        expected_result = [[1],
+                           [1]]
+        self.env.assertEquals(result.result_set, expected_result)
 
         q = """RETURN 1 as one UNION RETURN 1 as one"""
         result = redis_graph.query(q)
         # Expecting a single record, duplicate removed.
         self.env.assertEquals(len(result.result_set), 1)
+        expected_result = [[1]]
+        self.env.assertEquals(result.result_set, expected_result)
 
-        # Issue #741, create some data for path matching.
-        q = """CREATE (), (), ()"""
-        redis_graph.query(q)
         q = """MATCH a = () return length(a) AS len UNION ALL MATCH b = () RETURN length(b) AS len"""
         result = redis_graph.query(q)
         # 3 records from each sub-query, coresponding to each path matched.
         self.env.assertEquals(len(result.result_set), 6)
 
-    def test_invalid_union(self):
+    def test02_invalid_union(self):
         try:
             # projection must be exactly the same.
             q = """RETURN 1 as one UNION RETURN 1 as two""" 
@@ -41,3 +64,58 @@ class testUnion(FlowTestsBase):
         except redis.exceptions.ResponseError:
             # Expecting an error.
             pass
+
+    # Performing UNION with the same left and right side should
+    # produce the same result as evaluating just one side.
+    def test03_union_deduplication(self):
+        non_union_query = """MATCH (a)-[]->(b) RETURN a.v, b.v ORDER BY a.v, b.v"""
+        non_union_result = redis_graph.query(non_union_query)
+
+        union_query = """MATCH (a)-[]->(b) RETURN a.v, b.v ORDER BY a.v, b.v
+                         UNION
+                         MATCH (a)-[]->(b) RETURN a.v, b.v ORDER BY a.v, b.v"""
+        union_result = redis_graph.query(union_query)
+        self.env.assertEquals(union_result.result_set, non_union_result.result_set)
+
+    # Verify that edge alias reuse is allowed as intended.
+    def test04_union_referenced_edge(self):
+        # A syntax error should be raised on edge alias reuse in one side of a union.
+        try:
+            query = """MATCH ()-[e]->()-[e]->() RETURN e
+                       UNION
+                       MATCH ()-[e]->() RETURN e"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError:
+            # Expecting an error.
+            pass
+
+        # Using the same edge alias once per UNION side is expected.
+        query = """MATCH ()-[e]->() RETURN e.v ORDER BY e.v
+                   UNION
+                   MATCH ()-[e]->() RETURN e.v ORDER BY e.v
+                   UNION
+                   MATCH ()-[e]->() RETURN e.v ORDER BY e.v"""
+        result = redis_graph.query(query)
+
+        expected_result = [[False],
+                           [True]]
+        self.env.assertEquals(result.result_set, expected_result)
+
+    # Union should be capable of collating nodes and edges in a single column.
+    def test05_union_nodes_with_edges(self):
+        query = """MATCH ()-[e]->() RETURN e
+                   UNION
+                   MATCH (e) RETURN e"""
+        union_result = redis_graph.query(query)
+
+        # All 3 nodes and 2 edges should be returned.
+        self.env.assertEquals(len(union_result.result_set), 5)
+
+        query = """MATCH ()-[e]->() RETURN e
+                   UNION ALL
+                   MATCH (e) RETURN e"""
+        union_all_result = redis_graph.query(query)
+
+        # The same results should be produced regardless of whether ALL is specified.
+        self.env.assertEquals(union_result.result_set, union_all_result.result_set)

--- a/tests/flow/test_union.py
+++ b/tests/flow/test_union.py
@@ -77,9 +77,8 @@ class testUnion(FlowTestsBase):
         union_result = redis_graph.query(union_query)
         self.env.assertEquals(union_result.result_set, non_union_result.result_set)
 
-    # Verify that edge alias reuse is allowed as intended.
-    def test04_union_referenced_edge(self):
-        # A syntax error should be raised on edge alias reuse in one side of a union.
+    # A syntax error should be raised on edge alias reuse in one side of a union.
+    def test04_union_invalid_reused_edge(self):
         try:
             query = """MATCH ()-[e]->()-[e]->() RETURN e
                        UNION
@@ -90,7 +89,8 @@ class testUnion(FlowTestsBase):
             # Expecting an error.
             pass
 
-        # Using the same edge alias once per UNION side is expected.
+    # An edge alias appearing on both sides of a UNION is expected.
+    def test05_union_valid_reused_edge(self):
         query = """MATCH ()-[e]->() RETURN e.v ORDER BY e.v
                    UNION
                    MATCH ()-[e]->() RETURN e.v ORDER BY e.v
@@ -103,7 +103,7 @@ class testUnion(FlowTestsBase):
         self.env.assertEquals(result.result_set, expected_result)
 
     # Union should be capable of collating nodes and edges in a single column.
-    def test05_union_nodes_with_edges(self):
+    def test06_union_nodes_with_edges(self):
         query = """MATCH ()-[e]->() RETURN e
                    UNION
                    MATCH (e) RETURN e"""

--- a/tests/flow/test_union.py
+++ b/tests/flow/test_union.py
@@ -26,10 +26,10 @@ class testUnion(FlowTestsBase):
             nodes[v] = node
             redis_graph.add_node(node)
 
-        edge = Edge(nodes['v1'], "E1", nodes['v2'], properties={"v": True})
+        edge = Edge(nodes['v1'], "E1", nodes['v2'], properties={"v": "v1_v2"})
         redis_graph.add_edge(edge)
 
-        edge = Edge(nodes['v2'], "E2", nodes['v3'], properties={"v": False})
+        edge = Edge(nodes['v2'], "E2", nodes['v3'], properties={"v": "v2_v3"})
         redis_graph.add_edge(edge)
 
         redis_graph.flush()
@@ -58,7 +58,7 @@ class testUnion(FlowTestsBase):
     def test02_invalid_union(self):
         try:
             # projection must be exactly the same.
-            q = """RETURN 1 as one UNION RETURN 1 as two""" 
+            q = """RETURN 1 as one UNION RETURN 1 as two"""
             redis_graph.query(q)
             assert(False)
         except redis.exceptions.ResponseError:
@@ -98,8 +98,8 @@ class testUnion(FlowTestsBase):
                    MATCH ()-[e]->() RETURN e.v ORDER BY e.v"""
         result = redis_graph.query(query)
 
-        expected_result = [[False],
-                           [True]]
+        expected_result = [["v1_v2"],
+                           ["v2_v3"]]
         self.env.assertEquals(result.result_set, expected_result)
 
     # Union should be capable of collating nodes and edges in a single column.


### PR DESCRIPTION
Resolves #1046, fixing  the incorrect syntax error:
```
MATCH ()-[e]->() RETURN e UNION MATCH ()-[e]->() RETURN e"
(error) Cannot use the same relationship variable 'e' for multiple patterns.
```

Fixes a bug in OpDistinct logic on columns containing both nodes and edges (also, adds our first test for such columns!).