### PR TITLE
Perform one-time transpose of traversed matrices

### DIFF
--- a/src/arithmetic/algebraic_expression.h
+++ b/src/arithmetic/algebraic_expression.h
@@ -34,6 +34,7 @@ struct AlgebraicExpression {
 	union {
 		struct {
 			bool diagonal;          // Diagonal matrix.
+			bool should_free; // TODO use or delete
 			GrB_Matrix matrix;      // Matrix operand.
 			const char *src;        // Alias given to operand's rows (src node).
 			const char *dest;       // Alias given to operand's columns (destination node).
@@ -214,6 +215,10 @@ void AlgebraicExpression_Eval
 (
 	const AlgebraicExpression *exp, // Root node.
 	GrB_Matrix res                  // Result output.
+);
+
+void AlgebraicExpression_Initialize(
+	AlgebraicExpression **exp       // Expression to prep for evaluation.
 );
 
 //------------------------------------------------------------------------------

--- a/src/arithmetic/algebraic_expression.h
+++ b/src/arithmetic/algebraic_expression.h
@@ -34,7 +34,7 @@ struct AlgebraicExpression {
 	union {
 		struct {
 			bool diagonal;          // Diagonal matrix.
-			bool should_free;       // If the matrix is scoped to this expression, it should be freed with it.
+			bool bfree;             // If the matrix is scoped to this expression, it should be freed with it.
 			GrB_Matrix matrix;      // Matrix operand.
 			const char *src;        // Alias given to operand's rows (src node).
 			const char *dest;       // Alias given to operand's columns (destination node).
@@ -42,7 +42,7 @@ struct AlgebraicExpression {
 			const char *label;      // Label attached to matrix.
 		} operand;
 		struct {
-			AL_EXP_OP op;                       // Operation: `*`,`+`,`transpose`
+			AL_EXP_OP op;                   // Operation: `*`,`+`,`transpose`
 			AlgebraicExpression **children; // Child nodes.
 		} operation;
 	};
@@ -215,11 +215,6 @@ void AlgebraicExpression_Eval
 (
 	const AlgebraicExpression *exp, // Root node.
 	GrB_Matrix res                  // Result output.
-);
-
-void AlgebraicExpression_Initialize(
-	AlgebraicExpression **exp,      // Expression to prep for evaluation.
-	GrB_Matrix filter_matrix       // Filter matrix for leftmost multiplication.
 );
 
 //------------------------------------------------------------------------------

--- a/src/arithmetic/algebraic_expression.h
+++ b/src/arithmetic/algebraic_expression.h
@@ -218,7 +218,8 @@ void AlgebraicExpression_Eval
 );
 
 void AlgebraicExpression_Initialize(
-	AlgebraicExpression **exp       // Expression to prep for evaluation.
+	AlgebraicExpression **exp,      // Expression to prep for evaluation.
+	GrB_Matrix filter_matrix       // Filter matrix for leftmost multiplication.
 );
 
 //------------------------------------------------------------------------------

--- a/src/arithmetic/algebraic_expression.h
+++ b/src/arithmetic/algebraic_expression.h
@@ -32,14 +32,14 @@ typedef struct AlgebraicExpression AlgebraicExpression;
 
 struct AlgebraicExpression {
 	union {
-        struct {
-            bool diagonal;          // Diagonal matrix.
-		    GrB_Matrix matrix;      // Matrix operand.
-            const char *src;        // Alias given to operand's rows (src node).
-            const char *dest;       // Alias given to operand's columns (destination node).
-            const char *edge;       // Alias given to operand (edge).
-            const char *label;      // Label attached to matrix.
-        } operand;
+		struct {
+			bool diagonal;          // Diagonal matrix.
+			GrB_Matrix matrix;      // Matrix operand.
+			const char *src;        // Alias given to operand's rows (src node).
+			const char *dest;       // Alias given to operand's columns (destination node).
+			const char *edge;       // Alias given to operand (edge).
+			const char *label;      // Label attached to matrix.
+		} operand;
 		struct {
 			AL_EXP_OP op;                       // Operation: `*`,`+`,`transpose`
 			AlgebraicExpression **children; // Child nodes.
@@ -65,24 +65,24 @@ AlgebraicExpression **AlgebraicExpression_FromQueryGraph
 // Create a new AlgebraicExpression operation node.
 AlgebraicExpression *AlgebraicExpression_NewOperation
 (
-    AL_EXP_OP op    // Operation to perform.
+	AL_EXP_OP op    // Operation to perform.
 );
 
 // Create a new AlgebraicExpression operand node.
 AlgebraicExpression *AlgebraicExpression_NewOperand
 (
-    GrB_Matrix mat,     // Matrix.
-    bool diagonal,      // Is operand a diagonal matrix?
-    const char *src,    // Operand row domain (src node).
-    const char *dest,   // Operand column domain (destination node).
-    const char *edge,   // Operand alias (edge).
-    const char *label   // Label attached to matrix.
+	GrB_Matrix mat,     // Matrix.
+	bool diagonal,      // Is operand a diagonal matrix?
+	const char *src,    // Operand row domain (src node).
+	const char *dest,   // Operand column domain (destination node).
+	const char *edge,   // Operand alias (edge).
+	const char *label   // Label attached to matrix.
 );
 
 // Clone algebraic expression node.
 AlgebraicExpression *AlgebraicExpression_Clone
 (
-    const AlgebraicExpression *exp  // Expression to clone.
+	const AlgebraicExpression *exp  // Expression to clone.
 );
 
 //------------------------------------------------------------------------------
@@ -92,59 +92,59 @@ AlgebraicExpression *AlgebraicExpression_Clone
 // Returns the source entity alias represented by the left-most operand (row domain).
 const char *AlgebraicExpression_Source
 (
-    AlgebraicExpression *root   // Root of expression.
+	AlgebraicExpression *root   // Root of expression.
 );
 
 // Returns the destination entity alias represented by the right-most operand (column domain).
 const char *AlgebraicExpression_Destination
 (
-    AlgebraicExpression *root   // Root of expression.
+	AlgebraicExpression *root   // Root of expression.
 );
 
 /* Returns the first edge alias encountered.
  * if no edge alias is found NULL is returned. */
 const char *AlgebraicExpression_Edge
 (
-    const AlgebraicExpression *root   // Root of expression.
+	const AlgebraicExpression *root   // Root of expression.
 );
 
 // Returns the number of child nodes directly under root.
 uint AlgebraicExpression_ChildCount
 (
-    const AlgebraicExpression *root   // Root of expression.
+	const AlgebraicExpression *root   // Root of expression.
 );
 
 // Returns the number of operands in expression.
 uint AlgebraicExpression_OperandCount
 (
-    const AlgebraicExpression *root   // Root of expression.
+	const AlgebraicExpression *root   // Root of expression.
 );
 
 // Returns the number of operations of given type in expression.
 uint AlgebraicExpression_OperationCount
 (
-    const AlgebraicExpression *root,    // Root of expression.
-    AL_EXP_OP op_type                   // Type of operation.
+	const AlgebraicExpression *root,    // Root of expression.
+	AL_EXP_OP op_type                   // Type of operation.
 );
 
 // Returns true if entire expression is transposed.
 bool AlgebraicExpression_Transposed
 (
-    const AlgebraicExpression *root   // Root of expression.
+	const AlgebraicExpression *root   // Root of expression.
 );
 
 // Returns true if expression contains an operation of type `op`.
 bool AlgebraicExpression_ContainsOp
 (
-    const AlgebraicExpression *root,    // Root of expression.
-    AL_EXP_OP op                        // Operation to look for.
+	const AlgebraicExpression *root,    // Root of expression.
+	AL_EXP_OP op                        // Operation to look for.
 );
 
 // Checks to see if operand at position `operand_idx` is a diagonal matrix.
 bool AlgebraicExpression_DiagonalOperand
 (
-    const AlgebraicExpression *root,    // Root of expression.
-    uint operand_idx                    // Operand position (LTR, zero based).
+	const AlgebraicExpression *root,    // Root of expression.
+	uint operand_idx                    // Operand position (LTR, zero based).
 );
 
 //------------------------------------------------------------------------------
@@ -154,35 +154,35 @@ bool AlgebraicExpression_DiagonalOperand
 // Adds child node to root children list.
 void AlgebraicExpression_AddChild
 (
-    AlgebraicExpression *root,  // Root to attach child to.
-    AlgebraicExpression *child  // Child node to attach.
+	AlgebraicExpression *root,  // Root to attach child to.
+	AlgebraicExpression *child  // Child node to attach.
 );
 
 // Remove leftmost child node from root.
 AlgebraicExpression *AlgebraicExpression_RemoveLeftmostNode
 (
-    AlgebraicExpression **root   // Root from which to remove a child.
+	AlgebraicExpression **root   // Root from which to remove a child.
 );
 
 // Remove rightmost child node from root.
 AlgebraicExpression *AlgebraicExpression_RemoveRightmostNode
 (
-    AlgebraicExpression **root   // Root from which to remove a child.
+	AlgebraicExpression **root   // Root from which to remove a child.
 );
 
 // Multiply expression to the left by operand
 // m * (exp)
 void AlgebraicExpression_MultiplyToTheLeft
 (
-    AlgebraicExpression **root,
-    GrB_Matrix m
+	AlgebraicExpression **root,
+	GrB_Matrix m
 );
 
 // Multiply expression to the right by operand
 // (exp) * m
 void AlgebraicExpression_MultiplyToTheRight
 (
-    AlgebraicExpression **root,
+	AlgebraicExpression **root,
 	GrB_Matrix m
 );
 
@@ -190,15 +190,15 @@ void AlgebraicExpression_MultiplyToTheRight
 // m + (exp)
 void AlgebraicExpression_AddToTheLeft
 (
-    AlgebraicExpression **root,
-    GrB_Matrix m
+	AlgebraicExpression **root,
+	GrB_Matrix m
 );
 
 // Add expression to the right by operand
 // (exp) + m
 void AlgebraicExpression_AddToTheRight
 (
-    AlgebraicExpression **root,
+	AlgebraicExpression **root,
 	GrB_Matrix m
 );
 
@@ -206,14 +206,14 @@ void AlgebraicExpression_AddToTheRight
 // By wrapping exp in a transpose root node.
 void AlgebraicExpression_Transpose
 (
-    AlgebraicExpression **exp    // Expression to transpose.
+	AlgebraicExpression **exp    // Expression to transpose.
 );
 
 // Evaluate expression tree.
 void AlgebraicExpression_Eval
 (
-    const AlgebraicExpression *exp, // Root node.
-    GrB_Matrix res                  // Result output.
+	const AlgebraicExpression *exp, // Root node.
+	GrB_Matrix res                  // Result output.
 );
 
 //------------------------------------------------------------------------------
@@ -224,26 +224,26 @@ void AlgebraicExpression_Eval
 // e.g. B*T(B+A)
 AlgebraicExpression *AlgebraicExpression_FromString
 (
-    const char *exp,    // String representation of expression.
-    rax *matrices       // Map of matrices referred to in expression.
+	const char *exp,    // String representation of expression.
+	rax *matrices       // Map of matrices referred to in expression.
 );
 
 // Print a tree structure of algebraic expression to stdout.
 void AlgebraicExpression_PrintTree
 (
-    const AlgebraicExpression *exp  // Root node.
+	const AlgebraicExpression *exp  // Root node.
 );
 
 // Print algebraic expression to stdout.
 void AlgebraicExpression_Print
 (
-    const AlgebraicExpression *exp  // Root node.
+	const AlgebraicExpression *exp  // Root node.
 );
 
 // Return a string representation of expression.
 char *AlgebraicExpression_ToString
 (
-    const AlgebraicExpression *exp  // Root node.
+	const AlgebraicExpression *exp  // Root node.
 );
 
 //------------------------------------------------------------------------------
@@ -251,7 +251,7 @@ char *AlgebraicExpression_ToString
 //------------------------------------------------------------------------------
 void AlgebraicExpression_Optimize
 (
-    AlgebraicExpression **exp   // Expression to optimize.
+	AlgebraicExpression **exp   // Expression to optimize.
 );
 
 //------------------------------------------------------------------------------
@@ -261,5 +261,6 @@ void AlgebraicExpression_Optimize
 // Free algebraic expression.
 void AlgebraicExpression_Free
 (
-    AlgebraicExpression *root  // Root node.
+	AlgebraicExpression *root  // Root node.
 );
+

--- a/src/arithmetic/algebraic_expression.h
+++ b/src/arithmetic/algebraic_expression.h
@@ -23,8 +23,8 @@ typedef enum {
 
 // Type of node within an algebraic expression
 typedef enum {
-	AL_OPERAND,
-	AL_OPERATION,
+	AL_OPERAND = 1,
+	AL_OPERATION  = (1 << 1),
 } AlgebraicExpressionType;
 
 /* Forward declarations. */
@@ -34,7 +34,7 @@ struct AlgebraicExpression {
 	union {
 		struct {
 			bool diagonal;          // Diagonal matrix.
-			bool should_free; // TODO use or delete
+			bool should_free;       // If the matrix is scoped to this expression, it should be freed with it.
 			GrB_Matrix matrix;      // Matrix operand.
 			const char *src;        // Alias given to operand's rows (src node).
 			const char *dest;       // Alias given to operand's columns (destination node).
@@ -256,11 +256,6 @@ char *AlgebraicExpression_ToString
 // AlgebraicExpression optimizations
 //------------------------------------------------------------------------------
 void AlgebraicExpression_Optimize
-(
-	AlgebraicExpression **exp   // Expression to optimize.
-);
-
-void AlgebraicExpression_InitialOptimize
 (
 	AlgebraicExpression **exp   // Expression to optimize.
 );

--- a/src/arithmetic/algebraic_expression.h
+++ b/src/arithmetic/algebraic_expression.h
@@ -254,6 +254,11 @@ void AlgebraicExpression_Optimize
 	AlgebraicExpression **exp   // Expression to optimize.
 );
 
+void AlgebraicExpression_InitialOptimize
+(
+	AlgebraicExpression **exp   // Expression to optimize.
+);
+
 //------------------------------------------------------------------------------
 // AlgebraicExpression free
 //------------------------------------------------------------------------------

--- a/src/arithmetic/algebraic_expression/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression.c
@@ -149,31 +149,6 @@ static const char *_AlgebraicExpression_Operation_Source
 	}
 }
 
-/*
-// Returns the source entity alias, row domain.
-const char *AlgebraicExpression_Source
-(
-	AlgebraicExpression *root   // Root of expression.
-) {
-	assert(root);
-	while(root->type != AL_OPERAND) {
-		root = FIRST_CHILD(root);
-	}
-	return root->operand.src;
-}
-
-// Returns the destination entity alias represented by the right-most operand column domain.
-const char *AlgebraicExpression_Destination
-(
-	AlgebraicExpression *root   // Root of expression.
-) {
-	assert(root);
-	while(root->type != AL_OPERAND) {
-		root = LAST_CHILD(root);
-	}
-	return root->operand.dest;
-}
-*/
 // Returns the source entity alias (row domain)
 // Taking into consideration transpose
 static const char *_AlgebraicExpression_Operand_Source
@@ -198,7 +173,7 @@ static const char *_AlgebraicExpression_Source
 	case AL_OPERAND:
 		return _AlgebraicExpression_Operand_Source(root, transposed);
 	default:
-		assert("Unknow algebraic expression node type" && false);
+		assert("Unknown algebraic expression node type" && false);
 	}
 }
 

--- a/src/arithmetic/algebraic_expression/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression.c
@@ -53,8 +53,11 @@ static AlgebraicExpression *_AlgebraicExpression_CloneOperand
 (
 	const AlgebraicExpression *exp
 ) {
-	return AlgebraicExpression_NewOperand(exp->operand.matrix, exp->operand.diagonal, exp->operand.src,
-										  exp->operand.dest, exp->operand.edge, exp->operand.label);
+	AlgebraicExpression *clone = AlgebraicExpression_NewOperand(exp->operand.matrix,
+																exp->operand.diagonal, exp->operand.src,
+																exp->operand.dest, exp->operand.edge, exp->operand.label);
+	clone->operand.should_free = exp->operand.should_free;
+	return clone;
 }
 
 //------------------------------------------------------------------------------
@@ -87,6 +90,7 @@ AlgebraicExpression *AlgebraicExpression_NewOperand
 	node->type = AL_OPERAND;
 	node->operand.matrix = mat;
 	node->operand.diagonal = diagonal;
+	node->operand.should_free = false;
 	node->operand.src = src;
 	node->operand.dest = dest;
 	node->operand.edge = edge;
@@ -147,6 +151,31 @@ static const char *_AlgebraicExpression_Operation_Source
 	}
 }
 
+/*
+// Returns the source entity alias, row domain.
+const char *AlgebraicExpression_Source
+(
+	AlgebraicExpression *root   // Root of expression.
+) {
+	assert(root);
+	while(root->type != AL_OPERAND) {
+		root = FIRST_CHILD(root);
+	}
+	return root->operand.src;
+}
+
+// Returns the destination entity alias represented by the right-most operand column domain.
+const char *AlgebraicExpression_Destination
+(
+	AlgebraicExpression *root   // Root of expression.
+) {
+	assert(root);
+	while(root->type != AL_OPERAND) {
+		root = LAST_CHILD(root);
+	}
+	return root->operand.dest;
+}
+*/
 // Returns the source entity alias (row domain)
 // Taking into consideration transpose
 static const char *_AlgebraicExpression_Operand_Source

--- a/src/arithmetic/algebraic_expression/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression.c
@@ -108,7 +108,7 @@ AlgebraicExpression *AlgebraicExpression_Clone
 		return _AlgebraicExpression_CloneOperand(exp);
 		break;
 	default:
-		assert("Unknow algebraic expression node type" && false);
+		assert("Unknown algebraic expression node type" && false);
 		break;
 	}
 	return NULL;
@@ -373,7 +373,7 @@ AlgebraicExpression *AlgebraicExpression_RemoveLeftmostNode
 				AlgebraicExpression *replacement = _AlgebraicExpression_OperationRemoveRightmostChild(prev);
 				_AlgebraicExpression_InplaceRepurpose(prev, replacement);
 			} else {
-				assert("for the timebing, we should not be here" && false);
+				assert("for the time being, we should not be here" && false);
 			}
 		}
 	}

