### PR TITLE
Validate that all reference parameters are defined

### DIFF
--- a/tests/flow/test_params.py
+++ b/tests/flow/test_params.py
@@ -70,4 +70,37 @@ class testParams(FlowTestsBase):
             assert(False)
         except redis.exceptions.ResponseError as e:
             pass
+    
+    def test_missing_parameter(self):
+        # Make sure missing parameters are reported back as an error.
+        query = "RETURN $missing"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
 
+        query = "MATCH (a) WHERE a.v = $missing RETURN a"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+
+        query = "MATCH (a) SET a.v = $missing RETURN a"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+
+        query = "MERGE (a {v:$missing})"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass


### PR DESCRIPTION
This PR addresses #1091 
Whoever reviewing, please modify parameters introduction to rex by prefixing with '$'.
Thank you,

Please think of the query cache, what would happen if a cache hit occurs but we're missing some parameters?