### PR TITLE
Skip NULL-valued properties in bulk loader

### DIFF
--- a/src/bulk_insert/bulk_insert.c
+++ b/src/bulk_insert/bulk_insert.c
@@ -68,8 +68,6 @@ static inline SIValue _BulkInsert_ReadProperty(const char *data, size_t *data_id
 	TYPE t = data[*data_idx];
 	*data_idx += 1;
 	if(t == BI_NULL) {
-		// TODO This property will currently get entered with a NULL key.
-		// Update so that the entire key-value pair is omitted from the node
 		v = SI_NullVal();
 	} else if(t == BI_BOOL) {
 		bool b = data[*data_idx];
@@ -108,6 +106,7 @@ int _BulkInsert_ProcessNodeFile(RedisModuleCtx *ctx, GraphContext *gc, const cha
 		Graph_CreateNode(gc->g, label_id, &n);
 		for(unsigned int i = 0; i < prop_count; i++) {
 			SIValue value = _BulkInsert_ReadProperty(data, &data_idx);
+			if (SI_TYPE(value) == T_NULL) continue; // Don't insert null values.
 			GraphEntity_AddProperty((GraphEntity *)&n, prop_indicies[i], value);
 		}
 	}

--- a/src/bulk_insert/bulk_insert.c
+++ b/src/bulk_insert/bulk_insert.c
@@ -106,7 +106,9 @@ int _BulkInsert_ProcessNodeFile(RedisModuleCtx *ctx, GraphContext *gc, const cha
 		Graph_CreateNode(gc->g, label_id, &n);
 		for(unsigned int i = 0; i < prop_count; i++) {
 			SIValue value = _BulkInsert_ReadProperty(data, &data_idx);
-			if (SI_TYPE(value) == T_NULL) continue; // Don't insert null values.
+			// Cypher does not support NULL as a property value.
+			// If we encounter one here, simply skip it.
+			if(SI_TYPE(value) == T_NULL) continue;
 			GraphEntity_AddProperty((GraphEntity *)&n, prop_indicies[i], value);
 		}
 	}
@@ -143,6 +145,9 @@ int _BulkInsert_ProcessRelationFile(RedisModuleCtx *ctx, GraphContext *gc, const
 		// Process and add relation properties
 		for(unsigned int i = 0; i < prop_count; i ++) {
 			SIValue value = _BulkInsert_ReadProperty(data, &data_idx);
+			// Cypher does not support NULL as a property value.
+			// If we encounter one here, simply skip it.
+			if(SI_TYPE(value) == T_NULL) continue;
 			GraphEntity_AddProperty((GraphEntity *)&e, prop_indicies[i], value);
 		}
 	}


### PR DESCRIPTION
Minor update to bulk loader logic to skip invalid creation of NULL-valued properties, as this is not a valid Cypher construct.