### PR TITLE
do not propagate transpose effect when introducing a transpose operat…

### DIFF
--- a/src/arithmetic/algebraic_expression.h
+++ b/src/arithmetic/algebraic_expression.h
@@ -203,12 +203,10 @@ void AlgebraicExpression_AddToTheRight
 );
 
 // Transpose expression
-// T(T(A)) = A
-// T(A + B) = T(A) + T(B)
-// T(A * B) = T(B) * T(B)
+// By wrapping exp in a transpose root node.
 void AlgebraicExpression_Transpose
 (
-    AlgebraicExpression *exp    // Expression to transpose.
+    AlgebraicExpression **exp    // Expression to transpose.
 );
 
 // Evaluate expression tree.

--- a/src/arithmetic/algebraic_expression/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression.c
@@ -118,17 +118,71 @@ AlgebraicExpression *AlgebraicExpression_Clone
 // AlgebraicExpression attributes.
 //------------------------------------------------------------------------------
 
-// Returns the source entity alias represented by the left-most operand row domain.
+// Forward declaration.
+static const char *_AlgebraicExpression_Source(AlgebraicExpression *root, bool transposed);
+
+// Returns the source entity alias (row domain)
+// Taking into consideration transpose
+static const char *_AlgebraicExpression_Operation_Source
+(
+	AlgebraicExpression *root,  // Root of expression.
+	bool transposed             // Is root transposed
+) {
+	switch(root->operation.op) {
+	case AL_EXP_ADD:
+		// Src (A+B) = Src(A)
+		// Src (Transpose(A+B)) = Src (Transpose(A)+Transpose(B)) = Src (Transpose(A))
+		return _AlgebraicExpression_Source(FIRST_CHILD(root), transposed);
+	case AL_EXP_MUL:
+		// Src (A*B) = Src(A)
+		// Src (Transpose(A*B)) = Src (Transpose(B)*Transpose(A)) = Src (Transpose(B))
+		if(transposed) return _AlgebraicExpression_Source(LAST_CHILD(root), transposed);
+		else return _AlgebraicExpression_Source(FIRST_CHILD(root), transposed);
+	case AL_EXP_TRANSPOSE:
+		// Src (Transpose(Transpose(A))) = Src(A)
+		// Negate transpose.
+		return _AlgebraicExpression_Source(FIRST_CHILD(root), !transposed);
+	default:
+		assert("Unknown algebraic expression operation" && false);
+	}
+}
+
+// Returns the source entity alias (row domain)
+// Taking into consideration transpose
+static const char *_AlgebraicExpression_Operand_Source
+(
+	AlgebraicExpression *root,  // Root of expression.
+	bool transposed             // Is root transposed
+) {
+	return (transposed) ? root->operand.dest : root->operand.src;
+}
+
+// Returns the source entity alias (row domain)
+// Taking into consideration transpose
+static const char *_AlgebraicExpression_Source
+(
+	AlgebraicExpression *root,  // Root of expression.
+	bool transposed             // Is root transposed
+) {
+	assert(root);
+	switch(root->type) {
+	case AL_OPERATION:
+		return _AlgebraicExpression_Operation_Source(root, transposed);
+	case AL_OPERAND:
+		return _AlgebraicExpression_Operand_Source(root, transposed);
+	default:
+		assert("Unknow algebraic expression node type" && false);
+	}
+}
+
+// Returns the source entity alias, row domain.
 const char *AlgebraicExpression_Source
 (
 	AlgebraicExpression *root   // Root of expression.
 ) {
 	assert(root);
-	while(root->type == AL_OPERATION) {
-		root = root->operation.children[0];
-	}
+	return _AlgebraicExpression_Source(root, false);
 
-	return root->operand.src;
 }
 
 // Returns the destination entity alias represented by the right-most operand column domain.
