### PR TITLE
Add suppression for erroneous leak reports after DEBUG RELOAD

### DIFF
--- a/src/valgrind.supp
+++ b/src/valgrind.supp
@@ -66,3 +66,12 @@
    ...
    fun:Indexer_Add
 }
+
+{
+   <RLTest race: ignore leaks in _GraphContext_Free caused by DEBUG RELOAD>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:rdbLoad
+   fun:debugCommand
+}


### PR DESCRIPTION
This will hopefully fix the intermittent automation failure in leak checking in test_persistency.py.

Sample failure: https://circleci.com/gh/RedisGraph/RedisGraph/6627

These reported leaks are the same currently as those currently suppressed in our valgrind.supp file, except the caller is the code that performs `DEBUG RELOAD`. 