### PR TITLE
throw runtime-error on missing query parameters

### DIFF
--- a/src/ast/enrichment/annotate_params.c
+++ b/src/ast/enrichment/annotate_params.c
@@ -53,12 +53,13 @@ static void _annotate_params(AST *ast) {
 		const char *key = (const char *)iter.key;
 		const cypher_astnode_t **exp_arr = iter.data;
 		const cypher_astnode_t *param_value = raxFind(params_values, (unsigned char *) key, iter.key_len);
-		assert(param_value != raxNotFound);
+		/* if param_value is missing we'll throw a run-time error
+		 * on first access, in the meanwhile we can simply ignore it. */
+		if(param_value != raxNotFound) continue;
 		uint array_length = array_len(exp_arr);
 		for(uint i = 0; i < array_length; i++) {
 			cypher_astnode_attach_annotation(params_ctx, exp_arr[i], (void *)param_value, NULL);
 		}
-
 	}
 	raxStop(&iter);
 	raxFreeWithCallback(query_params_map, array_free);

--- a/tests/flow/test_params.py
+++ b/tests/flow/test_params.py
@@ -55,7 +55,6 @@ class testParams(FlowTestsBase):
         self._assert_resultset_equals_expected(redis_graph.query(query, params), query_info)
 
     def test_parameterized_skip_limit(self):
-
         params = {'skip': 1, 'limit': 1}
         query = "UNWIND [1,2,3] AS X RETURN X SKIP $skip LIMIT $limit"
         expected_results = [[2]]
@@ -71,3 +70,28 @@ class testParams(FlowTestsBase):
         except redis.exceptions.ResponseError as e:
             pass
 
+    def test_missing_parameter(self):
+        # Make sure missing parameters are reported back as an error.
+        query = "RETURN $missing"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+
+        query = "MATCH (a) WHERE a.v = $missing RETURN a"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+
+        query = "MATCH (a) SET a.v = $missing RETURN a"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass


### PR DESCRIPTION
This PR skips AST enticement for missing parameters and leaves error reporting for run-time first access
#1091 