@@ -137,12 +191,9 @@ const char *AlgebraicExpression_Destination
 	AlgebraicExpression *root   // Root of expression.
 ) {
 	assert(root);
-	while(root->type == AL_OPERATION) {
-		uint child_count = AlgebraicExpression_ChildCount(root);
-		root = root->operation.children[child_count - 1];
-	}
-
-	return root->operand.dest;
+	// Dest(exp) = Src(Transpose(exp))
+	// Gotta love it!
+	return _AlgebraicExpression_Source(root, true);
 }
 
 /* Returns the first edge alias encountered.

--- a/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
@@ -196,8 +196,10 @@ static AlgebraicExpression *_AlgebraicExpression_OperandFromEdge
 
 	QGNode *src_node = e->src;
 	QGNode *dest_node = e->dest;
-	const char *src = src_node->alias;
-	const char *dest = dest_node->alias;
+
+	// Use original `src` and `dest` for algebraic operands.
+	const char *src = (transpose) ? dest_node->alias : src_node->alias;
+	const char *dest = (transpose) ? src_node->alias : dest_node->alias;
 	const char *edge = _should_populate_edge(e) ? e->alias : NULL;
 	bool var_len_traversal = QGEdge_VariableLength(e);
 

--- a/src/arithmetic/algebraic_expression/algebraic_expression_debug.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_debug.c
@@ -50,7 +50,7 @@ AlgebraicExpression *_AlgebraicExpression_FromString
 			break;
 		case 'T':
 			root = _AlgebraicExpression_FromString(exp, matrices);
-			AlgebraicExpression_Transpose(root);
+			AlgebraicExpression_Transpose(&root);
 			break;
 		default:
 			// Operand.

--- a/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
@@ -235,6 +235,107 @@ static void _AlgebraicExpression_FlattenMultiplications(AlgebraicExpression *roo
 	}
 }
 
+//------------------------------------------------------------------------------
+// Transpose pushdown
+//------------------------------------------------------------------------------
+
+// Forward declaration.
+static void _Pushdown_TransposeExp(AlgebraicExpression *exp);
+
+// Transpose addition.
+static void _Pushdown_TransposeAddition
+(
+	AlgebraicExpression *exp
+) {
+	// T(A + B) = T(A) + T(B)
+	// Transpose children.
+	uint child_count = AlgebraicExpression_ChildCount(exp);
+	for(uint i = 0; i < child_count; i++) _Pushdown_TransposeExp(exp->operation.children[i]);
+}
+
+// Transpose multiplication.
+static void _Pushdown_TransposeMultiplication
+(
+	AlgebraicExpression *exp
+) {
+	// Swap children, Transpose(A * B) = Transpose(B) * Transpose(A)
+	array_reverse(exp->operation.children);
+	// Transpose children.
+	uint child_count = AlgebraicExpression_ChildCount(exp);
+	for(uint i = 0; i < child_count; i++) _Pushdown_TransposeExp(exp->operation.children[i]);
+}
+
+// Transpose transpose.
+static void _Pushdown_TransposeTranspose
+(
+	AlgebraicExpression *exp
+) {
+	// T(T(A)) = A
+	// Expecting just a single operand.
+	assert(AlgebraicExpression_ChildCount(exp) == 1);
+	AlgebraicExpression *only_child = _AlgebraicExpression_OperationRemoveRightmostChild(exp);
+
+	// Replace Transpose operation with its child.
+	_AlgebraicExpression_InplaceRepurpose(exp, only_child);
+}
+
+// Transpose operation.
+static void _Pushdown_TransposeOperation
+(
+	AlgebraicExpression *exp
+) {
+	switch(exp->operation.op) {
+	case AL_EXP_ADD:
+		// T(A + B) = T(A) + T(B)
+		_Pushdown_TransposeAddition(exp);
+		break;
+	case AL_EXP_MUL:
+		_Pushdown_TransposeMultiplication(exp);
+		break;
+	case AL_EXP_TRANSPOSE:
+		_Pushdown_TransposeTranspose(exp);
+		break;
+	default:
+		assert("Unknown algebraic expression operation");
+		break;
+	}
+}
+
+// Transpose operand.
+static void _Pushdown_TransposeOperand
+(
+	AlgebraicExpression *exp
+) {
+	// No need to transpose a diagonal matrix.
+	if(exp->operand.diagonal) return;
+
+	// A -> Transpose(A)
+	// We're going to repourpose exp, make a clone.
+	AlgebraicExpression *operand = AlgebraicExpression_Clone(exp);
+	_InplaceRepurposeOperandToOperation(exp, AL_EXP_TRANSPOSE);
+
+	/* Add original operand as a child of exp (which is now a transpose operation).
+	 * Transpose(A) */
+	AlgebraicExpression_AddChild(exp, operand);
+}
+
+static void _Pushdown_TransposeExp
+(
+	AlgebraicExpression *exp
+) {
+	switch(exp->type) {
+	case AL_OPERATION:
+		_Pushdown_TransposeOperation(exp);
+		break;
+	case AL_OPERAND:
+		_Pushdown_TransposeOperand(exp);
+		break;
+	default:
+		assert("unknown algebraic expression node type" && false);
+		break;
+	}
+}
+
 /* Push down transpose operations to the point where they are applied to individual operands
  * once this optimization is applied there shouldn't be instances of transpose acting on
  * operation nodes such as multiplication and addition.
@@ -290,15 +391,15 @@ static void _AlgebraicExpression_PushDownTranspose(AlgebraicExpression *root) {
 				/* Transpose operation:
 				 * Transpose(A + B) = Transpose(A) + Transpose(B)
 				 * Transpose(A * B) = Transpose(B) * Transpose(A) */
