### PR TITLE
Omp thread configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,51 @@
+# Run-time Configuration
+
+RedisGraph supports a few run-time configuration options that can be defined when loading the module. In the future more options will be added.
+
+## Passing configuration options on module load
+
+Passing configuration options is done by appending arguments after the `--loadmodule` argument when starting a server from the command line or after the `loadmodule` directive in a Redis config file. For example:
+
+In redis.conf:
+
+```
+loadmodule ./redisgraph.so OPT1 OPT2
+```
+
+From the command line:
+
+```
+$ redis-server --loadmodule ./redisgraph.so OPT1 OPT2
+```
+
+# RedisGraph configuration options
+
+## THREAD_COUNT 
+
+The number of threads in RedisGraph's thread pool. This is equivalent to the maximum number of queries that can be processed concurrently.
+
+### Default
+
+`THREAD_COUNT` defaults to the system's processor count.
+
+### Example
+
+```
+$ redis-server --loadmodule ./redisgraph.so THREAD_COUNT 4 
+```
+
+---
+
+## OMP_THREAD_COUNT 
+
+The maximum number of threads that OpenMP may use for computation. These threads are used for parallelizing GraphBLAS computations, so may be considered to control concurrency within the execution of individual queries.
+
+### Default
+
+`OMP_THREAD_COUNT` is defined by GraphBLAS by default.
+
+### Example
+
+```
+$ redis-server --loadmodule ./redisgraph.so OMP_THREAD_COUNT 1 
+```

--- a/src/config.c
+++ b/src/config.c
@@ -124,7 +124,7 @@ int Config_Init(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	}
 
 	int res = REDISMODULE_OK;
