### PR TITLE
aggregated slowlog should maintain original timestamps (#1199)

### DIFF
--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -134,7 +134,8 @@ cleanup:
 
 	// Log query to slowlog.
 	SlowLog *slowlog = GraphContext_GetSlowLog(gc);
-	SlowLog_Add(slowlog, command_ctx->command_name, command_ctx->query, QueryCtx_GetExecutionTime());
+	SlowLog_Add(slowlog, command_ctx->command_name, command_ctx->query,
+			QueryCtx_GetExecutionTime(), NULL);
 	ExecutionPlan_Free(plan);
 	ResultSet_Free(result_set);
 	AST_Free(ast);

--- a/src/slow_log/slow_log.h
+++ b/src/slow_log/slow_log.h
@@ -34,10 +34,25 @@ typedef struct {
 SlowLog *SlowLog_New();
 
 // Introduce item to slow log.
-void SlowLog_Add(SlowLog *slowlog, const char *cmd, const char *query, double latency);
+void SlowLog_Add
+(
+	SlowLog *slowlog,			// slowlog to add entry to
+	const char *cmd,			// command being logged
+	const char *query,			// query being logged
+	double latency,				// command latency
+	time_t *time				// optional time command was issued
+);
 
 // Replies with slow log content.
-void SlowLog_Replay(const SlowLog *slowlog, RedisModuleCtx *ctx);
+void SlowLog_Replay
+(
+	const SlowLog *slowlog,
+	RedisModuleCtx *ctx
+);
 
 // Free slowlog.
-void SlowLog_Free(SlowLog *slowlog);
+void SlowLog_Free
+(
+	SlowLog *slowlog
+);
+


### PR DESCRIPTION
(cherry picked from commit 5269402fecc2817e6e55c2a46e311eddc281b74f)