-				AlgebraicExpression_Transpose(child);
+				_Pushdown_TransposeExp(child);
 				/* Replace Transpose root with transposed expression.
 				 * Remove root only child. */
 				_AlgebraicExpression_OperationRemoveRightmostChild(root);
 				_AlgebraicExpression_InplaceRepurpose(root, child);
 
-				/* Note, there's no need to dig deep into `root` sub-expression
-				 * looking for additional transpose nodes, as calling
-				 * AlgebraicExpression_Transpose will remove all of those. */
+				/* It is possible for `root` to contain a transpose subexpression
+				 * push it further down. */
+				_AlgebraicExpression_PushDownTranspose(root);
 			}
 			break;
 		default:

--- a/src/arithmetic/algebraic_expression/algebraic_expression_transpose.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_transpose.c
@@ -8,115 +8,15 @@
 #include "utils.h"
 #include "../../util/arr.h"
 
-// Transpose addition.
-static void _AlgebraicExpression_TransposeAddition
-(
-	AlgebraicExpression *exp
-) {
-	// T(A + B) = T(A) + T(B)
-	// Transpose children.
-	uint child_count = AlgebraicExpression_ChildCount(exp);
-	for(uint i = 0; i < child_count; i++) AlgebraicExpression_Transpose(exp->operation.children[i]);
-}
-
-// Transpose multiplication.
-static void _AlgebraicExpression_TransposeMultiplication
-(
-	AlgebraicExpression *exp
-) {
-	// Swap children, Transpose(A * B) = Transpose(B) * Transpose(A)
-	array_reverse(exp->operation.children);
-	// Transpose children.
-	uint child_count = AlgebraicExpression_ChildCount(exp);
-	for(uint i = 0; i < child_count; i++) AlgebraicExpression_Transpose(exp->operation.children[i]);
-}
-
-// Transpose transpose.
-static void _AlgebraicExpression_TransposeTranspose
-(
-	AlgebraicExpression *exp
-) {
-	// T(T(A)) = A
-	// Expecting just a single operand.
-	assert(AlgebraicExpression_ChildCount(exp) == 1);
-	AlgebraicExpression *only_child = AlgebraicExpression_RemoveRightmostNode(&exp);
-
-	assert(only_child->type == AL_OPERAND);
-
-	// Swap src and dest.
-	const char *temp = only_child->operand.src;
-	only_child->operand.src = only_child->operand.dest;
-	only_child->operand.dest = temp;
-
-	// Replace Transpose operation with its child.
-	_AlgebraicExpression_InplaceRepurpose(exp, only_child);
-}
-
-// Transpose operation.
-static void _AlgebraicExpression_TransposeOperation
-(
-	AlgebraicExpression *exp
-) {
-	switch(exp->operation.op) {
-	case AL_EXP_ADD:
-		// T(A + B) = T(A) + T(B)
-		_AlgebraicExpression_TransposeAddition(exp);
-		break;
-	case AL_EXP_MUL:
-		_AlgebraicExpression_TransposeMultiplication(exp);
-		break;
-	case AL_EXP_TRANSPOSE:
-		_AlgebraicExpression_TransposeTranspose(exp);
-		break;
-	default:
-		assert("Unknown algebraic expression operation");
-		break;
-	}
-}
-
-// Transpose operand.
-static void _AlgebraicExpression_TransposeOperand
-(
-	AlgebraicExpression *exp
-) {
-	// No need to transpose a diagonal matrix.
-	if(exp->operand.diagonal) return;
-
-	// A -> Transpose(A)
-	// We're going to repourpose exp, make a clone.
-	AlgebraicExpression *operand = AlgebraicExpression_Clone(exp);
-	_InplaceRepurposeOperandToOperation(exp, AL_EXP_TRANSPOSE);
-
-	/* Add original operand as a child of exp (which is now a transpose operation).
-	 * Transpose(A) */
-	AlgebraicExpression_AddChild(exp, operand);
-
-	// Swap source and destination.
-	const char *temp = operand->operand.src;
-	operand->operand.src = operand->operand.dest;
-	operand->operand.dest = temp;
-}
-
-/* Transpose an entire expression recursively.
- * T(T(A)) = A
- * T(A + B) = T(A) + T(B)
- * T(A * B) = T(B) * T(B) */
+/* Transpose expression
+ * Wraps expression with a transpose operation
+ * Transpose(exp) */
 void AlgebraicExpression_Transpose
 (
-	AlgebraicExpression *exp    // Expression to transpose.
+	AlgebraicExpression **exp    // Expression to transpose.
 ) {
 	assert(exp);
-
-	switch(exp->type) {
-	case AL_OPERATION:
-		_AlgebraicExpression_TransposeOperation(exp);
-		break;
-
-	case AL_OPERAND:
-		_AlgebraicExpression_TransposeOperand(exp);
-		break;
-
-	default:
-		assert("Unknow algebraic expression node type" && false);
-	}
+	AlgebraicExpression *root = AlgebraicExpression_NewOperation(AL_EXP_TRANSPOSE);
+	AlgebraicExpression_AddChild(root, *exp);
+	*exp = root;
 }