-	for(int cur = 0; cur < argc - 1; cur += 2) {
+	for(int cur = 0; cur < argc; cur += 2) {
 		// Each configuration is a key-value pair.
 		const char *param = RedisModule_StringPtrLen(argv[cur], NULL);
 		RedisModuleString *val = argv[cur + 1];

--- a/src/config.c
+++ b/src/config.c
@@ -7,136 +7,157 @@
 #include "config.h"
 #include <unistd.h>
 #include <string.h>
-#include <assert.h>
 #include <limits.h>
 #include "util/redis_version.h"
 
-
 #define THREAD_COUNT "THREAD_COUNT" // Config param, number of threads in thread pool
 #define OMP_THREAD_COUNT "OMP_THREAD_COUNT" // Config param, max number of OpenMP threads
-#define VKEY_MAX_ENTITY_COUNT "VKEY_MAX_ENTITY_COUNT" // Config param, number of entities in virtual key
+#define VKEY_MAX_ENTITY_COUNT "VKEY_MAX_ENTITY_COUNT" // Config param, max number of entities in each virtual key
 #define VKEY_MAX_ENTITY_COUNT_DEFAULT 100000
 
 extern RG_Config config; // Global module configuration.
-static bool _initialized = false;
 
+static inline int _Config_ParsePositiveInteger(RedisModuleString *integer_str, long long *value) {
+	int res = RedisModule_StringToLongLong(integer_str, value);
+	// Return an error code if integer parsing fails or value is not positive.
+	if(res != REDISMODULE_OK || *value <= 0) return REDISMODULE_ERR;
+	return REDISMODULE_OK;
+}
 
-// Tries to fetch number of threads from
-// command line arguments if specified
-// otherwise returns thread count equals to the number
-// of cores available
-static long long _Config_SetThreadCount(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-	// Default.
+// If the user has specified a thread pool size, update the configuration.
+// Returns REDISMODULE_OK on success and REDISMODULE_ERR if the argument was invalid.
+static int _Config_SetThreadCount(RedisModuleCtx *ctx, RedisModuleString *count_str) {
+	long long thread_count;
+	int res = _Config_ParsePositiveInteger(count_str, &thread_count);
+	// Exit with error if integer parsing fails or thread count is outside of the valid range 1-INT_MAX.
+	if(res != REDISMODULE_OK || thread_count > INT_MAX) {
+		const char *invalid_arg = RedisModule_StringPtrLen(count_str, NULL);
+		RedisModule_Log(ctx, "warning", "Received invalid value %lld as thread count argument",
+						thread_count);
+		return REDISMODULE_ERR;
+	}
+
+	// Emit warning but do not fail if the specified thread count is greater than the system's
+	// number of cores (which is already set as the default value).
+	if(thread_count > config.thread_count) {
+		RedisModule_Log(ctx, "warning", "Number of threads: %d greater then number of cores: %d.",
+						thread_count, config.thread_count);
+	}
+
+	// Set the thread count in the configuration.
+	config.thread_count = thread_count;
+
+	return REDISMODULE_OK;
+}
+
+// If the user has specified a maximum number of OpenMP threads, update the configuration.
+// Returns REDISMODULE_OK on success and REDISMODULE_ERR if the argument was invalid.
+static int _Config_SetOMPThreadCount(RedisModuleCtx *ctx, RedisModuleString *count_str) {
+	long long omp_thread_count;
+	int res = _Config_ParsePositiveInteger(count_str, &omp_thread_count);
+	// Exit with error if integer parsing fails or OpenMP thread count is outside of the valid range 1-INT_MAX.
+	if(res != REDISMODULE_OK || omp_thread_count > INT_MAX) {
+		const char *invalid_arg = RedisModule_StringPtrLen(count_str, NULL);
+		RedisModule_Log(ctx, "warning", "Specified invalid maximum %lld for OpenMP thread count",
+						omp_thread_count);
+		return REDISMODULE_ERR;
+	}
+
+	// Set the OpenMP thread count in the configuration.
+	config.omp_thread_count = omp_thread_count;
+
+	return REDISMODULE_OK;
+}
+
+// If the user has specified a maximum number of entities per virtual key, update the configuration.
+// Returns REDISMODULE_OK on success and REDISMODULE_ERR if the argument was invalid.
+static int _Config_SetVirtualKeyEntitiesThreshold(RedisModuleCtx *ctx,
+												  RedisModuleString *entity_count_str) {
+	long long entity_count;
+	int res = _Config_ParsePositiveInteger(entity_count_str, &entity_count);
+	// Exit with error if integer parsing fails.
+	if(res != REDISMODULE_OK) {
+		const char *invalid_arg = RedisModule_StringPtrLen(entity_count_str, NULL);
+		RedisModule_Log(ctx, "warning", "Could not parse virtual key size argument '%s' as an integer",
+						invalid_arg);
+		return REDISMODULE_ERR;
+	}
+
+	// Log the new entity threshold.
+	RedisModule_Log(ctx, "notice", "Max number of entities per graph meta key set to %lld.",
+					entity_count);
+
+	// Update the entity count in the configuration.
+	config.vkey_entity_count = entity_count;
+
+	return REDISMODULE_OK;
+}
+
+// Initialize every module-level configuration to its default value.
+static void _Config_SetToDefaults(void) {
+	// The thread pool's default size is equal to the system's number of cores.
 	int CPUCount = sysconf(_SC_NPROCESSORS_ONLN);
-	long long threadCount = (CPUCount != -1) ? CPUCount : 1;
+	config.thread_count = (CPUCount != -1) ? CPUCount : 1;
 
-	// Number of thread specified in configuration?
-	// Expecting configuration to be in the form of key value pairs.
-	if(argc % 2 == 0) {
-		// Scan arguments for THREAD_COUNT.
-		for(int i = 0; i < argc; i += 2) {
-			const char *param = RedisModule_StringPtrLen(argv[i], NULL);
-			if(strcasecmp(param, THREAD_COUNT) == 0) {
-				RedisModule_StringToLongLong(argv[i + 1], &threadCount);
-				break;
-			}
+	// Allow GraphBLAS to set the OpenMP thread count by default.
+	config.omp_thread_count = -1;
+
+	if(!Redis_Version_GreaterOrEqual(6, 0, 0)) {
+		// For redis-server versions below 6.0.0, we will not split the graph into virtual keys.
+		config.vkey_entity_count = VKEY_ENTITY_COUNT_UNLIMITED;
+	} else {
+		// The default entity count of virtual keys for server versions >= 6 is set by macro.
+		config.vkey_entity_count = VKEY_MAX_ENTITY_COUNT_DEFAULT;
+	}
+}
+
+// If an argument is a key-value pair, emit an error if we try to read past the end of the argv array.
+#define VALIDATE_KEYVAL_ARGC { \
+	if (cur >= argc) { \
+		RedisModule_Log(ctx, "warning", "Module parameter '%s' requires a value", param); \
+		return REDISMODULE_ERR; \
+	} \
+}
+
+int Config_Init(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+	// Initialize the configuration to its default values.
+	_Config_SetToDefaults();
+
+	int res = REDISMODULE_OK;
+	for(int cur = 0; cur < argc; cur ++) {
+		const char *param = RedisModule_StringPtrLen(argv[cur], NULL);
+		if(!strcasecmp(param, THREAD_COUNT)) {
+			cur++; // Argument is a key-value pair, increment the counter.
+			VALIDATE_KEYVAL_ARGC; // Error if we try to read past the end of the argv array.
+			res = _Config_SetThreadCount(ctx, argv[cur]);
+		} else if(!strcasecmp(param, OMP_THREAD_COUNT)) {
+			cur++; // Argument is a key-value pair, increment the counter.
+			VALIDATE_KEYVAL_ARGC; // Error if we try to read past the end of the argv array.
+			res = _Config_SetOMPThreadCount(ctx, argv[cur]);
+		} else if(!strcasecmp(param, VKEY_MAX_ENTITY_COUNT)) {
+			cur++; // Argument is a key-value pair, increment the counter.
+			VALIDATE_KEYVAL_ARGC; // Error if we try to read past the end of the argv array.
+			res = _Config_SetVirtualKeyEntitiesThreshold(ctx, argv[cur]);
+		} else {
+			RedisModule_Log(ctx, "warning", "Encountered unknown module argument '%s'", param);
 		}
+
+		// Exit if we encountered an error.
+		if(res != REDISMODULE_OK) return res;
 	}
 
-	// Sanity.
-	assert(threadCount > 0);
-	if(threadCount > CPUCount)
-		RedisModule_Log(ctx,
-						"warning",
-						"Number of threads: %d greater then number of cores: %d.",
-						threadCount,
-						CPUCount);
-
-	return threadCount;
+	return res;
 }
 
-// Scans the LOADMODULE arguments for a user-defined maximum number of OpenMP threads.
-// Returns to -1 and does not override default behavior if no such valid argument was found.
-static int _Config_SetOMPThreadCount(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-	// Scan module arguments for OMP_THREAD_COUNT and extract the value if found.
-	for(int i = 0; i < argc; i += 2) {
-		const char *param = RedisModule_StringPtrLen(argv[i], NULL);
-		if(strcasecmp(param, OMP_THREAD_COUNT)) continue;
-
-		long long omp_thread_count;
-		RedisModule_StringToLongLong(argv[i + 1], &omp_thread_count);
-		if(omp_thread_count < 1 || omp_thread_count > INT_MAX) {
-			// The acceptable range for max OpenMP threads is 1 to INT_MAX.
-			RedisModule_Log(ctx, "warning",
-							"Specified invalid maximum %d for OpenMP threads",
-							omp_thread_count);
-			break;
-		}
-		// A valid maximum was specified, return it.
-		return omp_thread_count;
-	}
-
-	// Return -1 in the default case or if an invalid configuration was specified.
-	return -1;
+inline int Config_GetThreadCount() {
+	return config.thread_count;
 }
 
-// Tries to fetch the number of entities to encode as part of virtual key encoding.
-// Defaults to VKEY_MAX_ENTITY_COUNT_DEFAULT
-static uint64_t _Config_SetVirtualKeyEntitiesThreshold(RedisModuleCtx *ctx,
-													   RedisModuleString **argv,
-													   int argc) {
-
-	// For redis-server versions below 6.0.0, we will not split the graph to virtual keys.
-	if(!Redis_Version_GreaterOrEqual(6, 0, 0)) return VKEY_ENTITY_COUNT_UNLIMITED;
-	// Default.
-	long long threshold = VKEY_MAX_ENTITY_COUNT_DEFAULT;
-
-	// Entities threshold defined in configuration?
-	// Expecting configuration to be in the form of key value pairs.
-	if(argc % 2 == 0) {
-		// Scan arguments for VKEY_MAX_ENTITY_COUNT.
-		for(int i = 0; i < argc; i += 2) {
-			const char *param = RedisModule_StringPtrLen(argv[i], NULL);
-			if(strcasecmp(param, VKEY_MAX_ENTITY_COUNT) == 0) {
-				RedisModule_StringToLongLong(argv[i + 1], &threshold);
-				break;
-			}
-		}
-	}
-
-	// Sanity.
-	assert(threshold > 0 && "A positive integer is required for the number of entities in virtual key");
-	RedisModule_Log(ctx, "notice", "Entities limit per graph meta key set to %d.", threshold);
-
-	return (uint64_t)threshold;
+inline int Config_GetOMPThreadCount() {
+	return config.omp_thread_count;
 }
 
-void Config_Init(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
-	config.vkey_entity_count = _Config_SetVirtualKeyEntitiesThreshold(ctx, argv, argc);
-	config.thread_count = _Config_SetThreadCount(ctx, argv, argc);
-	config.omp_thread_count = _Config_SetOMPThreadCount(ctx, argv, argc);
-	_initialized = true;
-}
-
-/* Static function for:
- * 1. Validation of the configuration object.
- * 2. Future proofing retrieval calls to the configuration object from within config.c.
- * 3. Future proofing retrieval calls to the configuration object outside config.c.
- */
-static inline RG_Config _Config_GetModuleConfig() {
-	assert(_initialized && "Module configuration was not initialized");
-	return config;
-}
-
-long long Config_GetThreadCount() {
-	return _Config_GetModuleConfig().thread_count;
-}
-
-int Config_GetOMPThreadCount() {
-	return _Config_GetModuleConfig().omp_thread_count;
-}
-
-uint64_t Config_GetVirtualKeyEntityCount() {
-	return _Config_GetModuleConfig().vkey_entity_count;
+inline uint64_t Config_GetVirtualKeyEntityCount() {
+	return config.vkey_entity_count;
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -55,6 +55,8 @@ static long long _Config_SetThreadCount(RedisModuleCtx *ctx, RedisModuleString *
 	return threadCount;
 }
 
+// Scans the LOADMODULE arguments for a user-defined maximum number of OpenMP threads.
+// Returns to -1 and does not override default behavior if no such valid argument was found.
 static int _Config_SetOMPThreadCount(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	// Scan module arguments for OMP_THREAD_COUNT and extract the value if found.
 	for(int i = 0; i < argc; i += 2) {

--- a/src/config.c
+++ b/src/config.c
@@ -118,8 +118,8 @@ void Config_Init(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
 /* Static function for:
  * 1. Validation of the configuration object.
- * 2. Future proofing retrival calls to the configuration object from withing config.c.
- * 3. Futute proofing retrival calls to the configuration object outside config.c.
+ * 2. Future proofing retrieval calls to the configuration object from within config.c.
+ * 3. Future proofing retrieval calls to the configuration object outside config.c.
  */
 static inline RG_Config _Config_GetModuleConfig() {
 	assert(_initialized && "Module configuration was not initialized");

--- a/src/config.h
+++ b/src/config.h
@@ -11,14 +11,14 @@
 
 typedef struct {
 	int omp_thread_count;        // Maximum number of OpenMP threads, -1 indicates the default value.
-	long long thread_count;      // Thread count for thread pool.
+	int thread_count;            // Thread count for thread pool.
 	uint64_t vkey_entity_count;  // The limit of number of entities encoded at once for each RDB key.
 } RG_Config;
 
-void Config_Init(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+int Config_Init(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 // Return the module thread pool size.
-long long Config_GetThreadCount(void);
+int Config_GetThreadCount(void);
 
 // Return the max number of OpenMP threads or -1 if using the default value.
 int Config_GetOMPThreadCount(void);

--- a/src/config.h
+++ b/src/config.h
@@ -10,11 +10,13 @@
 #define VKEY_ENTITY_COUNT_UNLIMITED UINT64_MAX
 
 typedef struct {
-	int omp_thread_count;        // Maximum number of OpenMP threads, -1 indicates the default value.
+	int omp_thread_count;        // Maximum number of OpenMP threads.
 	int thread_count;            // Thread count for thread pool.
 	uint64_t vkey_entity_count;  // The limit of number of entities encoded at once for each RDB key.
 } RG_Config;
 
+// Set module-level configurations to defaults or to user arguments where provided.
+// Returns REDISMODULE_OK on success, emits an error and returns REDISMODULE_ERR on failure.
 int Config_Init(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 // Return the module thread pool size.

--- a/src/config.h
+++ b/src/config.h
@@ -10,6 +10,7 @@
 #define VKEY_ENTITY_COUNT_UNLIMITED UINT64_MAX
 
 typedef struct {
+	int omp_thread_count;        // Maximum number of OpenMP threads, -1 indicates the default value.
 	long long thread_count;      // Thread count for thread pool.
 	uint64_t vkey_entity_count;  // The limit of number of entities encoded at once for each RDB key.
 } RG_Config;
@@ -17,7 +18,11 @@ typedef struct {
 void Config_Init(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 
 // Return the module thread pool size.
-long long Config_GetThreadCount();
+long long Config_GetThreadCount(void);
+
+// Return the max number of OpenMP threads or -1 if the default.
+int Config_GetOMPThreadCount(void);
 
 // Return the module virtual key entity limit.
-uint64_t Confic_GetVirtualKeyEntityCount();
+uint64_t Config_GetVirtualKeyEntityCount(void);
+

--- a/src/config.h
+++ b/src/config.h
@@ -20,7 +20,7 @@ void Config_Init(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
 // Return the module thread pool size.
 long long Config_GetThreadCount(void);
 
-// Return the max number of OpenMP threads or -1 if the default.
+// Return the max number of OpenMP threads or -1 if using the default value.
 int Config_GetOMPThreadCount(void);
 
 // Return the module virtual key entity limit.

--- a/src/module.c
+++ b/src/module.c
@@ -114,6 +114,12 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 	if(!_Setup_ThreadPOOL(threadCount)) return REDISMODULE_ERR;
 	RedisModule_Log(ctx, "notice", "Thread pool created, using %d threads.", threadCount);
 
+	int ompThreadCount = Config_GetOMPThreadCount();
+	if(ompThreadCount > 0) {
+		GxB_set(GxB_NTHREADS, ompThreadCount);
+		RedisModule_Log(ctx, "notice", "Max number of OpenMP threads set to %d", ompThreadCount);
+	}
+
 	if(_RegisterDataTypes(ctx) != REDISMODULE_OK) return REDISMODULE_ERR;
 
 	if(RedisModule_CreateCommand(ctx, "graph.QUERY", CommandDispatch, "write deny-oom", 1, 1,
@@ -148,3 +154,4 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 
 	return REDISMODULE_OK;
 }
+

--- a/src/module.c
+++ b/src/module.c
@@ -121,8 +121,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 	RedisModule_Log(ctx, "notice", "Thread pool created, using %d threads.", threadCount);
 
 	int ompThreadCount = Config_GetOMPThreadCount();
-	res = GxB_set(GxB_NTHREADS, ompThreadCount);
-	if(res != GrB_SUCCESS) {
+	if(GxB_set(GxB_NTHREADS, ompThreadCount) != GrB_SUCCESS) {
 		RedisModule_Log(ctx, "warning", "Failed to set OpenMP thread count to %d", ompThreadCount);
 		return REDISMODULE_ERR;
 	}

--- a/src/module.c
+++ b/src/module.c
@@ -117,7 +117,7 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 	int ompThreadCount = Config_GetOMPThreadCount();
 	if(ompThreadCount > 0) {
 		GxB_set(GxB_NTHREADS, ompThreadCount);
-		RedisModule_Log(ctx, "notice", "Max number of OpenMP threads set to %d", ompThreadCount);
+		RedisModule_Log(ctx, "notice", "Maximum number of OpenMP threads set to %d", ompThreadCount);
 	}
 
 	if(_RegisterDataTypes(ctx) != REDISMODULE_OK) return REDISMODULE_ERR;

--- a/src/module.c
+++ b/src/module.c
@@ -73,7 +73,6 @@ static int _RegisterDataTypes(RedisModuleCtx *ctx) {
 static void _PrepareModuleGlobals(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	graphs_in_keyspace = array_new(GraphContext *, 1);
 	process_is_child = false;
-	Config_Init(ctx, argv, argc);
 }
 
 int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -104,19 +103,27 @@ int RedisModule_OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) 
 	Agg_RegisterFuncs();     // Register aggregation functions.
 	// Set up global lock and variables scoped to the entire module.
 	_PrepareModuleGlobals(ctx, argv, argc);
+
+	// Set up the module's configurable variables, using user-defined values where provided.
+	if(Config_Init(ctx, argv, argc) != REDISMODULE_OK) return REDISMODULE_ERR;
+
 	RegisterEventHandlers(ctx);
 	CypherWhitelist_Build(); // Build whitelist of supported Cypher elements.
 
 	// Create thread local storage key.
 	if(!QueryCtx_Init()) return REDISMODULE_ERR;
 
-	long long threadCount = Config_GetThreadCount();
+	int threadCount = Config_GetThreadCount();
 	if(!_Setup_ThreadPOOL(threadCount)) return REDISMODULE_ERR;
 	RedisModule_Log(ctx, "notice", "Thread pool created, using %d threads.", threadCount);
 
 	int ompThreadCount = Config_GetOMPThreadCount();
 	if(ompThreadCount > 0) {
-		GxB_set(GxB_NTHREADS, ompThreadCount);
+		GrB_Info res = GxB_set(GxB_NTHREADS, ompThreadCount);
+		if(res != GrB_SUCCESS) {
+			RedisModule_Log(ctx, "warning", "Failed to set OpenMP thread count to %d", ompThreadCount);
+			return REDISMODULE_ERR;
+		}
 		RedisModule_Log(ctx, "notice", "Maximum number of OpenMP threads set to %d", ompThreadCount);
 	}
 

--- a/src/module_event_handlers.c
+++ b/src/module_event_handlers.c
@@ -76,7 +76,7 @@ static bool _GraphContext_NameContainsTag(const GraphContext *gc) {
 
 // Calculate how many virtual keys are needed to represent the graph.
 static uint64_t _GraphContext_RequiredMetaKeys(const GraphContext *gc) {
-	uint64_t vkey_entity_count = Confic_GetVirtualKeyEntityCount();
+	uint64_t vkey_entity_count = Config_GetVirtualKeyEntityCount();
 	// If no limitation, return 0. The graph can be encoded in a single key.
 	if(vkey_entity_count == UNLIMITED) return 0;
 	uint64_t entities_count = Graph_NodeCount(gc->g) + Graph_EdgeCount(gc->g) + Graph_DeletedNodeCount(

--- a/src/serializers/encoder/v7/encode_graph.c
+++ b/src/serializers/encoder/v7/encode_graph.c
@@ -88,7 +88,7 @@ static PayloadInfo *_RdbSaveKeySchema(RedisModuleIO *rdb, GraphContext *gc) {
 	EncodeState current_state = GraphEncodeContext_GetEncodeState(gc->encoding_context);
 	// If it is the start of the encodeing, set the state to be NODES.
 	if(current_state == ENCODE_STATE_INIT) current_state = ENCODE_STATE_NODES;
-	uint64_t remaining_entities = Confic_GetVirtualKeyEntityCount();
+	uint64_t remaining_entities = Config_GetVirtualKeyEntityCount();
 	// No limit on the entities, the graph is encoded in one key.
 	if(remaining_entities == VKEY_ENTITY_COUNT_UNLIMITED) {
 		for(uint state = ENCODE_STATE_NODES; state < ENCODE_STATE_FINAL; state++) {
@@ -198,3 +198,4 @@ void RdbSaveGraph_v7(RedisModuleIO *rdb, void *value) {
 	// If a lock was acquired, release it.
 	if(_shouldAcquireLocks()) Graph_ReleaseLock(gc->g);
 }
+


### PR DESCRIPTION
Expose configuration for OpenMP max thread count on module load; add documentation for `THREAD_COUNT` and `OMP_THREAD_COUNT` configurations.