### PR TITLE
Guarantee that NOT conditions are unary

### DIFF
--- a/src/ast/ast_build_filter_tree.c
+++ b/src/ast/ast_build_filter_tree.c
@@ -27,7 +27,9 @@ void _FT_Append(FT_FilterNode **root_ptr, FT_FilterNode *child) {
 			FilterTree_AppendLeftChild(root, child);
 			return;
 		}
-		if(root->cond.right == NULL) {
+
+		// NOT condition nodes should always have a NULL right child; do not replace it.
+		if(root->cond.right == NULL && root->cond.op != OP_NOT) {
 			FilterTree_AppendRightChild(root, child);
 			return;
 		}

--- a/tests/unit/test_filter_tree.cpp
+++ b/tests/unit/test_filter_tree.cpp
@@ -301,25 +301,29 @@ TEST_F(FilterTreeTest, CollectModified) {
 }
 
 TEST_F(FilterTreeTest, NOTReduction) {
-	const char *filters[6] {
+	const char *filters[8] {
 		"MATCH (n) WHERE NOT n.v = 1 RETURN n",
 		"MATCH (n) WHERE NOT NOT n.v = 1 RETURN n",
 		"MATCH (n) WHERE NOT (n.v > 5 AND n.v < 20) RETURN n",
 		"MATCH (n) WHERE NOT (n.v <= 5 OR n.v <> 20) RETURN n",
 		"MATCH (n) WHERE NOT( NOT( NOT( n.v >= 1 AND (n.v < 5 OR n.v <> 3) ) ) ) RETURN n",
 		"MATCH (n) WHERE n.v = 2 AND NOT n.x > 4 RETURN n",
+		"MATCH (n) WHERE NOT n.v = 1 MATCH (n2) WHERE ID(n2) = ID(n) RETURN n",
+		"MATCH (n) WHERE NOT NOT n.v = 1 MATCH (n2) WHERE ID(n2) = ID(n) RETURN n",
 	};
 
-	const char *expected[6] {
+	const char *expected[8] {
 		"MATCH (n) WHERE n.v <> 1 RETURN n",
 		"MATCH (n) WHERE n.v = 1 RETURN n",
 		"MATCH (n) WHERE n.v <= 5 OR n.v >= 20 RETURN n",
 		"MATCH (n) WHERE n.v > 5 AND n.v = 20 RETURN n",
 		"MATCH (n) WHERE (n.v < 1 OR (n.v >= 5 AND n.v = 3)) RETURN n",
 		"MATCH (n) WHERE n.v = 2 AND n.x <= 4 RETURN n",
+		"MATCH (n) WHERE n.v <> 1 MATCH (n2) WHERE ID(n2) = ID(n) RETURN n",
+		"MATCH (n) WHERE n.v = 1 MATCH (n2) WHERE ID(n2) = ID(n) RETURN n",
 	};
 
-	for(int i = 0; i < 6; i++) {
+	for(int i = 0; i < 8; i++) {
 		const char *actual = filters[i];
 		const char *expected_q = expected[i];
 
@@ -485,3 +489,4 @@ TEST_F(FilterTreeTest, FilterTree_Compact) {
 	FilterTree_Free(actual);
 	FilterTree_Free(expected);
 }
+


### PR DESCRIPTION
Should resolve #1088 

Fixes a bug in which multiple WHERE clauses allow a right-hand child to be added to a NOT condition. NOT is unary; this should never be allowed.