--- a/tests/flow/test_bidirectional_traversals.py
+++ b/tests/flow/test_bidirectional_traversals.py
@@ -340,3 +340,15 @@ class testBidirectionalTraversals(FlowTestsBase):
         query = """MATCH (a)-[e:E]-(b) RETURN e.val, a.val, b.val ORDER BY e.val, a.val, b.val"""
         traverse_result = acyclic_graph.query(query)
         self.env.assertEquals(actual_result.result_set, traverse_result.result_set)
+
+    def test13_multiple_bidirectional_edges(self):
+        # Traverse over 2 bidirectional edges.
+        query = """MATCH (a)-[]-()-[]-(c) RETURN a.val, c.val ORDER BY a.val, c.val"""
+
+        actual_result = acyclic_graph.query(query)
+        expected_result = [['v1', 'v1'],
+                           ['v1', 'v3'],
+                           ['v2', 'v2'],
+                           ['v3', 'v1'],
+                           ['v3', 'v3']]
+        self.env.assertEquals(actual_result.result_set, expected_result)

--- a/tests/unit/test_traversal_ordering.cpp
+++ b/tests/unit/test_traversal_ordering.cpp
@@ -224,7 +224,8 @@ TEST_F(TraversalOrderingTest, FilterFirst) {
 	filters = build_filter_tree_from_query("MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE B.val = 1 RETURN *");
 
 	orderExpressions(qg, set, 3, filters, NULL);
-	ASSERT_TRUE(set[0] == ExpAB || set[0] == ExpBC);
+    
+    ASSERT_STREQ(AlgebraicExpression_Source(set[0]), "B");
 
 	FilterTree_Free(filters);
 
@@ -236,7 +237,7 @@ TEST_F(TraversalOrderingTest, FilterFirst) {
 	filters = build_filter_tree_from_query("MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE C.val = 1 RETURN *");
 
 	orderExpressions(qg, set, 3, filters, NULL);
-	ASSERT_TRUE(set[0] == ExpBC || set[0] == ExpCD);
+    ASSERT_STREQ(AlgebraicExpression_Source(set[0]), "C");
 
 	FilterTree_Free(filters);
 
@@ -249,9 +250,7 @@ TEST_F(TraversalOrderingTest, FilterFirst) {
 
 	orderExpressions(qg, set, 3, filters, NULL);
 
-	ASSERT_EQ(set[0], ExpCD);
-	ASSERT_EQ(set[1], ExpBC);
-	ASSERT_EQ(set[2], ExpAB);
+	ASSERT_STREQ(AlgebraicExpression_Source(set[0]), "D");
 
 	// Clean up.
 	FilterTree_Free(filters);


### PR DESCRIPTION
…ion, maintain expression structure
Fixes #1096 

We used to propagate transpose effect e.g. swap operands and domains whenever we added a transpose operation to an expression, with this change transpose operation is no different from any other operation when introduce, source and destination domains of an expression are computed by traversing an expression, we would like to maintain operand domains regardless if they are transposed.