### PR TITLE
Add suppression for erroneous leak reports after DEBUG RELOAD (#1094)

### DIFF
--- a/src/valgrind.supp
+++ b/src/valgrind.supp
@@ -66,3 +66,12 @@
    ...
    fun:Indexer_Add
 }
+
+{
+   <RLTest race: ignore leaks in _GraphContext_Free caused by DEBUG RELOAD>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   ...
+   fun:rdbLoad
+   fun:debugCommand
+}


### PR DESCRIPTION
(cherry picked from commit 386a8e6c8be9c59278c34c9ac8fd6cc6aac55c1e)