### PR TITLE
Move index iterator construction to first Consume call (#1169)

### DIFF
--- a/src/execution_plan/ops/op_index_scan.c
+++ b/src/execution_plan/ops/op_index_scan.c
@@ -19,13 +19,14 @@ static int IndexScanToString(const OpBase *ctx, char *buf, uint buf_len) {
 }
 
 OpBase *NewIndexScanOp(const ExecutionPlan *plan, Graph *g, const QGNode *n, RSIndex *idx,
-					   RSResultsIterator *iter) {
+					   RSQNode *rs_query_node) {
 	IndexScan *op = rm_malloc(sizeof(IndexScan));
 	op->g = g;
 	op->n = n;
 	op->idx = idx;
-	op->iter = iter;
+	op->iter = NULL;
 	op->child_record = NULL;
+	op->rs_query_node = rs_query_node;
 
 	// Set our Op operations
 	OpBase_Init((OpBase *)op, OPType_INDEX_SCAN, "Index Scan", IndexScanInit, IndexScanConsume,
@@ -49,6 +50,14 @@ static inline void _UpdateRecord(IndexScan *op, Record r, EntityID node_id) {
 
 static Record IndexScanConsumeFromChild(OpBase *opBase) {
 	IndexScan *op = (IndexScan *)opBase;
+
+	if(op->iter == NULL) {
+		/* On the first execution of IndexScanConsumeFromChild, use the RediSearch query node
+		 * to populate an index iterator. This causes the index to acquire a read lock. */
+		op->iter = RediSearch_GetResultsIterator(op->rs_query_node, op->idx);
+		// The query node is now part of the iterator, explicitly NULL-set it to prevent a double free.
+		op->rs_query_node = NULL;
+	}
 
 	if(op->child_record == NULL) {
 		op->child_record = OpBase_Consume(op->op.children[0]);
@@ -80,6 +89,14 @@ static Record IndexScanConsumeFromChild(OpBase *opBase) {
 
 static Record IndexScanConsume(OpBase *opBase) {
 	IndexScan *op = (IndexScan *)opBase;
+	if(op->iter == NULL) {
+		/* On the first execution of IndexScanConsume, use the RediSearch query node
+		 * to populate an index iterator. This causes the index to acquire a read lock. */
+		op->iter = RediSearch_GetResultsIterator(op->rs_query_node, op->idx);
+		// The query node is now part of the iterator, explicitly NULL-set it to prevent a double free.
+		op->rs_query_node = NULL;
+	}
+
 	const EntityID *nodeId = RediSearch_ResultsIteratorNext(op->iter, op->idx, NULL);
 	if(!nodeId) return NULL;
 
@@ -106,6 +123,11 @@ static void IndexScanFree(OpBase *opBase) {
 	if(op->iter) {
 		RediSearch_ResultsIteratorFree(op->iter);
 		op->iter = NULL;
+	}
+
+	if(op->rs_query_node) {
+		RediSearch_QueryNodeFree(op->rs_query_node);
+		op->rs_query_node = NULL;
 	}
 
 	if(op->child_record) {

--- a/src/execution_plan/ops/op_index_scan.h
+++ b/src/execution_plan/ops/op_index_scan.h
@@ -18,11 +18,12 @@ typedef struct {
 	RSIndex *idx;
 	const QGNode *n;
 	uint nodeRecIdx;
-	RSResultsIterator *iter;
+	RSQNode *rs_query_node;     /* RediSearch query node used to construct iterator. */
+	RSResultsIterator *iter;    /* RediSearch iterator over an index with the appropriate filters. */
 	Record child_record;        /* The Record this op acts on if it is not a tap. */
 } IndexScan;
 
 /* Creates a new IndexScan operation */
 OpBase *NewIndexScanOp(const ExecutionPlan *plan, Graph *g, const QGNode *n, RSIndex *idx,
-					   RSResultsIterator *iter);
+					   RSQNode *rs_query_node);
 

--- a/src/execution_plan/optimizations/utilize_indices.c
+++ b/src/execution_plan/optimizations/utilize_indices.c
@@ -499,10 +499,8 @@ cleanup:
 
 	if(root) {
 		/* We've successfully created a RediSearch query node that may be used to populate an Index Scan.
-		 * Pass ownership of the root node to the iterator. */
-		RSResultsIterator *iter = RediSearch_GetResultsIterator(root, rs_idx);
-		// Build the Index Scan.
-		OpBase *indexOp = NewIndexScanOp(scan->op.plan, scan->g, scan->n, rs_idx, iter);
+		 * Build a new Index Scan and pass ownership of the query node to it. */
+		OpBase *indexOp = NewIndexScanOp(scan->op.plan, scan->g, scan->n, rs_idx, root);
 
 		/* Replace the redundant scan op with the newly-constructed Index Scan. */
 		ExecutionPlan_ReplaceOp(plan, (OpBase *)scan, indexOp);

--- a/tests/flow/test_index_scans.py
+++ b/tests/flow/test_index_scans.py
@@ -267,3 +267,12 @@ class testIndexScanFlow(FlowTestsBase):
         expected_result = ["Lucy Yanfital"]
         self.env.assertEquals(query_result.result_set[0], expected_result)
 
+    def test11_single_index_multiple_scans(self):
+        query = "MERGE (p1:person {age: 40}) MERGE (p2:person {age: 41})"
+        plan = redis_graph.execution_plan(query)
+        # Two index scans should be performed.
+        self.env.assertEqual(plan.count("Index Scan"), 2)
+
+        query_result = redis_graph.query(query)
+        # Two new nodes should be created.
+        self.env.assertEquals(query_result.nodes_created, 2)


### PR DESCRIPTION
* Move index iterator construction to first Consume call

* Address PR comments

Co-authored-by: Roi Lipman <swilly22@users.noreply.github.com>
(cherry picked from commit 78531537fd493f108a694272a4868d1afbe63cd7)