### PR TITLE
added explain and profile options as invalid options in redisgraph

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1468,6 +1468,14 @@ static AST_Validation _ValidateDuplicateParameters(const cypher_astnode_t *state
 	uint noptions = cypher_ast_statement_noptions(statement);
 	for(uint i = 0; i < noptions; i++) {
 		const cypher_astnode_t *option = cypher_ast_statement_get_option(statement, i);
+		const cypher_astnode_type_t type = cypher_astnode_type(option);
+		if((type == CYPHER_AST_EXPLAIN_OPTION) || (type == CYPHER_AST_PROFILE_OPTION)) {
+			const char *invalid_option_name = cypher_astnode_typestr(type);
+			QueryCtx_SetError("The %s option should be used in GRAPH.%s command", invalid_option_name,
+							  invalid_option_name);
+			raxFree(param_names);
+			return AST_INVALID;
+		}
 		uint nparams = cypher_ast_cypher_option_nparams(option);
 		for(uint j = 0; j < nparams; j++) {
 			const cypher_astnode_t *param = cypher_ast_cypher_option_get_param(option, j);

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1462,20 +1462,27 @@ static void _collect_query_parameters_names(const cypher_astnode_t *root, rax *k
 	}
 }
 
-static AST_Validation _ValidateDuplicateParameters(const cypher_astnode_t *statement) {
-	char *err = NULL;
-	rax *param_names = raxNew();
+static AST_Validation _ValidateParamsOnly(const cypher_astnode_t *statement) {
 	uint noptions = cypher_ast_statement_noptions(statement);
 	for(uint i = 0; i < noptions; i++) {
 		const cypher_astnode_t *option = cypher_ast_statement_get_option(statement, i);
 		const cypher_astnode_type_t type = cypher_astnode_type(option);
 		if((type == CYPHER_AST_EXPLAIN_OPTION) || (type == CYPHER_AST_PROFILE_OPTION)) {
 			const char *invalid_option_name = cypher_astnode_typestr(type);
-			QueryCtx_SetError("The %s option should be used in GRAPH.%s command", invalid_option_name,
-							  invalid_option_name);
-			raxFree(param_names);
+			QueryCtx_SetError("Please use GRAPH.%s 'key' 'query' command instead of GRAPH.QUERY 'key' '%s query'",
+							  invalid_option_name, invalid_option_name);
 			return AST_INVALID;
 		}
+	}
+	return AST_VALID;
+}
+
+static AST_Validation _ValidateDuplicateParameters(const cypher_astnode_t *statement) {
+	char *err = NULL;
+	rax *param_names = raxNew();
+	uint noptions = cypher_ast_statement_noptions(statement);
+	for(uint i = 0; i < noptions; i++) {
+		const cypher_astnode_t *option = cypher_ast_statement_get_option(statement, i);
 		uint nparams = cypher_ast_cypher_option_nparams(option);
 		for(uint j = 0; j < nparams; j++) {
 			const cypher_astnode_t *param = cypher_ast_cypher_option_get_param(option, j);
@@ -1661,6 +1668,7 @@ AST_Validation AST_Validate_QueryParams(const cypher_parse_result_t *result) {
 	// In case of no parameters.
 	if(cypher_ast_statement_noptions(root) == 0) return AST_VALID;
 
+	if(_ValidateParamsOnly(root) != AST_VALID) return AST_INVALID;
 	if(_ValidateDuplicateParameters(root) != AST_VALID) return AST_INVALID;
 
 	return AST_VALID;

--- a/tests/flow/test_params.py
+++ b/tests/flow/test_params.py
@@ -107,36 +107,3 @@ class testParams(FlowTestsBase):
         plan = redis_graph.execution_plan(query)
         self.env.assertIn('NodeByIdSeek', plan)
 
-    def test_invalid_cypher_options(self):
-        query = "EXPLAIN MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
-        try:
-            redis_graph.query(query)
-            assert(False)
-        except:
-            # Expecting an error.
-            pass
-
-        query = "PROFILE MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
-        try:
-            redis_graph.query(query)
-            assert(False)
-        except:
-            # Expecting an error.
-            pass
-
-        query = "CYPHER val=1 EXPLAIN MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
-        try:
-            redis_graph.query(query)
-            assert(False)
-        except:
-            # Expecting an error.
-            pass
-
-        query = "CYPHER val=1 PROFILE MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
-        try:
-            redis_graph.query(query)
-            assert(False)
-        except:
-            # Expecting an error.
-            pass
-

--- a/tests/flow/test_params.py
+++ b/tests/flow/test_params.py
@@ -107,3 +107,36 @@ class testParams(FlowTestsBase):
         plan = redis_graph.execution_plan(query)
         self.env.assertIn('NodeByIdSeek', plan)
 
+    def test_invalid_cypher_options(self):
+        query = "EXPLAIN MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+
+        query = "PROFILE MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+
+        query = "CYPHER val=1 EXPLAIN MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+
+        query = "CYPHER val=1 PROFILE MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -225,3 +225,37 @@ class testQueryValidationFlow(FlowTestsBase):
             # Expecting an error.
             assert("not defined" in e.message)
             pass
+
+    def test_invalid_cypher_options(self):
+        query = "EXPLAIN MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+
+        query = "PROFILE MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+
+        query = "CYPHER val=1 EXPLAIN MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+
+        query = "CYPHER val=1 PROFILE MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
+        try:
+            redis_graph.query(query)
+            assert(False)
+        except:
+            # Expecting an error.
+            pass
+


### PR DESCRIPTION
`EXPLAIN` and `PROFILE` are cypher query execution options. In RedisGraph we have them as explicit commands.
This PR invalidate a query sent with those options as invalid query and prompts the user to use the explicit command 

```
127.0.0.1:6379> graph.query g "EXPLAIN MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
(error) The EXPLAIN option should be used in GRAPH.EXPLAIN command
127.0.0.1:6379> graph.query g "PROFILE MATCH (p:president)-[:born]->(:state {name:'Hawaii'}) RETURN p"
(error) The PROFILE option should be used in GRAPH.PROFILE command
```

closes #1181 