--- a/src/arithmetic/algebraic_expression/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression.c
@@ -53,10 +53,8 @@ static AlgebraicExpression *_AlgebraicExpression_CloneOperand
 (
 	const AlgebraicExpression *exp
 ) {
-	AlgebraicExpression *clone = AlgebraicExpression_NewOperand(exp->operand.matrix,
-																exp->operand.diagonal, exp->operand.src,
-																exp->operand.dest, exp->operand.edge, exp->operand.label);
-	clone->operand.should_free = exp->operand.should_free;
+	AlgebraicExpression *clone = rm_malloc(sizeof(AlgebraicExpression));
+	memcpy(clone, exp, sizeof(AlgebraicExpression));
 	return clone;
 }
 

--- a/src/arithmetic/algebraic_expression/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression.c
@@ -88,7 +88,7 @@ AlgebraicExpression *AlgebraicExpression_NewOperand
 	node->type = AL_OPERAND;
 	node->operand.matrix = mat;
 	node->operand.diagonal = diagonal;
-	node->operand.should_free = false;
+	node->operand.bfree = false;
 	node->operand.src = src;
 	node->operand.dest = dest;
 	node->operand.edge = edge;

--- a/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
@@ -35,8 +35,8 @@ static GrB_Matrix _Eval_Add(const AlgebraicExpression *exp, GrB_Matrix res) {
 	GrB_Matrix a = GrB_NULL;        // Left operand.
 	GrB_Matrix b = GrB_NULL;        // Right operand.
 	GrB_Matrix inter = GrB_NULL;    // Intermediate matrix.
-	GrB_Descriptor desc = GrB_NULL; // Descriptor used for transposing operands (currently unused).
 	bool res_in_use = false;        // Can we use `res` for intermediate evaluation.
+	GrB_Descriptor desc = GrB_NULL; // Descriptor used for transposing operands (currently unused).
 
 	// Get left and right operands.
 	AlgebraicExpression *left = CHILD_AT(exp, 0);
@@ -158,6 +158,8 @@ static GrB_Matrix _Eval_Mul(const AlgebraicExpression *exp, GrB_Matrix res) {
 	B = right->operand.matrix;
 
 	if(B == IDENTITY_MATRIX) {
+		// Reset descriptor, as the identity matrix does not need to be transposed.
+		if(desc != GrB_NULL) GrB_Descriptor_set(desc, GrB_INP1, GxB_DEFAULT);
 		// B is the identity matrix, Perform A * I.
 		info = GrB_Matrix_apply(res, GrB_NULL, GrB_NULL, GrB_IDENTITY_BOOL, A, desc);
 		if(info != GrB_SUCCESS) {
@@ -195,6 +197,8 @@ static GrB_Matrix _Eval_Mul(const AlgebraicExpression *exp, GrB_Matrix res) {
 		B = right->operand.matrix;
 
 		if(B != IDENTITY_MATRIX) {
+			// Reset descriptor, as the identity matrix does not need to be transposed.
+			if(desc != GrB_NULL) GrB_Descriptor_set(desc, GrB_INP1, GxB_DEFAULT);
 			// Perform multiplication.
 			info = GrB_mxm(res, GrB_NULL, GrB_NULL, GxB_ANY_PAIR_BOOL, res, B, desc);
 			if(info != GrB_SUCCESS) {

--- a/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
@@ -35,6 +35,7 @@ static GrB_Matrix _Eval_Add(const AlgebraicExpression *exp, GrB_Matrix res) {
 	GrB_Matrix a = GrB_NULL;        // Left operand.
 	GrB_Matrix b = GrB_NULL;        // Right operand.
 	GrB_Matrix inter = GrB_NULL;    // Intermediate matrix.
+	GrB_Descriptor desc = GrB_NULL; // Descriptor used for transposing operands (currently unused).
 	bool res_in_use = false;        // Can we use `res` for intermediate evaluation.
 
 	// Get left and right operands.
@@ -46,46 +47,67 @@ static GrB_Matrix _Eval_Add(const AlgebraicExpression *exp, GrB_Matrix res) {
 	if(left->type == AL_OPERAND) {
 		a = left->operand.matrix;
 	} else {
-		a = _AlgebraicExpression_Eval(left, res);
-		res_in_use = true;
+		if(left->operation.op == AL_EXP_TRANSPOSE) {
+			a = left->operation.children[0]->operand.matrix;
+			if(desc == GrB_NULL) GrB_Descriptor_new(&desc);
+			GrB_Descriptor_set(desc, GrB_INP0, GrB_TRAN);
+		} else {
+			a = _AlgebraicExpression_Eval(left, res);
+			res_in_use = true;
+		}
 	}
 
 	/* If right operand is a matrix, simply get it.
 	 * Otherwise evaluate right hand side using `res` if free or create an additional matrix to store RHS value. */
 	if(right->type == AL_OPERAND) {
 		b = right->operand.matrix;
-	} else if(res_in_use) {
-		// `res` is in use, create an additional matrix.
-		GrB_Matrix_nrows(&nrows, a);
-		GrB_Matrix_ncols(&ncols, a);
-		info = GrB_Matrix_new(&inter, GrB_BOOL, nrows, ncols);
-		if(info != GrB_SUCCESS) {
-			fprintf(stderr, "%s", GrB_error());
-			assert(false);
-		}
-		b = _AlgebraicExpression_Eval(right, inter);
 	} else {
-		// `res` is not used just yet, use it for RHS evaluation.
-		b = _AlgebraicExpression_Eval(right, res);
+		if(right->operation.op == AL_EXP_TRANSPOSE) {
+			b = right->operation.children[0]->operand.matrix;
+			if(desc == GrB_NULL) GrB_Descriptor_new(&desc);
+			GrB_Descriptor_set(desc, GrB_INP1, GrB_TRAN);
+		} else if(res_in_use) {
+			// `res` is in use, create an additional matrix.
+			GrB_Matrix_nrows(&nrows, a);
+			GrB_Matrix_ncols(&ncols, a);
+			info = GrB_Matrix_new(&inter, GrB_BOOL, nrows, ncols);
+			if(info != GrB_SUCCESS) {
+				fprintf(stderr, "%s", GrB_error());
+				assert(false);
+			}
+			b = _AlgebraicExpression_Eval(right, inter);
+		} else {
+			// `res` is not used just yet, use it for RHS evaluation.
+			b = _AlgebraicExpression_Eval(right, res);
+		}
 	}
 
 	// Perform addition.
 	if(GrB_eWiseAdd_Matrix_Semiring(res, GrB_NULL, GrB_NULL, GxB_ANY_PAIR_BOOL, a, b,
-									GrB_NULL) != GrB_SUCCESS) {
+									desc) != GrB_SUCCESS) {
 		printf("Failed adding operands, error:%s\n", GrB_error());
 		assert(false);
 	}
 
+	// Reset descriptor if non-null.
+	if(desc != GrB_NULL) GrB_Descriptor_set(desc, GrB_INP0, GxB_DEFAULT);
+
 	uint child_count = AlgebraicExpression_ChildCount(exp);
 	// Expression has more than 2 operands, e.g. A+B+C...
 	for(uint i = 2; i < child_count; i++) {
+		// Reset descriptor if non-null.
+		if(desc != GrB_NULL) GrB_Descriptor_set(desc, GrB_INP1, GxB_DEFAULT);
 		right = CHILD_AT(exp, i);
 
 		if(right->type == AL_OPERAND) {
 			b = right->operand.matrix;
 		} else {
-			if(inter == GrB_NULL) {
-				// Can't use `res`, use an intermediate matrix.
+			if(right->operation.op == AL_EXP_TRANSPOSE) {
+				b = right->operation.children[0]->operand.matrix;
+				if(desc == GrB_NULL) GrB_Descriptor_new(&desc);
+				GrB_Descriptor_set(desc, GrB_INP1, GrB_TRAN);
+			} else if(inter == GrB_NULL) {
+				// Can't use `res`, use an intermidate matrix.
 				GrB_Matrix_nrows(&nrows, res);
 				GrB_Matrix_ncols(&ncols, res);
 				GrB_Matrix_new(&inter, GrB_BOOL, nrows, ncols);
@@ -102,6 +124,7 @@ static GrB_Matrix _Eval_Add(const AlgebraicExpression *exp, GrB_Matrix res) {
 	}
 
 	if(inter != GrB_NULL) GrB_Matrix_free(&inter);
+	if(desc != GrB_NULL) GrB_free(&desc);
 	return res;
 }
 
@@ -114,16 +137,29 @@ static GrB_Matrix _Eval_Mul(const AlgebraicExpression *exp, GrB_Matrix res) {
 	GrB_Matrix B;
 	GrB_Info info;
 	GrB_Index nvals;
+	GrB_Descriptor desc = GrB_NULL;
 	AlgebraicExpression *left = CHILD_AT(exp, 0);
 	AlgebraicExpression *right = CHILD_AT(exp, 1);
 
-	assert(left->type == AL_OPERAND && right->type == AL_OPERAND);
+	if(left->type == AL_OPERATION) {
+		assert(left->operation.op == AL_EXP_TRANSPOSE);
+		if(desc == GrB_NULL) GrB_Descriptor_new(&desc);
+		GrB_Descriptor_set(desc, GrB_INP0, GrB_TRAN);
+		left = CHILD_AT(left, 0);
+	}
 	A = left->operand.matrix;
+
+	if(right->type == AL_OPERATION) {
+		assert(right->operation.op == AL_EXP_TRANSPOSE);
+		if(desc == GrB_NULL) GrB_Descriptor_new(&desc);
+		GrB_Descriptor_set(desc, GrB_INP1, GrB_TRAN);
+		right = CHILD_AT(right, 0);
+	}
 	B = right->operand.matrix;
 
 	if(B == IDENTITY_MATRIX) {
 		// B is the identity matrix, Perform A * I.
-		info = GrB_Matrix_apply(res, GrB_NULL, GrB_NULL, GrB_IDENTITY_BOOL, A, GrB_NULL);
+		info = GrB_Matrix_apply(res, GrB_NULL, GrB_NULL, GrB_IDENTITY_BOOL, A, desc);
 		if(info != GrB_SUCCESS) {
 			// If the multiplication failed, print error info to stderr and exit.
 			fprintf(stderr, "Encountered an error in matrix multiplication:\n%s\n", GrB_error());
@@ -131,7 +167,7 @@ static GrB_Matrix _Eval_Mul(const AlgebraicExpression *exp, GrB_Matrix res) {
 		}
 	} else {
 		// Perform multiplication.
-		info = GrB_mxm(res, GrB_NULL, GrB_NULL, GxB_ANY_PAIR_BOOL, A, B, GrB_NULL);
+		info = GrB_mxm(res, GrB_NULL, GrB_NULL, GxB_ANY_PAIR_BOOL, A, B, desc);
 		if(info != GrB_SUCCESS) {
 			// If the multiplication failed, print error info to stderr and exit.
 			fprintf(stderr, "Encountered an error in matrix multiplication:\n%s\n", GrB_error());
@@ -141,15 +177,26 @@ static GrB_Matrix _Eval_Mul(const AlgebraicExpression *exp, GrB_Matrix res) {
 
 	GrB_Matrix_nvals(&nvals, res);
 
+	// Reset descriptor if non-null.
+	if(desc != GrB_NULL) GrB_Descriptor_set(desc, GrB_INP0, GxB_DEFAULT);
+
 	uint child_count = AlgebraicExpression_ChildCount(exp);
 	for(uint i = 2; i < child_count; i++) {
+		// Reset descriptor if non-null.
+		if(desc != GrB_NULL) GrB_Descriptor_set(desc, GrB_INP1, GxB_DEFAULT);
+
 		right = CHILD_AT(exp, i);
-		assert(right->type == AL_OPERAND);
+		if(right->type == AL_OPERATION) {
+			assert(right->operation.op == AL_EXP_TRANSPOSE);
+			if(desc == GrB_NULL) GrB_Descriptor_new(&desc);
+			GrB_Descriptor_set(desc, GrB_INP1, GrB_TRAN);
+			right = CHILD_AT(right, 0);
+		}
 		B = right->operand.matrix;
 
 		if(B != IDENTITY_MATRIX) {
 			// Perform multiplication.
-			info = GrB_mxm(res, GrB_NULL, GrB_NULL, GxB_ANY_PAIR_BOOL, res, B, GrB_NULL);
+			info = GrB_mxm(res, GrB_NULL, GrB_NULL, GxB_ANY_PAIR_BOOL, res, B, desc);
 			if(info != GrB_SUCCESS) {
 				// If the multiplication failed, print error info to stderr and exit.
 				fprintf(stderr, "Encountered an error in matrix multiplication:\n%s\n", GrB_error());
@@ -159,6 +206,8 @@ static GrB_Matrix _Eval_Mul(const AlgebraicExpression *exp, GrB_Matrix res) {
 		GrB_Matrix_nvals(&nvals, res);
 		if(nvals == 0) break;
 	}
+
+	if(desc != GrB_NULL) GrB_free(&desc);
 
 	return res;
 }

--- a/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
@@ -229,7 +229,8 @@ void AlgebraicExpression_Initialize(AlgebraicExpression **exp, GrB_Matrix filter
 
 	// Add placeholder operand to hold filter matrix as leftmost multiplication.
 	AlgebraicExpression_MultiplyToTheLeft(exp, filter_matrix);
-	// Perform one-time optimization of expression.
-	AlgebraicExpression_InitialOptimize(exp);
+
+	// Optimize the expression tree.
+	AlgebraicExpression_Optimize(exp);
 }
 

--- a/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
@@ -223,10 +223,12 @@ void AlgebraicExpression_Eval(const AlgebraicExpression *exp, GrB_Matrix res) {
 	_AlgebraicExpression_Eval(exp, res);
 }
 
-void AlgebraicExpression_Initialize(AlgebraicExpression **exp) {
+void AlgebraicExpression_Initialize(AlgebraicExpression **exp, GrB_Matrix filter_matrix) {
 	// On first evaluation we need to fetch operands.
 	_AlgebraicExpression_FetchOperands(*exp, QueryCtx_GetGraphCtx(), QueryCtx_GetGraph());
 
+	// Add placeholder operand to hold filter matrix as leftmost multiplication.
+	AlgebraicExpression_MultiplyToTheLeft(exp, filter_matrix);
 	// Perform one-time optimization of expression.
 	AlgebraicExpression_InitialOptimize(exp);
 }

--- a/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
@@ -179,9 +179,6 @@ GrB_Matrix _AlgebraicExpression_Eval(const AlgebraicExpression *exp, GrB_Matrix 
 			break;
 
 		case AL_EXP_TRANSPOSE:
-			// Transpose operations should have been replaced by transposed operands by this point.
-			assert("Encountered unexpected transpose operation." && false);
-			// TODO consider what to do about unused code paths
 			res = _Eval_Transpose(exp, res);
 			break;
 
@@ -202,16 +199,5 @@ GrB_Matrix _AlgebraicExpression_Eval(const AlgebraicExpression *exp, GrB_Matrix 
 void AlgebraicExpression_Eval(const AlgebraicExpression *exp, GrB_Matrix res) {
 	assert(exp && exp->type == AL_OPERATION);
 	_AlgebraicExpression_Eval(exp, res);
-}
-
-void AlgebraicExpression_Initialize(AlgebraicExpression **exp, GrB_Matrix filter_matrix) {
-	// On first evaluation we need to fetch operands.
-	_AlgebraicExpression_FetchOperands(*exp, QueryCtx_GetGraphCtx(), QueryCtx_GetGraph());
-
-	// Add placeholder operand to hold filter matrix as leftmost multiplication.
-	AlgebraicExpression_MultiplyToTheLeft(exp, filter_matrix);
-
-	// Optimize the expression tree.
-	AlgebraicExpression_Optimize(exp);
 }
 

--- a/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_eval.c
@@ -32,10 +32,10 @@ static GrB_Matrix _Eval_Add(const AlgebraicExpression *exp, GrB_Matrix res) {
 	GrB_Info info;
 	GrB_Index nrows;                // Number of rows of operand.
 	GrB_Index ncols;                // Number of columns of operand.
+	bool res_in_use = false;        // Can we use `res` for intermediate evaluation.
 	GrB_Matrix a = GrB_NULL;        // Left operand.
 	GrB_Matrix b = GrB_NULL;        // Right operand.
 	GrB_Matrix inter = GrB_NULL;    // Intermediate matrix.
-	bool res_in_use = false;        // Can we use `res` for intermediate evaluation.
 	GrB_Descriptor desc = GrB_NULL; // Descriptor used for transposing operands (currently unused).
 
 	// Get left and right operands.

--- a/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
@@ -506,12 +506,14 @@ static void _AlgebraicExpression_ApplyTranspose(AlgebraicExpression *root) {
 					 * T(T(A)) == A */
 					// Disconnect the intermediate transpose op and its child.
 					child = _AlgebraicExpression_OperationRemoveRightmostChild(root);
-					AlgebraicExpression *grandchild = _AlgebraicExpression_OperationRemoveRightmostChild(root);
+					AlgebraicExpression *grandchild = _AlgebraicExpression_OperationRemoveRightmostChild(child);
 					// Replace the current op with the grandchild.
 					_AlgebraicExpression_InplaceRepurpose(root, grandchild);
 					// Free the disconnected intermediate operation.
 					AlgebraicExpression_Free(child);
-					child = grandchild;
+					// The root has been replaced with the grandchild, and the intermediates have been freeed.
+					// Set the child pointer to root so that we can recurse properly.
+					child = root;
 				}
 
 				// Continue seeking transpose ops.

--- a/src/arithmetic/algebraic_expression/utils.c
+++ b/src/arithmetic/algebraic_expression/utils.c
@@ -163,7 +163,7 @@ void _AlgebraicExpression_FreeOperand
 	AlgebraicExpression *node
 ) {
 	assert(node && node->type == AL_OPERAND);
-	if(node->operand.should_free) GrB_Matrix_free(&node->operand.matrix);
+	if(node->operand.bfree) GrB_Matrix_free(&node->operand.matrix);
 }
 
 // Locate operand at position `operand_idx` counting from left to right.

--- a/src/arithmetic/algebraic_expression/utils.c
+++ b/src/arithmetic/algebraic_expression/utils.c
@@ -149,10 +149,10 @@ void _AlgebraicExpression_FreeOperation
 ) {
 	assert(node && node->type == AL_OPERATION);
 
-	// if(node->operation.op == AL_EXP_TRANSPOSE) {
-	// AlgebraicExpression *child = node->operation.children[0];
-	// if(child->operand.should_free) GrB_Matrix_free(&child->operand.matrix);
-	// }
+	if(node->operation.op == AL_EXP_TRANSPOSE) {
+		AlgebraicExpression *child = node->operation.children[0];
+		if(child->operand.should_free) GrB_Matrix_free(&child->operand.matrix);
+	}
 
 	if(node->operation.children) {
 		uint child_count = AlgebraicExpression_ChildCount(node);

--- a/src/arithmetic/algebraic_expression/utils.c
+++ b/src/arithmetic/algebraic_expression/utils.c
@@ -148,12 +148,6 @@ void _AlgebraicExpression_FreeOperation
 	AlgebraicExpression *node
 ) {
 	assert(node && node->type == AL_OPERATION);
-
-	if(node->operation.op == AL_EXP_TRANSPOSE) {
-		AlgebraicExpression *child = node->operation.children[0];
-		if(child->operand.should_free) GrB_Matrix_free(&child->operand.matrix);
-	}
-
 	if(node->operation.children) {
 		uint child_count = AlgebraicExpression_ChildCount(node);
 		for(uint i = 0; i < child_count; i++) {
@@ -169,6 +163,7 @@ void _AlgebraicExpression_FreeOperand
 	AlgebraicExpression *node
 ) {
 	assert(node && node->type == AL_OPERAND);
+	if(node->operand.should_free) GrB_Matrix_free(&node->operand.matrix);
 }
 
 // Locate operand at position `operand_idx` counting from left to right.

--- a/src/arithmetic/algebraic_expression/utils.c
+++ b/src/arithmetic/algebraic_expression/utils.c
@@ -149,6 +149,11 @@ void _AlgebraicExpression_FreeOperation
 ) {
 	assert(node && node->type == AL_OPERATION);
 
+	// if(node->operation.op == AL_EXP_TRANSPOSE) {
+	// AlgebraicExpression *child = node->operation.children[0];
+	// if(child->operand.should_free) GrB_Matrix_free(&child->operand.matrix);
+	// }
+
 	if(node->operation.children) {
 		uint child_count = AlgebraicExpression_ChildCount(node);
 		for(uint i = 0; i < child_count; i++) {

--- a/src/arithmetic/algebraic_expression/utils.h
+++ b/src/arithmetic/algebraic_expression/utils.h
@@ -24,7 +24,7 @@ void _InplaceRepurposeOperandToOperation
 // exp mustn't contain any children.
 void _AlgebraicExpression_InplaceRepurpose
 (
-    AlgebraicExpression *exp,           // Expression to repurpose.
+	AlgebraicExpression *exp,           // Expression to repurpose.
 	AlgebraicExpression *replacement    // Replacement expression taking over `exp`.
 );
 
@@ -106,7 +106,7 @@ AlgebraicExpression *_AlgebraicExpression_GetOperand
 // Resolves all missing operands.
 void _AlgebraicExpression_FetchOperands
 (
-    AlgebraicExpression *exp,   // Expression to resolve operands for.
-    const GraphContext *gc,     // Graph context.
-    Graph *g                    // Graph object.
+	AlgebraicExpression *exp,   // Expression to resolve operands for.
+	const GraphContext *gc,     // Graph context.
+	Graph *g                    // Graph object.
 );

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -44,9 +44,11 @@ void _traverse(CondTraverse *op) {
 		GrB_Matrix_new(&op->M, GrB_BOOL, op->recordsCap, required_dim);
 		GrB_Matrix_new(&op->F, GrB_BOOL, op->recordsCap, required_dim);
 
-		// Initialize the algebraic expression and
-		// prepend the filter matrix to the multiplication.
-		AlgebraicExpression_Initialize(&op->ae, op->F);
+		// Prepend the filter matrix to algebraic expression as the leftmost operand.
+		AlgebraicExpression_MultiplyToTheLeft(&op->ae, op->F);
+
+		// Optimize the expression tree.
+		AlgebraicExpression_Optimize(&op->ae);
 	}
 
 	// Populate filter matrix.

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -44,6 +44,12 @@ void _traverse(CondTraverse *op) {
 		GrB_Matrix_new(&op->F, GrB_BOOL, op->recordsCap, required_dim);
 	}
 
+	// If this is the first evaluation, initialize the expression.
+	if(!op->exp_initialized) {
+		AlgebraicExpression_Initialize(&op->ae);
+		op->exp_initialized = true;
+	}
+
 	// Populate filter matrix.
 	_populate_filter_matrix(op);
 	// Clone expression, as we're about to modify the structure with Optimize.
@@ -76,6 +82,7 @@ OpBase *NewCondTraverseOp(const ExecutionPlan *plan, Graph *g, AlgebraicExpressi
 	op->recordsCap = 0;
 	op->recordCount = 0;
 	op->edge_ctx = NULL;
+	op->exp_initialized = false;
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_CONDITIONAL_TRAVERSE, "Conditional Traverse", CondTraverseInit,

--- a/src/execution_plan/ops/op_conditional_traverse.h
+++ b/src/execution_plan/ops/op_conditional_traverse.h
@@ -17,12 +17,13 @@ typedef struct {
 	OpBase op;
 	Graph *graph;
 	AlgebraicExpression *ae;
+	bool exp_initialized;       // False until the expression has been evaluated once.
 	GrB_Matrix F;               // Filter matrix.
 	GrB_Matrix M;               // Algebraic expression result.
 	EdgeTraverseCtx *edge_ctx;  // Edge collection data if the edge needs to be set.
 	GxB_MatrixTupleIter *iter;  // Iterator over M.
 	int srcNodeIdx;             // Source node index into record.
-	int destNodeIdx;            // Destination  node index into record.
+	int destNodeIdx;            // Destination node index into record.
 	uint recordCount;           // Number of held records.
 	uint recordsCap;            // Max number of records to process.
 	Record *records;            // Array of records.

--- a/src/execution_plan/ops/op_conditional_traverse.h
+++ b/src/execution_plan/ops/op_conditional_traverse.h
@@ -17,7 +17,6 @@ typedef struct {
 	OpBase op;
 	Graph *graph;
 	AlgebraicExpression *ae;
-	bool exp_initialized;       // False until the expression has been evaluated once.
 	GrB_Matrix F;               // Filter matrix.
 	GrB_Matrix M;               // Algebraic expression result.
 	EdgeTraverseCtx *edge_ctx;  // Edge collection data if the edge needs to be set.

--- a/src/execution_plan/ops/op_expand_into.c
+++ b/src/execution_plan/ops/op_expand_into.c
@@ -44,6 +44,12 @@ static void _traverse(OpExpandInto *op) {
 		GrB_Matrix_new(&op->F, GrB_BOOL, op->recordsCap, required_dim);
 	}
 
+	// If this is the first evaluation, initialize the expression.
+	if(!op->exp_initialized) {
+		AlgebraicExpression_Initialize(&op->ae);
+		op->exp_initialized = true;
+	}
+
 	// Populate filter matrix.
 	_populate_filter_matrix(op);
 	// Clone expression, as we're about to modify the structure with Optimize.
@@ -71,6 +77,7 @@ OpBase *NewExpandIntoOp(const ExecutionPlan *plan, Graph *g, AlgebraicExpression
 	op->recordsCap = 0;
 	op->recordCount = 0;
 	op->edge_ctx = NULL;
+	op->exp_initialized = false;
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_EXPAND_INTO, "Expand Into", ExpandIntoInit, ExpandIntoConsume,

--- a/src/execution_plan/ops/op_expand_into.c
+++ b/src/execution_plan/ops/op_expand_into.c
@@ -37,31 +37,24 @@ static void _populate_filter_matrix(OpExpandInto *op) {
  * removed filter matrix from original expression
  * clears filter matrix. */
 static void _traverse(OpExpandInto *op) {
-	// Create both filter and result matrices.
+	// If op->F is null, this is the first time we are traversing.
 	if(op->F == GrB_NULL) {
+		// Create both filter and result matrices.
 		size_t required_dim = Graph_RequiredMatrixDim(op->graph);
 		GrB_Matrix_new(&op->M, GrB_BOOL, op->recordsCap, required_dim);
 		GrB_Matrix_new(&op->F, GrB_BOOL, op->recordsCap, required_dim);
-	}
 
-	// If this is the first evaluation, initialize the expression.
-	if(!op->exp_initialized) {
-		AlgebraicExpression_Initialize(&op->ae);
-		op->exp_initialized = true;
+		// Initialize the algebraic expression and
+		// prepend the filter matrix to the multiplication.
+		AlgebraicExpression_Initialize(&op->ae, op->F);
 	}
 
 	// Populate filter matrix.
 	_populate_filter_matrix(op);
-	// Clone expression, as we're about to modify the structure with Optimize.
-	AlgebraicExpression *clone = AlgebraicExpression_Clone(op->ae);
-	// Append filter matrix to algebraic expression, as the left most operand.
-	AlgebraicExpression_MultiplyToTheLeft(&clone, op->F);
-	// TODO: consider performing optimization as part of evaluation.
-	AlgebraicExpression_Optimize(&clone);
+
 	// Evaluate expression.
-	AlgebraicExpression_Eval(clone, op->M);
-	// Free clone.
-	AlgebraicExpression_Free(clone);
+	AlgebraicExpression_Eval(op->ae, op->M);
+
 	// Clear filter matrix.
 	GrB_Matrix_clear(op->F);
 }
@@ -77,7 +70,6 @@ OpBase *NewExpandIntoOp(const ExecutionPlan *plan, Graph *g, AlgebraicExpression
 	op->recordsCap = 0;
 	op->recordCount = 0;
 	op->edge_ctx = NULL;
-	op->exp_initialized = false;
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_EXPAND_INTO, "Expand Into", ExpandIntoInit, ExpandIntoConsume,

--- a/src/execution_plan/ops/op_expand_into.c
+++ b/src/execution_plan/ops/op_expand_into.c
@@ -44,9 +44,11 @@ static void _traverse(OpExpandInto *op) {
 		GrB_Matrix_new(&op->M, GrB_BOOL, op->recordsCap, required_dim);
 		GrB_Matrix_new(&op->F, GrB_BOOL, op->recordsCap, required_dim);
 
-		// Initialize the algebraic expression and
-		// prepend the filter matrix to the multiplication.
-		AlgebraicExpression_Initialize(&op->ae, op->F);
+		// Prepend the filter matrix to algebraic expression as the leftmost operand.
+		AlgebraicExpression_MultiplyToTheLeft(&op->ae, op->F);
+
+		// Optimize the expression tree.
+		AlgebraicExpression_Optimize(&op->ae);
 	}
 
 	// Populate filter matrix.

--- a/src/execution_plan/ops/op_expand_into.h
+++ b/src/execution_plan/ops/op_expand_into.h
@@ -17,6 +17,7 @@ typedef struct {
 	OpBase op;
 	Graph *graph;
 	AlgebraicExpression *ae;
+	bool exp_initialized;       // False until the expression has been evaluated once.
 	GrB_Matrix F;               // Filter matrix.
 	GrB_Matrix M;               // Algebraic expression result.
 	EdgeTraverseCtx *edge_ctx;  // Edge collection data if the edge needs to be set.

--- a/src/execution_plan/ops/op_expand_into.h
+++ b/src/execution_plan/ops/op_expand_into.h
@@ -17,7 +17,6 @@ typedef struct {
 	OpBase op;
 	Graph *graph;
 	AlgebraicExpression *ae;
-	bool exp_initialized;       // False until the expression has been evaluated once.
 	GrB_Matrix F;               // Filter matrix.
 	GrB_Matrix M;               // Algebraic expression result.
 	EdgeTraverseCtx *edge_ctx;  // Edge collection data if the edge needs to be set.

--- a/src/execution_plan/ops/shared/print_functions.c
+++ b/src/execution_plan/ops/shared/print_functions.c
@@ -48,3 +48,4 @@ int ScanToString(const OpBase *op, char *buf, uint buf_len, const QGNode *n) {
 	offset += QGNode_ToString(n, buf + offset, buf_len - offset);
 	return offset;
 }
+

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -37,6 +37,7 @@ tck:
 	### Cypher Technology Compatibility Kit (TCK)
 	@$(MAKE) -C tck TEST_ARGS="$(TEST_ARGS)"
 
+memcheck: export RS_GLOBAL_DTORS = 1
 memcheck:
 	@$(MAKE) -C flow TEST_ARGS="$(MEMCHECK_ARGS)"
 	@$(MAKE) -C tck TEST_ARGS="$(MEMCHECK_ARGS)"

--- a/tests/unit/test_algebraic_expression.cpp
+++ b/tests/unit/test_algebraic_expression.cpp
@@ -174,30 +174,30 @@ class AlgebraicExpressionTest: public ::testing::Test {
 		mat_id = GraphContext_GetSchema(gc, "war", SCHEMA_EDGE)->id;
 		mat_ew = Graph_GetRelationMatrix(g, mat_id);
 
-        _matrices = raxNew();
-        raxInsert(_matrices, (unsigned char *)"p", strlen("p"), mat_p, NULL);
-        raxInsert(_matrices, (unsigned char *)"f", strlen("f"), mat_f, NULL);
-        raxInsert(_matrices, (unsigned char *)"c", strlen("c"), mat_c, NULL);
-        raxInsert(_matrices, (unsigned char *)"e", strlen("e"), mat_e, NULL);
-        raxInsert(_matrices, (unsigned char *)"F", strlen("F"), mat_ef, NULL);
-        raxInsert(_matrices, (unsigned char *)"V", strlen("V"), mat_ev, NULL);
-        raxInsert(_matrices, (unsigned char *)"W", strlen("W"), mat_ew, NULL);
+		_matrices = raxNew();
+		raxInsert(_matrices, (unsigned char *)"p", strlen("p"), mat_p, NULL);
+		raxInsert(_matrices, (unsigned char *)"f", strlen("f"), mat_f, NULL);
+		raxInsert(_matrices, (unsigned char *)"c", strlen("c"), mat_c, NULL);
+		raxInsert(_matrices, (unsigned char *)"e", strlen("e"), mat_e, NULL);
+		raxInsert(_matrices, (unsigned char *)"F", strlen("F"), mat_ef, NULL);
+		raxInsert(_matrices, (unsigned char *)"V", strlen("V"), mat_ev, NULL);
+		raxInsert(_matrices, (unsigned char *)"W", strlen("W"), mat_ew, NULL);
 	}
 
 	AlgebraicExpression **build_algebraic_expression(const char *query) {
 		GraphContext *gc = QueryCtx_GetGraphCtx();
-        Graph *g = QueryCtx_GetGraph();
+		Graph *g = QueryCtx_GetGraph();
 		cypher_parse_result_t *parse_result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
 		AST *master_ast = AST_Build(parse_result);
 		AST *ast = AST_NewSegment(master_ast, 0, cypher_ast_query_nclauses(master_ast->root));
 		QueryGraph *qg = BuildQueryGraph(gc, ast);
 		AlgebraicExpression **ae = AlgebraicExpression_FromQueryGraph(qg);
 
-        uint exp_count = array_len(ae);
-        for(uint i = 0; i < exp_count; i++) {
-            AlgebraicExpression_Optimize(ae + i);
-            _AlgebraicExpression_FetchOperands(ae[i], gc, g);
-        }
+		uint exp_count = array_len(ae);
+		for(uint i = 0; i < exp_count; i++) {
+			AlgebraicExpression_Optimize(ae + i);
+			_AlgebraicExpression_FetchOperands(ae[i], gc, g);
+		}
 
 		return ae;
 	}
@@ -263,8 +263,8 @@ class AlgebraicExpressionTest: public ::testing::Test {
 	}
 
 	void _compare_algebraic_operand(AlgebraicExpression *a, AlgebraicExpression *b) {
-        ASSERT_TRUE(a->type == AL_OPERAND);
-        ASSERT_TRUE(b->type == AL_OPERAND);
+		ASSERT_TRUE(a->type == AL_OPERAND);
+		ASSERT_TRUE(b->type == AL_OPERAND);
 		// ASSERT_EQ(a->operand.free, b->operand.free);
 		ASSERT_EQ(a->operand.matrix, b->operand.matrix);
 		// ASSERT_EQ(a->operand.diagonal, b->operand.diagonal);
@@ -275,10 +275,10 @@ class AlgebraicExpressionTest: public ::testing::Test {
 		ASSERT_EQ(AlgebraicExpression_ChildCount(a), AlgebraicExpression_ChildCount(b));
 		ASSERT_EQ(AlgebraicExpression_OperandCount(a), AlgebraicExpression_OperandCount(b));
 		// ASSERT_EQ(AlgebraicExpression_OperationCount(a, AL_EXP_ALL), AlgebraicExpression_OperationCount(b, AL_EXP_ALL));
-        if(a->type == AL_OPERAND) _compare_algebraic_operand(a, b);
+		if(a->type == AL_OPERAND) _compare_algebraic_operand(a, b);
 
-        uint child_count = AlgebraicExpression_ChildCount(a);
-        for(uint i = 0; i < child_count; i++) {
+		uint child_count = AlgebraicExpression_ChildCount(a);
+		for(uint i = 0; i < child_count; i++) {
 			compare_algebraic_expression(a->operation.children[i], b->operation.children[i]);
 		}
 	}
@@ -299,256 +299,258 @@ class AlgebraicExpressionTest: public ::testing::Test {
 };
 
 TEST_F(AlgebraicExpressionTest, AlgebraicExpression_New) {
-    GrB_Matrix matrix = GrB_NULL;
-    bool diagonal = false;
-    const char *src = "src";
-    const char *dest = "dest";
-    const char *edge = "edge";
-    const char *label = "label";
+	GrB_Matrix matrix = GrB_NULL;
+	bool diagonal = false;
+	const char *src = "src";
+	const char *dest = "dest";
+	const char *edge = "edge";
+	const char *label = "label";
 
-    AlgebraicExpression *operand = AlgebraicExpression_NewOperand(matrix, diagonal, src, dest, edge, label);
-    ASSERT_EQ(operand->type, AL_OPERAND);
-    ASSERT_EQ(operand->operand.matrix, matrix);
-    ASSERT_EQ(operand->operand.diagonal, diagonal);
-    ASSERT_EQ(operand->operand.src, src);
-    ASSERT_EQ(operand->operand.dest, dest);
-    ASSERT_EQ(operand->operand.edge, edge);
-    ASSERT_EQ(operand->operand.label, label);
+	AlgebraicExpression *operand = AlgebraicExpression_NewOperand(matrix, diagonal, src, dest, edge,
+																  label);
+	ASSERT_EQ(operand->type, AL_OPERAND);
+	ASSERT_EQ(operand->operand.matrix, matrix);
+	ASSERT_EQ(operand->operand.diagonal, diagonal);
+	ASSERT_EQ(operand->operand.src, src);
+	ASSERT_EQ(operand->operand.dest, dest);
+	ASSERT_EQ(operand->operand.edge, edge);
+	ASSERT_EQ(operand->operand.label, label);
 
-    ASSERT_EQ(AlgebraicExpression_Source(operand), src);
-    ASSERT_EQ(AlgebraicExpression_Destination(operand), dest);
-    ASSERT_EQ(AlgebraicExpression_Edge(operand), edge);
-    ASSERT_EQ(AlgebraicExpression_ChildCount(operand), 0);
-    ASSERT_EQ(AlgebraicExpression_OperandCount(operand), 1);
-    ASSERT_EQ(AlgebraicExpression_Transposed(operand), false);
+	ASSERT_EQ(AlgebraicExpression_Source(operand), src);
+	ASSERT_EQ(AlgebraicExpression_Destination(operand), dest);
+	ASSERT_EQ(AlgebraicExpression_Edge(operand), edge);
+	ASSERT_EQ(AlgebraicExpression_ChildCount(operand), 0);
+	ASSERT_EQ(AlgebraicExpression_OperandCount(operand), 1);
+	ASSERT_EQ(AlgebraicExpression_Transposed(operand), false);
 
-    AL_EXP_OP op = AL_EXP_ADD;
-    AlgebraicExpression *operation = AlgebraicExpression_NewOperation(op);
-    AlgebraicExpression_AddChild(operation, operand);
+	AL_EXP_OP op = AL_EXP_ADD;
+	AlgebraicExpression *operation = AlgebraicExpression_NewOperation(op);
+	AlgebraicExpression_AddChild(operation, operand);
 
-    ASSERT_EQ(operation->type, AL_OPERATION);
-    ASSERT_EQ(operation->operation.op, op);
-    ASSERT_EQ(array_len(operation->operation.children), 1);
+	ASSERT_EQ(operation->type, AL_OPERATION);
+	ASSERT_EQ(operation->operation.op, op);
+	ASSERT_EQ(array_len(operation->operation.children), 1);
 
-    ASSERT_EQ(AlgebraicExpression_Source(operation), src);
-    ASSERT_EQ(AlgebraicExpression_Destination(operation), dest);
-    ASSERT_EQ(AlgebraicExpression_Edge(operation), edge);
-    ASSERT_EQ(AlgebraicExpression_ChildCount(operation), 1);
-    ASSERT_EQ(AlgebraicExpression_OperandCount(operation), 1);
-    ASSERT_EQ(AlgebraicExpression_Transposed(operation), false);
+	ASSERT_EQ(AlgebraicExpression_Source(operation), src);
+	ASSERT_EQ(AlgebraicExpression_Destination(operation), dest);
+	ASSERT_EQ(AlgebraicExpression_Edge(operation), edge);
+	ASSERT_EQ(AlgebraicExpression_ChildCount(operation), 1);
+	ASSERT_EQ(AlgebraicExpression_OperandCount(operation), 1);
+	ASSERT_EQ(AlgebraicExpression_Transposed(operation), false);
 
-    // Will free `operand` aswell.
-    AlgebraicExpression_Free(operation);
+	// Will free `operand` aswell.
+	AlgebraicExpression_Free(operation);
 }
 
-TEST_F(AlgebraicExpressionTest, AlgebraicExpression_Domains) {	
+TEST_F(AlgebraicExpressionTest, AlgebraicExpression_Domains) {
 	GrB_Matrix A;
 	GrB_Matrix B;
-    const char *src_domain;     // Row domain of expression
-    const char *dest_domain;    // Column domain of expression
-    AlgebraicExpression *exp;
-    
-    GrB_Matrix_new(&A, GrB_BOOL, 2, 2);	
-    GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
+	const char *src_domain;     // Row domain of expression
+	const char *dest_domain;    // Column domain of expression
+	AlgebraicExpression *exp;
 
-    rax *matrices = raxNew();
-    raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
-    raxInsert(matrices, (unsigned char *)"B", strlen("B"), B, NULL);
+	GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
+	GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
 
-    /* Note: addition is performed over matrices with the same source and destination domain
-     * While multiplication takes on source domain of first operand, and destination domain of its last operand
-     * For a given operand A both its source and destination domains are 'A' */
+	rax *matrices = raxNew();
+	raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
+	raxInsert(matrices, (unsigned char *)"B", strlen("B"), B, NULL);
 
-    // A
-    // Source(A) = A.
-    // Destination(A) = A.
-    exp = AlgebraicExpression_FromString("A", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "A");
-    ASSERT_STREQ(dest_domain, "A");
-    AlgebraicExpression_Free(exp);
+	/* Note: addition is performed over matrices with the same source and destination domain
+	 * While multiplication takes on source domain of first operand, and destination domain of its last operand
+	 * For a given operand A both its source and destination domains are 'A' */
 
-    // A+B
-    // Addition doesn't modifies column domain.
-    // Source(A+B) = A.
-    // Destination(A+B) = A.
-    exp = AlgebraicExpression_FromString("A+B", matrices);    
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "A");
-    ASSERT_STREQ(dest_domain, "A");
-    AlgebraicExpression_Free(exp);
+	// A
+	// Source(A) = A.
+	// Destination(A) = A.
+	exp = AlgebraicExpression_FromString("A", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "A");
+	ASSERT_STREQ(dest_domain, "A");
+	AlgebraicExpression_Free(exp);
 
-    // B+A
-    // Addition doesn't modifies column domain.
-    // Source(B+A) = B.
-    // Destination(B+A) = B.
-    exp = AlgebraicExpression_FromString("B+A", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "B");
-    ASSERT_STREQ(dest_domain, "B");
-    AlgebraicExpression_Free(exp);
+	// A+B
+	// Addition doesn't modifies column domain.
+	// Source(A+B) = A.
+	// Destination(A+B) = A.
+	exp = AlgebraicExpression_FromString("A+B", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "A");
+	ASSERT_STREQ(dest_domain, "A");
+	AlgebraicExpression_Free(exp);
 
-    // A*B
-    // Source(A*B) = A.
-    // Destination(A*B) = B.
-    exp = AlgebraicExpression_FromString("A*B", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "A");
-    ASSERT_STREQ(dest_domain, "B");
-    AlgebraicExpression_Free(exp);
+	// B+A
+	// Addition doesn't modifies column domain.
+	// Source(B+A) = B.
+	// Destination(B+A) = B.
+	exp = AlgebraicExpression_FromString("B+A", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "B");
+	ASSERT_STREQ(dest_domain, "B");
+	AlgebraicExpression_Free(exp);
 
-    // B*A
-    // Source(B*A) = B.
-    // Destination(B*A) = A.
-    exp = AlgebraicExpression_FromString("B*A", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "B");
-    ASSERT_STREQ(dest_domain, "A");
-    AlgebraicExpression_Free(exp);
+	// A*B
+	// Source(A*B) = A.
+	// Destination(A*B) = B.
+	exp = AlgebraicExpression_FromString("A*B", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "A");
+	ASSERT_STREQ(dest_domain, "B");
+	AlgebraicExpression_Free(exp);
 
-    // Transpose(A)
-    // Source(Transpose(A)) = A.
-    // Destination(Transpose(A)) = A.
-    exp = AlgebraicExpression_FromString("T(A)", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "A");
-    ASSERT_STREQ(dest_domain, "A");
-    AlgebraicExpression_Free(exp);
+	// B*A
+	// Source(B*A) = B.
+	// Destination(B*A) = A.
+	exp = AlgebraicExpression_FromString("B*A", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "B");
+	ASSERT_STREQ(dest_domain, "A");
+	AlgebraicExpression_Free(exp);
 
-    // Transpose((A+B))
-    // Source(Transpose((A+B))) = A.
-    // Destination(Transpose((A+B))) = A.
-    exp = AlgebraicExpression_FromString("T(A+B)", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "A");
-    ASSERT_STREQ(dest_domain, "A");
-    AlgebraicExpression_Free(exp);
+	// Transpose(A)
+	// Source(Transpose(A)) = A.
+	// Destination(Transpose(A)) = A.
+	exp = AlgebraicExpression_FromString("T(A)", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "A");
+	ASSERT_STREQ(dest_domain, "A");
+	AlgebraicExpression_Free(exp);
 
-    // Transpose((B+A))
-    // Source(Transpose((B+A))) = B.
-    // Destination(Transpose((B+A))) = B.
-    exp = AlgebraicExpression_FromString("T(B+A)", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "B");
-    ASSERT_STREQ(dest_domain, "B");
-    AlgebraicExpression_Free(exp);
+	// Transpose((A+B))
+	// Source(Transpose((A+B))) = A.
+	// Destination(Transpose((A+B))) = A.
+	exp = AlgebraicExpression_FromString("T(A+B)", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "A");
+	ASSERT_STREQ(dest_domain, "A");
+	AlgebraicExpression_Free(exp);
 
-    // Transpose((A*B))
-    // Source(Transpose((A*B))) = B.
-    // Destination(Transpose((A*B))) = A.
-    exp = AlgebraicExpression_FromString("T(A*B)", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "B");
-    ASSERT_STREQ(dest_domain, "A");
-    AlgebraicExpression_Free(exp);
+	// Transpose((B+A))
+	// Source(Transpose((B+A))) = B.
+	// Destination(Transpose((B+A))) = B.
+	exp = AlgebraicExpression_FromString("T(B+A)", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "B");
+	ASSERT_STREQ(dest_domain, "B");
+	AlgebraicExpression_Free(exp);
 
-    // Transpose((B*A))
-    // Source(Transpose((B*A))) = A.
-    // Destination(Transpose((B*A))) = B.
-    exp = AlgebraicExpression_FromString("T(B*A)", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "A");
-    ASSERT_STREQ(dest_domain, "B");
-    AlgebraicExpression_Free(exp);
+	// Transpose((A*B))
+	// Source(Transpose((A*B))) = B.
+	// Destination(Transpose((A*B))) = A.
+	exp = AlgebraicExpression_FromString("T(A*B)", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "B");
+	ASSERT_STREQ(dest_domain, "A");
+	AlgebraicExpression_Free(exp);
 
-    // Transpose(Transpose(A)) = A
-    // Source(Transpose(Transpose(A)) = A.
-    // Destination(Transpose(Transpose(A)) = A.
-    exp = AlgebraicExpression_FromString("T(T(A))", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "A");
-    ASSERT_STREQ(dest_domain, "A");
-    AlgebraicExpression_Free(exp);
+	// Transpose((B*A))
+	// Source(Transpose((B*A))) = A.
+	// Destination(Transpose((B*A))) = B.
+	exp = AlgebraicExpression_FromString("T(B*A)", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "A");
+	ASSERT_STREQ(dest_domain, "B");
+	AlgebraicExpression_Free(exp);
 
-    // Transpose(Transpose((A+B))) = A+B
-    // Source(Transpose(Transpose((A+B)))) = A.
-    // Destination(Transpose(Transpose((A+B))) = A.
-    exp = AlgebraicExpression_FromString("T(T(A+B))", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "A");
-    ASSERT_STREQ(dest_domain, "A");
-    AlgebraicExpression_Free(exp);
+	// Transpose(Transpose(A)) = A
+	// Source(Transpose(Transpose(A)) = A.
+	// Destination(Transpose(Transpose(A)) = A.
+	exp = AlgebraicExpression_FromString("T(T(A))", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "A");
+	ASSERT_STREQ(dest_domain, "A");
+	AlgebraicExpression_Free(exp);
 
-    // Transpose(Transpose((B+A))) = B+A
-    // Source(Transpose(Transpose((B+A))) = B.
-    // Destination(Transpose(Transpose((B+A))) = B.
-    exp = AlgebraicExpression_FromString("T(T(B+A))", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "B");
-    ASSERT_STREQ(dest_domain, "B");
-    AlgebraicExpression_Free(exp);
+	// Transpose(Transpose((A+B))) = A+B
+	// Source(Transpose(Transpose((A+B)))) = A.
+	// Destination(Transpose(Transpose((A+B))) = A.
+	exp = AlgebraicExpression_FromString("T(T(A+B))", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "A");
+	ASSERT_STREQ(dest_domain, "A");
+	AlgebraicExpression_Free(exp);
 
-    // Transpose(Transpose((A*B))) = A*B
-    // Source(Transpose(Transpose((A*B))) = A.
-    // Destination(Transpose(Transpose((A*B))) = B.
-    exp = AlgebraicExpression_FromString("T(T(A*B))", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "A");
-    ASSERT_STREQ(dest_domain, "B");
-    AlgebraicExpression_Free(exp);
+	// Transpose(Transpose((B+A))) = B+A
+	// Source(Transpose(Transpose((B+A))) = B.
+	// Destination(Transpose(Transpose((B+A))) = B.
+	exp = AlgebraicExpression_FromString("T(T(B+A))", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "B");
+	ASSERT_STREQ(dest_domain, "B");
+	AlgebraicExpression_Free(exp);
 
-    // Transpose(Transpose((B*A)) = B*A
-    // Source(Transpose(Transpose((B*A))) = B.
-    // Destination(Transpose(Transpose((B*A))) = A.
-    exp = AlgebraicExpression_FromString("T(T(B*A))", matrices);
-    src_domain = AlgebraicExpression_Source(exp);
-    dest_domain = AlgebraicExpression_Destination(exp);
-    ASSERT_STREQ(src_domain, "B");
-    ASSERT_STREQ(dest_domain, "A");
-    AlgebraicExpression_Free(exp);
+	// Transpose(Transpose((A*B))) = A*B
+	// Source(Transpose(Transpose((A*B))) = A.
+	// Destination(Transpose(Transpose((A*B))) = B.
+	exp = AlgebraicExpression_FromString("T(T(A*B))", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "A");
+	ASSERT_STREQ(dest_domain, "B");
+	AlgebraicExpression_Free(exp);
 
-    raxFree(matrices);
+	// Transpose(Transpose((B*A)) = B*A
+	// Source(Transpose(Transpose((B*A))) = B.
+	// Destination(Transpose(Transpose((B*A))) = A.
+	exp = AlgebraicExpression_FromString("T(T(B*A))", matrices);
+	src_domain = AlgebraicExpression_Source(exp);
+	dest_domain = AlgebraicExpression_Destination(exp);
+	ASSERT_STREQ(src_domain, "B");
+	ASSERT_STREQ(dest_domain, "A");
+	AlgebraicExpression_Free(exp);
+
+	raxFree(matrices);
 	GrB_Matrix_free(&A);
 	GrB_Matrix_free(&B);
 }
 
 TEST_F(AlgebraicExpressionTest, AlgebraicExpression_Clone) {
-    AlgebraicExpression *exp = NULL;
-    AlgebraicExpression *clone = NULL;
-    const char *expressions[13] = {"A", "A*B", "A*B*C", "A+B", "A+B+C", "A*B+C", "A+B*C",
-    "T(A)", "T(A*B)", "T(A*B*C)", "T(A+B)", "T(A+B+C)", "T(T(A))"};
+	AlgebraicExpression *exp = NULL;
+	AlgebraicExpression *clone = NULL;
+	const char *expressions[13] = {"A", "A*B", "A*B*C", "A+B", "A+B+C", "A*B+C", "A+B*C",
+								   "T(A)", "T(A*B)", "T(A*B*C)", "T(A+B)", "T(A+B+C)", "T(T(A))"
+								  };
 
-    for(uint i = 0; i < 13; i++) {        
-        exp = AlgebraicExpression_FromString(expressions[i], NULL);
-        clone = AlgebraicExpression_Clone(exp);
-        compare_algebraic_expression(exp, clone);
-        AlgebraicExpression_Free(clone);
-        AlgebraicExpression_Free(exp);
-    }
+	for(uint i = 0; i < 13; i++) {
+		exp = AlgebraicExpression_FromString(expressions[i], NULL);
+		clone = AlgebraicExpression_Clone(exp);
+		compare_algebraic_expression(exp, clone);
+		AlgebraicExpression_Free(clone);
+		AlgebraicExpression_Free(exp);
+	}
 }
 
 TEST_F(AlgebraicExpressionTest, AlgebraicExpression_Transpose) {
-    AlgebraicExpression *exp = NULL;
-    AlgebraicExpression *transposed_exp = NULL;
+	AlgebraicExpression *exp = NULL;
+	AlgebraicExpression *transposed_exp = NULL;
 
-    const char *expressions[6] = {"A", "A*B", "A*B*C", "A+B", "A+B+C", "T(A)"};
-    const char *transposed_expressions[6] = {"T(A)", "T(B)*T(A)", "T(C)*T(B)*T(A)", "T(A)+T(B)", "T(A)+T(B)+T(C)", "A"};
+	const char *expressions[6] = {"A", "A*B", "A*B*C", "A+B", "A+B+C", "T(A)"};
+	const char *transposed_expressions[6] = {"T(A)", "T(B)*T(A)", "T(C)*T(B)*T(A)", "T(A)+T(B)", "T(A)+T(B)+T(C)", "A"};
 
-    for(uint i = 0; i < 6; i++) {
-        exp = AlgebraicExpression_FromString(expressions[i], NULL);
-        AlgebraicExpression_Transpose(&exp);
-	    AlgebraicExpression_Optimize(&exp); // Performs transpose pushdown.
+	for(uint i = 0; i < 6; i++) {
+		exp = AlgebraicExpression_FromString(expressions[i], NULL);
+		AlgebraicExpression_Transpose(&exp);
+		AlgebraicExpression_Optimize(&exp); // Performs transpose pushdown.
 
-        transposed_exp = AlgebraicExpression_FromString(transposed_expressions[i], NULL);
-        compare_algebraic_expression(exp, transposed_exp);
+		transposed_exp = AlgebraicExpression_FromString(transposed_expressions[i], NULL);
+		compare_algebraic_expression(exp, transposed_exp);
 
-        AlgebraicExpression_Free(exp);
-        AlgebraicExpression_Free(transposed_exp);
-    }
+		AlgebraicExpression_Free(exp);
+		AlgebraicExpression_Free(transposed_exp);
+	}
 }
 
 TEST_F(AlgebraicExpressionTest, Exp_OP_ADD) {
@@ -582,10 +584,10 @@ TEST_F(AlgebraicExpressionTest, Exp_OP_ADD) {
 	GrB_Matrix_setElement_BOOL(C, true, 1, 0);
 	GrB_Matrix_setElement_BOOL(C, true, 1, 1);
 
-    rax *matrices = raxNew();
-    raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
-    raxInsert(matrices, (unsigned char *)"B", strlen("B"), B, NULL);
-    AlgebraicExpression *exp = AlgebraicExpression_FromString("A+B", matrices);
+	rax *matrices = raxNew();
+	raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
+	raxInsert(matrices, (unsigned char *)"B", strlen("B"), B, NULL);
+	AlgebraicExpression *exp = AlgebraicExpression_FromString("A+B", matrices);
 
 	// Matrix used for intermidate computations of AlgebraicExpression_Eval
 	// but also contains the result of expression evaluation.
@@ -596,12 +598,12 @@ TEST_F(AlgebraicExpressionTest, Exp_OP_ADD) {
 	// A + B = C.
 	ASSERT_TRUE(_compare_matrices(res, C));
 
-    raxFree(matrices);
+	raxFree(matrices);
 	GrB_Matrix_free(&A);
 	GrB_Matrix_free(&B);
 	GrB_Matrix_free(&C);
 	GrB_Matrix_free(&res);
-    AlgebraicExpression_Free(exp);
+	AlgebraicExpression_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, Exp_OP_MUL) {
@@ -624,10 +626,10 @@ TEST_F(AlgebraicExpressionTest, Exp_OP_MUL) {
 	GrB_Matrix_setElement_BOOL(I, true, 0, 0);
 	GrB_Matrix_setElement_BOOL(I, true, 1, 1);
 
-    rax *matrices = raxNew();
-    raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
-    raxInsert(matrices, (unsigned char *)"I", strlen("I"), I, NULL);
-    AlgebraicExpression *exp = AlgebraicExpression_FromString("A*I", matrices);
+	rax *matrices = raxNew();
+	raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
+	raxInsert(matrices, (unsigned char *)"I", strlen("I"), I, NULL);
+	AlgebraicExpression *exp = AlgebraicExpression_FromString("A*I", matrices);
 
 	// Matrix used for intermidate computations of AlgebraicExpression_Eval
 	// but also contains the result of expression evaluation.
@@ -638,11 +640,11 @@ TEST_F(AlgebraicExpressionTest, Exp_OP_MUL) {
 	// A * I = A.
 	ASSERT_TRUE(_compare_matrices(res, A));
 
-    raxFree(matrices);
-    GrB_Matrix_free(&A);
+	raxFree(matrices);
+	GrB_Matrix_free(&A);
 	GrB_Matrix_free(&I);
 	GrB_Matrix_free(&res);
-    AlgebraicExpression_Free(exp);
+	AlgebraicExpression_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, Exp_OP_ADD_Transpose) {
@@ -670,21 +672,21 @@ TEST_F(AlgebraicExpressionTest, Exp_OP_ADD_Transpose) {
 	// but also contains the result of expression evaluation.
 	GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
 
-	// A + Transpose(A)	
-    rax *matrices = raxNew();
-    raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
-    AlgebraicExpression *exp = AlgebraicExpression_FromString("A+T(A)", matrices);	
+	// A + Transpose(A)
+	rax *matrices = raxNew();
+	raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
+	AlgebraicExpression *exp = AlgebraicExpression_FromString("A+T(A)", matrices);
 	AlgebraicExpression_Eval(exp, res);
 
 	// Using the A matrix described above,
 	// A + Transpose(A) = B.
 	ASSERT_TRUE(_compare_matrices(res, B));
 
-    raxFree(matrices);
+	raxFree(matrices);
 	GrB_Matrix_free(&A);
 	GrB_Matrix_free(&B);
 	GrB_Matrix_free(&res);
-    AlgebraicExpression_Free(exp);
+	AlgebraicExpression_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, Exp_OP_MUL_Transpose) {
@@ -711,20 +713,20 @@ TEST_F(AlgebraicExpressionTest, Exp_OP_MUL_Transpose) {
 	GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
 
 	// Transpose(A) * A
-    rax *matrices = raxNew();
-    raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
-    AlgebraicExpression *exp = AlgebraicExpression_FromString("A*T(A)", matrices);
+	rax *matrices = raxNew();
+	raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
+	AlgebraicExpression *exp = AlgebraicExpression_FromString("A*T(A)", matrices);
 	AlgebraicExpression_Eval(exp, res);
 
 	// Using the A matrix described above,
 	// Transpose(A) * A = B.
 	ASSERT_TRUE(_compare_matrices(res, B));
 
-    raxFree(matrices);
+	raxFree(matrices);
 	GrB_Matrix_free(&A);
 	GrB_Matrix_free(&B);
 	GrB_Matrix_free(&res);
-    AlgebraicExpression_Free(exp);
+	AlgebraicExpression_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, Exp_OP_A_MUL_B_Plus_C) {
@@ -758,21 +760,21 @@ TEST_F(AlgebraicExpressionTest, Exp_OP_A_MUL_B_Plus_C) {
 	GrB_Matrix_new(&res, GrB_BOOL, 2, 2);
 
 	// A * (B+C) = A.rax *matrices = raxNew();
-    rax *matrices = raxNew();
-    raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
-    raxInsert(matrices, (unsigned char *)"B", strlen("B"), B, NULL);
-    raxInsert(matrices, (unsigned char *)"C", strlen("C"), C, NULL);
-    AlgebraicExpression *exp = AlgebraicExpression_FromString("A*(B+C)", matrices);
-	AlgebraicExpression_Eval(exp, res);	
-	
-    ASSERT_TRUE(_compare_matrices(res, A));
+	rax *matrices = raxNew();
+	raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
+	raxInsert(matrices, (unsigned char *)"B", strlen("B"), B, NULL);
+	raxInsert(matrices, (unsigned char *)"C", strlen("C"), C, NULL);
+	AlgebraicExpression *exp = AlgebraicExpression_FromString("A*(B+C)", matrices);
+	AlgebraicExpression_Eval(exp, res);
 
-    raxFree(matrices);
+	ASSERT_TRUE(_compare_matrices(res, A));
+
+	raxFree(matrices);
 	GrB_Matrix_free(&A);
 	GrB_Matrix_free(&B);
 	GrB_Matrix_free(&C);
 	GrB_Matrix_free(&res);
-    AlgebraicExpression_Free(exp);
+	AlgebraicExpression_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, ExpTransform_A_Times_B_Plus_C) {
@@ -786,24 +788,24 @@ TEST_F(AlgebraicExpressionTest, ExpTransform_A_Times_B_Plus_C) {
 	GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
 	GrB_Matrix_new(&C, GrB_BOOL, 2, 2);
 
-    rax *matrices = raxNew();
-    raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
-    raxInsert(matrices, (unsigned char *)"B", strlen("B"), B, NULL);
-    raxInsert(matrices, (unsigned char *)"C", strlen("C"), C, NULL);
-    AlgebraicExpression *exp = AlgebraicExpression_FromString("A*(B+C)", matrices);
-    
-    // Verifications
+	rax *matrices = raxNew();
+	raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
+	raxInsert(matrices, (unsigned char *)"B", strlen("B"), B, NULL);
+	raxInsert(matrices, (unsigned char *)"C", strlen("C"), C, NULL);
+	AlgebraicExpression *exp = AlgebraicExpression_FromString("A*(B+C)", matrices);
+
+	// Verifications
 	// (A*B)+(A*C)
 	ASSERT_TRUE(exp->type == AL_OPERATION && exp->operation.op == AL_EXP_ADD);
 
 	AlgebraicExpression *rootLeftChild = exp->operation.children[0];
 	AlgebraicExpression *rootRightChild = exp->operation.children[1];
-    ASSERT_TRUE(rootLeftChild && rootLeftChild->type == AL_OPERATION &&
+	ASSERT_TRUE(rootLeftChild && rootLeftChild->type == AL_OPERATION &&
 				rootLeftChild->operation.op == AL_EXP_MUL);
 	ASSERT_TRUE(rootRightChild && rootRightChild->type == AL_OPERATION &&
 				rootRightChild->operation.op == AL_EXP_MUL);
 
-    AlgebraicExpression *leftLeft = rootLeftChild->operation.children[0];
+	AlgebraicExpression *leftLeft = rootLeftChild->operation.children[0];
 	ASSERT_TRUE(leftLeft->type == AL_OPERAND && leftLeft->operand.matrix == A);
 
 	AlgebraicExpression *leftRight = rootLeftChild->operation.children[1];
@@ -815,11 +817,11 @@ TEST_F(AlgebraicExpressionTest, ExpTransform_A_Times_B_Plus_C) {
 	AlgebraicExpression *rightRight = rootRightChild->operation.children[1];
 	ASSERT_TRUE(rightRight->type == AL_OPERAND && rightRight->operand.matrix == C);
 
-    raxFree(matrices);
+	raxFree(matrices);
 	GrB_Matrix_free(&A);
 	GrB_Matrix_free(&B);
 	GrB_Matrix_free(&C);
-    AlgebraicExpression_Free(exp);
+	AlgebraicExpression_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, ExpTransform_AB_Times_C_Plus_D) {
@@ -835,13 +837,13 @@ TEST_F(AlgebraicExpressionTest, ExpTransform_AB_Times_C_Plus_D) {
 	GrB_Matrix_new(&C, GrB_BOOL, 2, 2);
 	GrB_Matrix_new(&D, GrB_BOOL, 2, 2);
 
-    // A*B*(C+D) -> A*B*C + A*B*D
+	// A*B*(C+D) -> A*B*C + A*B*D
 	AlgebraicExpression *exp = AlgebraicExpression_NewOperand(C, false, NULL, NULL, NULL, NULL);
 
 	// A*B*(C+D)
 	AlgebraicExpression_AddToTheRight(&exp, D);
-    AlgebraicExpression_MultiplyToTheLeft(&exp, B);
-    AlgebraicExpression_MultiplyToTheLeft(&exp, A);
+	AlgebraicExpression_MultiplyToTheLeft(&exp, B);
+	AlgebraicExpression_MultiplyToTheLeft(&exp, A);
 	AlgebraicExpression_Optimize(&exp);
 
 	// Verifications
@@ -865,7 +867,7 @@ TEST_F(AlgebraicExpressionTest, ExpTransform_AB_Times_C_Plus_D) {
 	AlgebraicExpression *leftchild_2 = rootLeftChild->operation.children[2];
 	ASSERT_TRUE(leftchild_2->type == AL_OPERAND && leftchild_2->operand.matrix == C);
 
-    AlgebraicExpression *rightchild_0 = rootRightChild->operation.children[0];
+	AlgebraicExpression *rightchild_0 = rootRightChild->operation.children[0];
 	ASSERT_TRUE(rightchild_0->type == AL_OPERAND && rightchild_0->operand.matrix == A);
 
 	AlgebraicExpression *rightchild_1 = rootRightChild->operation.children[1];
@@ -879,7 +881,7 @@ TEST_F(AlgebraicExpressionTest, ExpTransform_AB_Times_C_Plus_D) {
 	GrB_Matrix_free(&B);
 	GrB_Matrix_free(&C);
 	GrB_Matrix_free(&D);
-    AlgebraicExpression_Free(exp);
+	AlgebraicExpression_Free(exp);
 }
 
 TEST_F(AlgebraicExpressionTest, ExpTransform_A_Plus_B_Times_C_Plus_D) {
@@ -889,66 +891,66 @@ TEST_F(AlgebraicExpressionTest, ExpTransform_A_Plus_B_Times_C_Plus_D) {
 	GrB_Matrix B;
 	GrB_Matrix C;
 	GrB_Matrix D;
-    GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
+	GrB_Matrix_new(&A, GrB_BOOL, 2, 2);
 	GrB_Matrix_new(&B, GrB_BOOL, 2, 2);
 	GrB_Matrix_new(&C, GrB_BOOL, 2, 2);
 	GrB_Matrix_new(&D, GrB_BOOL, 2, 2);
 
-    rax *matrices = raxNew();
-    raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
-    raxInsert(matrices, (unsigned char *)"B", strlen("B"), B, NULL);
-    raxInsert(matrices, (unsigned char *)"C", strlen("C"), C, NULL);
-    raxInsert(matrices, (unsigned char *)"D", strlen("D"), D, NULL);
+	rax *matrices = raxNew();
+	raxInsert(matrices, (unsigned char *)"A", strlen("A"), A, NULL);
+	raxInsert(matrices, (unsigned char *)"B", strlen("B"), B, NULL);
+	raxInsert(matrices, (unsigned char *)"C", strlen("C"), C, NULL);
+	raxInsert(matrices, (unsigned char *)"D", strlen("D"), D, NULL);
 
-    // (A+B)*(C+D) -> A*C + A*D + B*C + B*D.
+	// (A+B)*(C+D) -> A*C + A*D + B*C + B*D.
 	AlgebraicExpression *exp = AlgebraicExpression_FromString("(A+B)*(C+D)", matrices);
-    char *exp_str = AlgebraicExpression_ToString(exp);
-    /* Verifications
+	char *exp_str = AlgebraicExpression_ToString(exp);
+	/* Verifications
 	 * (A*C) + (A*D) + (B*C) + (B*D).
-     *    +
-     *       +
-     *           +
-     *               *
-     *                   A
-     *                   C
-     *               *
-     *                   A
-     *                   D
-     *           *
-     *               B
-     *               C
-     *       *
-     *           B
-     *           D
-     * */
+	 *    +
+	 *       +
+	 *           +
+	 *               *
+	 *                   A
+	 *                   C
+	 *               *
+	 *                   A
+	 *                   D
+	 *           *
+	 *               B
+	 *               C
+	 *       *
+	 *           B
+	 *           D
+	 * */
 
-    ASSERT_STREQ("(((A * C + A * D) + B * C) + B * D)", exp_str);
-    rm_free(exp_str);
-    raxFree(matrices);
+	ASSERT_STREQ("(((A * C + A * D) + B * C) + B * D)", exp_str);
+	rm_free(exp_str);
+	raxFree(matrices);
 	GrB_Matrix_free(&A);
 	GrB_Matrix_free(&B);
 	GrB_Matrix_free(&C);
 	GrB_Matrix_free(&D);
-    AlgebraicExpression_Free(exp);
+	AlgebraicExpression_Free(exp);
 }
 
-TEST_F(AlgebraicExpressionTest, MultipleIntermidateReturnNodes) {	
-    // "MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p, f, c, e";
+TEST_F(AlgebraicExpressionTest, MultipleIntermidateReturnNodes) {
+	// "MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p, f, c, e";
 	const char *q = query_multiple_intermidate_return_nodes;
 	AlgebraicExpression **actual = build_algebraic_expression(q);
-    uint exp_count = array_len(actual);
+	uint exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 3);
 
-    AlgebraicExpression *expected[3];
-    
-    // P * EF * F
-    expected[0] = AlgebraicExpression_FromString("p*F*f", _matrices);    
+	AlgebraicExpression *expected[3];
+
+	// P * EF * F
+	expected[0] = AlgebraicExpression_FromString("p*F*f", _matrices);
 
 	// EV * C
-    expected[1] = AlgebraicExpression_FromString("V*c", _matrices);    
+	expected[1] = AlgebraicExpression_FromString("V*c", _matrices);
 
 	// EW * E
-    expected[2] = AlgebraicExpression_FromString("W*e", _matrices);
+	expected[2] = AlgebraicExpression_FromString("W*e", _matrices);
 
 	compare_algebraic_expressions(actual, expected, 3);
 
@@ -961,16 +963,16 @@ TEST_F(AlgebraicExpressionTest, MultipleIntermidateReturnNodes) {
 TEST_F(AlgebraicExpressionTest, OneIntermidateReturnNode) {
 	const char *q = query_one_intermidate_return_nodes;
 	AlgebraicExpression **actual = build_algebraic_expression(q);
-    uint exp_count = array_len(actual);
+	uint exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 2);
 
 	AlgebraicExpression *expected[2];
-	
-    // p*F*f*V*c
-    expected[0] = AlgebraicExpression_FromString("p*F*f*V*c", _matrices);
+
+	// p*F*f*V*c
+	expected[0] = AlgebraicExpression_FromString("p*F*f*V*c", _matrices);
 
 	// W*e
-    expected[1] = AlgebraicExpression_FromString("W*e", _matrices);
+	expected[1] = AlgebraicExpression_FromString("W*e", _matrices);
 
 	compare_algebraic_expressions(actual, expected, 2);
 
@@ -983,11 +985,11 @@ TEST_F(AlgebraicExpressionTest, OneIntermidateReturnNode) {
 TEST_F(AlgebraicExpressionTest, NoIntermidateReturnNodes) {
 	const char *q = query_no_intermidate_return_nodes;
 	AlgebraicExpression **actual = build_algebraic_expression(q);
-    uint exp_count = array_len(actual);
+	uint exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 1);
 
 	AlgebraicExpression *expected[1];
-    // p*F*f*V*c*W*e
+	// p*F*f*V*c*W*e
 	expected[0] = AlgebraicExpression_FromString("p*F*f*V*c*W*e", _matrices);
 	compare_algebraic_expressions(actual, expected, 1);
 
@@ -1007,12 +1009,12 @@ TEST_F(AlgebraicExpressionTest, OneIntermidateReturnEdge) {
 
 	q = query_return_first_edge;
 	actual = build_algebraic_expression(q);
-    uint exp_count = array_len(actual);
+	uint exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 2);
 
 	AlgebraicExpression *expected[3];
 	expected[0] = AlgebraicExpression_FromString("p*F*f", _matrices);
-    expected[1] = AlgebraicExpression_FromString("V*c*W*e", _matrices);
+	expected[1] = AlgebraicExpression_FromString("V*c*W*e", _matrices);
 	compare_algebraic_expressions(actual, expected, 2);
 
 	// Clean up.
@@ -1025,13 +1027,13 @@ TEST_F(AlgebraicExpressionTest, OneIntermidateReturnEdge) {
 	//==============================================================================================
 	q = query_return_intermidate_edge;
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 3);
 
 	expected[0] = AlgebraicExpression_FromString("p*F*f", _matrices);
-    expected[1] = AlgebraicExpression_FromString("V*c", _matrices);
-    expected[2] = AlgebraicExpression_FromString("W*e", _matrices);
-    compare_algebraic_expressions(actual, expected, 3);
+	expected[1] = AlgebraicExpression_FromString("V*c", _matrices);
+	expected[2] = AlgebraicExpression_FromString("W*e", _matrices);
+	compare_algebraic_expressions(actual, expected, 3);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1043,13 +1045,13 @@ TEST_F(AlgebraicExpressionTest, OneIntermidateReturnEdge) {
 	//==============================================================================================
 	q = query_return_last_edge;
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 2);
 
-	
-    expected[0] = AlgebraicExpression_FromString("p*F*f*V*c", _matrices);
-    expected[1] = AlgebraicExpression_FromString("W*e", _matrices);
-    compare_algebraic_expressions(actual, expected, 2);
+
+	expected[0] = AlgebraicExpression_FromString("p*F*f*V*c", _matrices);
+	expected[1] = AlgebraicExpression_FromString("W*e", _matrices);
+	compare_algebraic_expressions(actual, expected, 2);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1061,7 +1063,7 @@ TEST_F(AlgebraicExpressionTest, BothDirections) {
 	const char *q =
 		"MATCH (p:Person)-[ef:friend]->(f:Person)<-[ev:visit]-(c:City)-[ew:war]->(e:City) RETURN p,e";
 	AlgebraicExpression **actual = build_algebraic_expression(q);
-    uint exp_count = array_len(actual);
+	uint exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 1);
 
 	AlgebraicExpression *expected[1];
@@ -1077,7 +1079,7 @@ TEST_F(AlgebraicExpressionTest, BothDirections) {
 TEST_F(AlgebraicExpressionTest, SingleNode) {
 	const char *q = "MATCH (p:Person) RETURN p";
 	AlgebraicExpression **actual = build_algebraic_expression(q);
-    uint exp_count = array_len(actual);
+	uint exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 0);
 
 	AlgebraicExpression **expected = NULL;
@@ -1093,12 +1095,12 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	const char *q =
 		"MATCH (p:Person)-[ef:friend]->(f:Person) MATCH (f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p,e";
 	AlgebraicExpression **actual = build_algebraic_expression(q);
-    uint exp_count = array_len(actual);
+	uint exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 1);
 
 	AlgebraicExpression *expected[8];
 	expected[0] = AlgebraicExpression_FromString("p*F*f*V*c*W*e", _matrices);
-    compare_algebraic_expressions(actual, expected, 1);
+	compare_algebraic_expressions(actual, expected, 1);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1108,11 +1110,11 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (p:Person)-[ef:friend]->(f:Person) MATCH (f:Person)<-[ev:visit]-(c:City)<-[ew:war]-(e:City) RETURN p,e";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 1);
 
 	expected[0] = AlgebraicExpression_FromString("e*W*c*V*f*T(F)*p", _matrices);
-    compare_algebraic_expressions(actual, expected, 1);
+	compare_algebraic_expressions(actual, expected, 1);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1122,11 +1124,11 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (p:Person)-[ef:friend]->(f:Person) MATCH (f:Person)-[ev:visit]->(c:City) MATCH (c:City)-[ew:war]->(e:City) RETURN p,e";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 1);
 
 	expected[0] = AlgebraicExpression_FromString("p*F*f*V*c*W*e", _matrices);
-    compare_algebraic_expressions(actual, expected, 1);
+	compare_algebraic_expressions(actual, expected, 1);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1136,7 +1138,7 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (a:Person)-[:friend]->(f:Person) MATCH (b:Person)-[:friend]->(f:Person) RETURN a,b";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 1);
 
 	expected[0] = AlgebraicExpression_FromString("p*F*p*T(F)*p", _matrices);
@@ -1151,12 +1153,12 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (a:Person)-[:friend]->(d:Person) MATCH (b:Person)-[:friend]->(d:Person) MATCH (c:Person)-[:friend]->(d:Person) RETURN a";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 3);
 
 	expected[0] = AlgebraicExpression_FromString("p*F*p", _matrices);
 	expected[1] = AlgebraicExpression_FromString("T(F)*p", _matrices);
-    expected[2] = AlgebraicExpression_FromString("p*F*p", _matrices);
+	expected[2] = AlgebraicExpression_FromString("p*F*p", _matrices);
 	compare_algebraic_expressions(actual, expected, 3);
 
 	// Clean up.
@@ -1168,13 +1170,13 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (a:Person)-[:friend]->(b:Person) MATCH (a:Person)-[:friend]->(c:Person) MATCH (a:Person)-[:friend]->(d:Person) RETURN a";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 3);
 
 	expected[0] = AlgebraicExpression_FromString("p*T(F)*p", _matrices);
 	expected[1] = AlgebraicExpression_FromString("F*p", _matrices);
-    expected[2] = AlgebraicExpression_FromString("p*F*p", _matrices);
-    compare_algebraic_expressions(actual, expected, 3);
+	expected[2] = AlgebraicExpression_FromString("p*F*p", _matrices);
+	compare_algebraic_expressions(actual, expected, 3);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1189,11 +1191,11 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (a:Person)-[:friend]->(b:Person)-[:friend]->(a:Person) RETURN a";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 1);
 
 	expected[0] = AlgebraicExpression_FromString("p*F*p*F*p", _matrices);
-    compare_algebraic_expressions(actual, expected, 1);
+	compare_algebraic_expressions(actual, expected, 1);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1204,11 +1206,11 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (a:Person)-[:friend]->(b:Person)-[:friend]->(c:Person)-[:friend]->(a:Person) RETURN a";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 1);
 
 	expected[0] = AlgebraicExpression_FromString("p*F*p*F*p*F*p", _matrices);
-    compare_algebraic_expressions(actual, expected, 1);
+	compare_algebraic_expressions(actual, expected, 1);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1219,7 +1221,7 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (a:Person)-[:friend]->(a) RETURN a";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 1);
 
 	expected[0] = AlgebraicExpression_FromString("p*F*p", _matrices);
@@ -1234,13 +1236,13 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p2)-[:friend]->(p4)-[:friend]->(p5) RETURN p1";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 3);
 
 	expected[0] = AlgebraicExpression_FromString("F", _matrices);
-    expected[1] = AlgebraicExpression_FromString("F*F", _matrices);	
-    expected[2] = AlgebraicExpression_FromString("F*F", _matrices);
-    compare_algebraic_expressions(actual, expected, 3);
+	expected[1] = AlgebraicExpression_FromString("F*F", _matrices);
+	expected[2] = AlgebraicExpression_FromString("F*F", _matrices);
+	compare_algebraic_expressions(actual, expected, 3);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1251,15 +1253,15 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p2)-[:friend]->(p4)-[:friend]->(p5) RETURN p1,p2,p3,p4,p5";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 5);
 
 	expected[0] = AlgebraicExpression_FromString("F", _matrices);
-    expected[1] = AlgebraicExpression_FromString("F", _matrices);
-    expected[2] = AlgebraicExpression_FromString("F", _matrices);
+	expected[1] = AlgebraicExpression_FromString("F", _matrices);
+	expected[2] = AlgebraicExpression_FromString("F", _matrices);
 	expected[3] = AlgebraicExpression_FromString("F", _matrices);
-    expected[4] = AlgebraicExpression_FromString("F", _matrices);
-    compare_algebraic_expressions(actual, expected, 5);
+	expected[4] = AlgebraicExpression_FromString("F", _matrices);
+	compare_algebraic_expressions(actual, expected, 5);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1270,14 +1272,14 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p4)-[:friend]->(p5)-[:friend]->(p2)-[:friend]->(p6)-[:friend]->(p7)-[:friend]->(p3) RETURN p1";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 4);
 
 	expected[0] = AlgebraicExpression_FromString("F", _matrices);
-    expected[1] = AlgebraicExpression_FromString("F*F*F", _matrices);
-    expected[2] = AlgebraicExpression_FromString("F*F*F", _matrices);
-    expected[3] = AlgebraicExpression_FromString("F", _matrices);
-    compare_algebraic_expressions(actual, expected, 4);
+	expected[1] = AlgebraicExpression_FromString("F*F*F", _matrices);
+	expected[2] = AlgebraicExpression_FromString("F*F*F", _matrices);
+	expected[3] = AlgebraicExpression_FromString("F", _matrices);
+	compare_algebraic_expressions(actual, expected, 4);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1288,7 +1290,7 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p4)-[:friend]->(p5)-[:friend]->(p2)-[:friend]->(p6)-[:friend]->(p7)-[:friend]->(p3) RETURN p1,p2,p3,p4,p5,p6,p7";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 8);
 
 	expected[0] = AlgebraicExpression_FromString("F", _matrices);
@@ -1310,14 +1312,14 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p4)-[:friend]->(p1)-[:friend]->(p4)-[:friend]->(p5) RETURN p1";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 4);
-	
+
 	expected[0] = AlgebraicExpression_FromString("T(F)", _matrices);
 	expected[1] = AlgebraicExpression_FromString("F", _matrices);
 	expected[2] = AlgebraicExpression_FromString("F*F*F", _matrices);
 	expected[3] = AlgebraicExpression_FromString("F", _matrices);
-    compare_algebraic_expressions(actual, expected, 4);
+	compare_algebraic_expressions(actual, expected, 4);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1328,17 +1330,17 @@ TEST_F(AlgebraicExpressionTest, ShareableEntity) {
 	exp_count = 0;
 	q = "MATCH (p1)-[:friend]->(p2)-[:friend]->(p3)-[:friend]->(p4)-[:friend]->(p1)-[:friend]->(p4)-[:friend]->(p5) RETURN p1,p2,p3,p4,p5";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 6);
 
-	
+
 	expected[0] = AlgebraicExpression_FromString("T(F)", _matrices);
-    expected[1] = AlgebraicExpression_FromString("F", _matrices);
-    expected[2] = AlgebraicExpression_FromString("F", _matrices);
-    expected[3] = AlgebraicExpression_FromString("F", _matrices);
+	expected[1] = AlgebraicExpression_FromString("F", _matrices);
+	expected[2] = AlgebraicExpression_FromString("F", _matrices);
+	expected[3] = AlgebraicExpression_FromString("F", _matrices);
 	expected[4] = AlgebraicExpression_FromString("F", _matrices);
 	expected[5] = AlgebraicExpression_FromString("F", _matrices);
-    compare_algebraic_expressions(actual, expected, 6);
+	compare_algebraic_expressions(actual, expected, 6);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1350,14 +1352,14 @@ TEST_F(AlgebraicExpressionTest, VariableLength) {
 	const char *q =
 		"MATCH (p:Person)-[ef:friend]->(f:Person)-[:visit*1..3]->(c:City)-[ew:war]->(e:City) RETURN p,e";
 	AlgebraicExpression **actual = build_algebraic_expression(q);
-    uint exp_count = array_len(actual);
+	uint exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 3);
-    
+
 	AlgebraicExpression *expected[3];
 	expected[0] = AlgebraicExpression_FromString("p*F*f", _matrices);
 	expected[1] = AlgebraicExpression_FromString("V", _matrices);
 	expected[2] = AlgebraicExpression_FromString("c*W*e", _matrices);
-    compare_algebraic_expressions(actual, expected, 3);
+	compare_algebraic_expressions(actual, expected, 3);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1368,13 +1370,13 @@ TEST_F(AlgebraicExpressionTest, VariableLength) {
 	exp_count = 0;
 	q = "MATCH (p:Person)-[ef:friend]->(f:Person)<-[:visit*1..3]-(c:City)-[ew:war]->(e:City) RETURN p,e";
 	actual = build_algebraic_expression(q);
-    exp_count = array_len(actual);
+	exp_count = array_len(actual);
 	ASSERT_EQ(exp_count, 3);
-    
-    expected[0] = AlgebraicExpression_FromString("p*F*f", _matrices);
-    expected[1] = AlgebraicExpression_FromString("T(V)", _matrices);
-    expected[2] = AlgebraicExpression_FromString("c*W*e", _matrices);
-    compare_algebraic_expressions(actual, expected, 3);
+
+	expected[0] = AlgebraicExpression_FromString("p*F*f", _matrices);
+	expected[1] = AlgebraicExpression_FromString("T(V)", _matrices);
+	expected[2] = AlgebraicExpression_FromString("c*W*e", _matrices);
+	compare_algebraic_expressions(actual, expected, 3);
 
 	// Clean up.
 	free_algebraic_expressions(actual, exp_count);
@@ -1386,11 +1388,11 @@ TEST_F(AlgebraicExpressionTest, ExpressionExecute) {
 	GraphContext *gc = QueryCtx_GetGraphCtx();
 	Graph *g = gc->g;
 
-    // "MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p, e"
+	// "MATCH (p:Person)-[ef:friend]->(f:Person)-[ev:visit]->(c:City)-[ew:war]->(e:City) RETURN p, e"
 	const char *q = query_no_intermidate_return_nodes;
 	AlgebraicExpression **ae = build_algebraic_expression(q);
-    uint exp_count = array_len(ae);
-    ASSERT_EQ(exp_count, 1);
+	uint exp_count = array_len(ae);
+	ASSERT_EQ(exp_count, 1);
 
 	AlgebraicExpression *exp = ae[0];
 	ASSERT_STREQ(AlgebraicExpression_Source(exp), "p");
@@ -1422,5 +1424,6 @@ TEST_F(AlgebraicExpressionTest, ExpressionExecute) {
 	GrB_Matrix_free(&res);
 	GrB_Matrix_free(&expected);
 	free_algebraic_expressions(ae, exp_count);
-    array_free(ae);
+	array_free(ae);
 }
+

--- a/tests/unit/test_algebraic_expression.cpp
+++ b/tests/unit/test_algebraic_expression.cpp
@@ -271,6 +271,7 @@ class AlgebraicExpressionTest: public ::testing::Test {
 		ASSERT_TRUE(a->type == AL_OPERAND);
 		ASSERT_TRUE(b->type == AL_OPERAND);
 		// Can't compare matrix pointers, as transpose ops will have rewritten them
+		// TODO re-enable this after introducing persistent transposed adjacency matrices.
 		// ASSERT_EQ(a->operand.matrix, b->operand.matrix);
 	}
 


### PR DESCRIPTION
As discussed in #1058, this PR reintroduces the optimization to transpose matrices that require it once rather than per-traversal. This greatly increases performance of dest->src traversals.

With this change, AlgebraicExpression trees will no longer have any transpose operation nodes after the optimization stage. As such, all the code paths that handle these operations are currently unused, but have largely been left as-is since they may prove useful again in the future.