### PR TITLE
Move index iterator construction to first Consume call

### DIFF
--- a/src/execution_plan/ops/op_index_scan.h
+++ b/src/execution_plan/ops/op_index_scan.h
@@ -18,11 +18,12 @@ typedef struct {
 	RSIndex *idx;
 	const QGNode *n;
 	uint nodeRecIdx;
-	RSResultsIterator *iter;
+	RSQNode *iter_populator;    /* RediSearch query node used to construct iterator. */
+	RSResultsIterator *iter;    /* RediSearch iterator over an index with the appropriate filters. */
 	Record child_record;        /* The Record this op acts on if it is not a tap. */
 } IndexScan;
 
 /* Creates a new IndexScan operation */
 OpBase *NewIndexScanOp(const ExecutionPlan *plan, Graph *g, const QGNode *n, RSIndex *idx,
-					   RSResultsIterator *iter);
+					   RSQNode *iter_populator);
 

--- a/src/execution_plan/ops/op_index_scan.h
+++ b/src/execution_plan/ops/op_index_scan.h
@@ -18,12 +18,12 @@ typedef struct {
 	RSIndex *idx;
 	const QGNode *n;
 	uint nodeRecIdx;
-	RSQNode *iter_populator;    /* RediSearch query node used to construct iterator. */
+	RSQNode *rs_query_node;     /* RediSearch query node used to construct iterator. */
 	RSResultsIterator *iter;    /* RediSearch iterator over an index with the appropriate filters. */
 	Record child_record;        /* The Record this op acts on if it is not a tap. */
 } IndexScan;
 
 /* Creates a new IndexScan operation */
 OpBase *NewIndexScanOp(const ExecutionPlan *plan, Graph *g, const QGNode *n, RSIndex *idx,
-					   RSQNode *iter_populator);
+					   RSQNode *rs_query_node);
 

--- a/src/execution_plan/optimizations/utilize_indices.c
+++ b/src/execution_plan/optimizations/utilize_indices.c
@@ -493,10 +493,8 @@ cleanup:
 
 	if(root) {
 		/* We've successfully created a RediSearch query node that may be used to populate an Index Scan.
-		 * Pass ownership of the root node to the iterator. */
-		RSResultsIterator *iter = RediSearch_GetResultsIterator(root, rs_idx);
-		// Build the Index Scan.
-		OpBase *indexOp = NewIndexScanOp(scan->op.plan, scan->g, scan->n, rs_idx, iter);
+		 * Build a new Index Scan and pass ownership of the query node to it. */
+		OpBase *indexOp = NewIndexScanOp(scan->op.plan, scan->g, scan->n, rs_idx, root);
 
 		/* Replace the redundant scan op with the newly-constructed Index Scan. */
 		ExecutionPlan_ReplaceOp(plan, (OpBase *)scan, indexOp);

--- a/tests/flow/test_index_scans.py
+++ b/tests/flow/test_index_scans.py
@@ -267,3 +267,12 @@ class testIndexScanFlow(FlowTestsBase):
         expected_result = ["Lucy Yanfital"]
         self.env.assertEquals(query_result.result_set[0], expected_result)
 
+    def test11_single_index_multiple_scans(self):
+        query = "MERGE (p1:person {age: 40}) MERGE (p2:person {age: 41})"
+        plan = redis_graph.execution_plan(query)
+        # Two index scans should be performed.
+        self.env.assertEqual(plan.count("Index Scan"), 2)
+
+        query_result = redis_graph.query(query)
+        # Two new nodes should be created.
+        self.env.assertEquals(query_result.nodes_created, 2)


### PR DESCRIPTION
This PR resolves an issue with queries deadlocking if multiple Index Scans utilizing the same index are positioned in the op tree such that a write to that index cannot acquire the index's write lock, as in `MERGE (a:A {v: 1}) MERGE (b:A {v: 2})`:
```
1) "Merge"
2) "    Merge"
3) "        Index Scan | (a:A)"
4) "        MergeCreate"
5) "    Index Scan | (b:A)"
6) "        Argument"
7) "    MergeCreate"
8) "        Argument"
```
The solution is for index scans to build their iterator (and thus acquire their read lock) at the time of first `Consume` invocation, rather than at the time of op creation.

Resolves #1150 