### PR TITLE
ReduceScan and ReduceTraversal respect variable scopes (#1070)

### DIFF
--- a/src/execution_plan/execution_plan_modify.c
+++ b/src/execution_plan/execution_plan_modify.c
@@ -264,6 +264,12 @@ void ExecutionPlan_BoundVariables(const OpBase *op, rax *modifiers) {
 		}
 	}
 
+	/* Project and Aggregate operations demarcate variable scopes,
+	 * collect their projections but do not recurse into their children.
+	 * Note that future optimizations which operate across scopes will require different logic
+	 * than this for application. */
+	if(op->type == OPType_PROJECT || op->type == OPType_AGGREGATE) return;
+
 	for(int i = 0; i < op->childCount; i++) {
 		ExecutionPlan_BoundVariables(op->children[i], modifiers);
 	}

--- a/src/execution_plan/optimizations/reduce_scans.c
+++ b/src/execution_plan/optimizations/reduce_scans.c
@@ -29,25 +29,25 @@ static void _reduceScans(ExecutionPlan *plan, OpBase *scan) {
 	assert(array_len(scan->modifies) == 1);
 	const char *scanned_alias = scan->modifies[0];
 
-	// Check if that alias is already bound by any of the scan's children.
+	// Collect variables bound before this operation.
+	rax *bound_vars = raxNew();
 	for(int i = 0; i < scan->childCount; i ++) {
-		if(ExecutionPlan_LocateOpResolvingAlias(scan->children[i], scanned_alias)) {
-			/* Here is the case where a node is already populated in the record when it arrived to a label scan operation.
-			 * The label scan operation here is redundent since it will re-scan the entire graph, so we will replace it with
-			 * a conditional traverse operation which will filter only the nodes with the requested labels.
-			 * The conditional traverse is done over the label matrix, and is more efficient then a filter operation. */
-			if(scan->type == OPType_NODE_BY_LABEL_SCAN) {
-				OpBase *traverse = _LabelScanToConditionalTraverse((NodeByLabelScan *)scan);
-				ExecutionPlan_ReplaceOp(plan, scan, traverse);
-				OpBase_Free(scan);
-				break;
-			}
-			// The scanned alias is already bound, remove the redundant scan op.
-			ExecutionPlan_RemoveOp(plan, scan);
-			OpBase_Free(scan);
-			break;
-		}
+		ExecutionPlan_BoundVariables(scan->children[i], bound_vars);
 	}
+
+	if(raxFind(bound_vars, (unsigned char *)scanned_alias, strlen(scanned_alias)) != raxNotFound) {
+		// If the alias the scan operates on is already bound, the scan operation is redundant.
+		if(scan->type == OPType_NODE_BY_LABEL_SCAN) {
+			// If we are performing a label scan, introduce a conditional traversal to filter by label.
+			OpBase *traverse = _LabelScanToConditionalTraverse((NodeByLabelScan *)scan);
+			ExecutionPlan_ReplaceOp(plan, scan, traverse);
+		} else {
+			// Remove the redundant scan op.
+			ExecutionPlan_RemoveOp(plan, scan);
+		}
+		OpBase_Free(scan);
+	}
+	raxFree(bound_vars);
 }
 
 void reduceScans(ExecutionPlan *plan) {

--- a/tests/flow/test_optimizations_plan.py
+++ b/tests/flow/test_optimizations_plan.py
@@ -325,10 +325,32 @@ class testOptimizationsPlan(FlowTestsBase):
         executionPlan = graph.execution_plan(query)
         self.env.assertNotIn("Filter", executionPlan)
 
-    def test19_test_filter_compaction_not_removing_false_filter(self):
+    def test20_test_filter_compaction_not_removing_false_filter(self):
         query = "MATCH (n) WHERE 1 > 1 RETURN n"
         executionPlan = graph.execution_plan(query)
         self.env.assertIn("Filter", executionPlan)
         resultset = graph.query(query).result_set
         expected = []
+        self.env.assertEqual(resultset, expected)
+
+    # ExpandInto should be applied where possible on projected graph entities.
+    def test21_expand_into_projected_endpoints(self):
+        query = """MATCH (a)-[]->(b) WITH a, b MATCH (a)-[e]->(b) RETURN a.val, b.val ORDER BY a.val, b.val LIMIT 3"""
+        executionPlan = graph.execution_plan(query)
+        self.env.assertIn("Expand Into", executionPlan)
+        resultset = graph.query(query).result_set
+        expected = [[0, 1],
+                    [0, 2],
+                    [0, 3]]
+        self.env.assertEqual(resultset, expected)
+
+    # Variables bound in one scope should not be used to introduce ExpandInto ops in later scopes.
+    def test22_no_expand_into_across_scopes(self):
+        query = """MATCH (reused_1)-[]->(reused_2) WITH COUNT(reused_2) as edge_count MATCH (reused_1)-[]->(reused_2) RETURN edge_count, reused_1.val, reused_2.val ORDER BY reused_1.val, reused_2.val LIMIT 3"""
+        executionPlan = graph.execution_plan(query)
+        self.env.assertNotIn("Expand Into", executionPlan)
+        resultset = graph.query(query).result_set
+        expected = [[14, 0, 1],
+                    [14, 0, 2],
+                    [14, 0, 3]]
         self.env.assertEqual(resultset, expected)

--- a/tests/tck/features/WithAcceptance.feature
+++ b/tests/tck/features/WithAcceptance.feature
@@ -265,7 +265,6 @@ Feature: WithAcceptance
             | 'B'  |
         And no side effects
 
-    @skip
     Scenario: A simple pattern with one bound endpoint
         Given an empty graph
         And having executed:


### PR DESCRIPTION
* ReduceScan and ReduceTraversal respect variable scopes

* Fix source lookup

* PR fixes

Co-authored-by: Roi Lipman <swilly22@users.noreply.github.com>
(cherry picked from commit 29b75d8bad41fa09edaec651c7093f53e18ee9c2)