### PR TITLE
Resolve race in accessing/updating attribute maps (#1165)

### DIFF
--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -22,6 +22,9 @@
 #include <ctype.h>
 #include <assert.h>
 
+// Property keys in variadic expressions will be ATTRIBUTE_UNSET until the first lookup.
+#define ATTRIBUTE_UNSET (ATTRIBUTE_NOTFOUND - 1)
+
 // Forward declaration
 static AR_EXP_Result _AR_EXP_Evaluate(AR_ExpNode *root, const Record r, SIValue *result);
 // Clear an op node internals, without free the node allocation itself.
@@ -145,7 +148,7 @@ AR_ExpNode *AR_EXP_NewVariableOperandNode(const char *alias, const char *prop) {
 	node->operand.variadic.entity_alias = alias;
 	node->operand.variadic.entity_alias_idx = IDENTIFIER_NOT_FOUND;
 	node->operand.variadic.entity_prop = prop;
-	node->operand.variadic.entity_prop_idx = ATTRIBUTE_NOTFOUND;
+	node->operand.variadic.entity_prop_idx = ATTRIBUTE_UNSET;
 
 	return node;
 }
@@ -370,7 +373,7 @@ static AR_EXP_Result _AR_EXP_EvaluateProperty(AR_ExpNode *node, const Record r, 
 	}
 
 	GraphEntity *ge = Record_GetGraphEntity(r, node->operand.variadic.entity_alias_idx);
-	if(node->operand.variadic.entity_prop_idx == ATTRIBUTE_NOTFOUND) {
+	if(node->operand.variadic.entity_prop_idx == ATTRIBUTE_UNSET) {
 		_AR_EXP_UpdatePropIdx(node, NULL);
 	}
 

--- a/src/ast/ast_build_op_contexts.h
+++ b/src/ast/ast_build_op_contexts.h
@@ -35,7 +35,7 @@ typedef struct {
 PropertyMap *AST_ConvertPropertiesMap(const cypher_astnode_t *props);
 
 // Extract the necessary information to populate an update operation from a SET clause.
-EntityUpdateEvalCtx *AST_PrepareUpdateOp(const cypher_astnode_t *set_clause);
+EntityUpdateEvalCtx *AST_PrepareUpdateOp(GraphContext *gc, const cypher_astnode_t *set_clause);
 
 // Extract the necessary information to populate a delete operation from a DELETE clause.
 AR_ExpNode **AST_PrepareDeleteOp(const cypher_astnode_t *delete_clause);
@@ -50,8 +50,8 @@ void AST_PreparePathCreation(const cypher_astnode_t *path, QueryGraph *qg, rax *
 							 NodeCreateCtx **nodes, EdgeCreateCtx **edges);
 
 // Extract the necessary information to populate a merge operation from a MERGE clause.
-AST_MergeContext AST_PrepareMergeOp(const cypher_astnode_t *merge_clause, QueryGraph *qg,
-									rax *bound_vars);
+AST_MergeContext AST_PrepareMergeOp(const cypher_astnode_t *merge_clause, GraphContext *gc,
+									QueryGraph *qg, rax *bound_vars);
 
 // Extract the necessary information to populate a create operation from all CREATE clauses.
 AST_CreateContext AST_PrepareCreateOp(QueryGraph *qg, rax *bound_vars);

--- a/src/ast/ast_shared.c
+++ b/src/ast/ast_shared.c
@@ -104,12 +104,8 @@ void PropertyMap_Free(PropertyMap *map) {
 }
 
 EntityUpdateEvalCtx EntityUpdateEvalCtx_Clone(EntityUpdateEvalCtx ctx) {
-	EntityUpdateEvalCtx clone;
-	clone.alias = ctx.alias;
-	clone.attribute = ctx.attribute;
-	clone.attribute_idx = ctx.attribute_idx;
+	EntityUpdateEvalCtx clone = ctx;
 	clone.exp = AR_EXP_Clone(ctx.exp);
-	clone.record_idx = ctx.record_idx;
 	return clone;
 }
 
@@ -130,3 +126,4 @@ EdgeCreateCtx EdgeCreateCtx_Clone(EdgeCreateCtx ctx) {
 	clone.properties = _PropertyMap_Clone(ctx.properties);
 	return clone;
 }
+

--- a/src/ast/ast_shared.h
+++ b/src/ast/ast_shared.h
@@ -49,8 +49,7 @@ typedef struct {
 // Context describing an update expression.
 typedef struct {
 	const char *alias;          /* Alias of entity being updated. */
-	const char *attribute;      /* Attribute name to update. */
-	Attribute_ID attribute_idx; /* Attribute internal ID. */
+	Attribute_ID attribute_id;  /* ID of attribute to update. */
 	int record_idx;             /* Record offset this entity is stored at. */
 	struct AR_ExpNode *exp;     /* Expression to evaluate. */
 } EntityUpdateEvalCtx;

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -570,7 +570,7 @@ static void _buildMergeOp(GraphContext *gc, AST *ast, ExecutionPlan *plan,
 	}
 
 	// Convert all the AST data required to populate our operations tree.
-	AST_MergeContext merge_ctx = AST_PrepareMergeOp(clause, plan->query_graph, bound_vars);
+	AST_MergeContext merge_ctx = AST_PrepareMergeOp(clause, gc, plan->query_graph, bound_vars);
 
 	// Create a Merge operation. It will store no information at this time except for any graph updates
 	// it should make due to ON MATCH and ON CREATE SET directives in the query.
@@ -591,8 +591,9 @@ static void _buildMergeOp(GraphContext *gc, AST *ast, ExecutionPlan *plan,
 	array_free(arguments);
 }
 
-static inline void _buildUpdateOp(ExecutionPlan *plan, const cypher_astnode_t *clause) {
-	EntityUpdateEvalCtx *update_exps = AST_PrepareUpdateOp(clause);
+static inline void _buildUpdateOp(GraphContext *gc, ExecutionPlan *plan,
+								  const cypher_astnode_t *clause) {
+	EntityUpdateEvalCtx *update_exps = AST_PrepareUpdateOp(gc, clause);
 	OpBase *op = NewUpdateOp(plan, update_exps);
 	_ExecutionPlan_UpdateRoot(plan, op);
 }
@@ -624,7 +625,7 @@ static void _ExecutionPlanSegment_ConvertClause(GraphContext *gc, AST *ast, Exec
 	} else if(t == CYPHER_AST_MERGE) {
 		_buildMergeOp(gc, ast, plan, clause);
 	} else if(t == CYPHER_AST_SET) {
-		_buildUpdateOp(plan, clause);
+		_buildUpdateOp(gc, plan, clause);
 	} else if(t == CYPHER_AST_DELETE) {
 		_buildDeleteOp(plan, clause);
 	} else if(t == CYPHER_AST_RETURN) {

--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -37,14 +37,14 @@ static void _UpdateProperty(Record r, GraphEntity *ge, EntityUpdateEvalCtx *upda
 	SIValue new_value = AR_EXP_Evaluate(update_ctx->exp, r);
 
 	// Try to get current property value.
-	SIValue *old_value = GraphEntity_GetProperty(ge, update_ctx->attribute_idx);
+	SIValue *old_value = GraphEntity_GetProperty(ge, update_ctx->attribute_id);
 
 	if(old_value == PROPERTY_NOTFOUND) {
 		// Add new property.
-		GraphEntity_AddProperty(ge, update_ctx->attribute_idx, new_value);
+		GraphEntity_AddProperty(ge, update_ctx->attribute_id, new_value);
 	} else {
 		// Update property.
-		GraphEntity_SetProperty(ge, update_ctx->attribute_idx, new_value);
+		GraphEntity_SetProperty(ge, update_ctx->attribute_id, new_value);
 	}
 }
 
@@ -56,10 +56,6 @@ static void _UpdateProperties(ResultSetStatistics *stats, EntityUpdateEvalCtx *u
 	GraphContext *gc = QueryCtx_GetGraphCtx();
 	// Lock everything.
 	QueryCtx_LockForCommit();
-	// Iterate over all update contexts, converting property keys to IDs.
-	for(uint i = 0; i < update_count; i ++) {
-		updates[i].attribute_idx = GraphContext_FindOrAddAttribute(gc, updates[i].attribute);
-	}
 
 	for(uint i = 0; i < record_count; i ++) {  // For each record to update
 		Record r = records[i];

--- a/src/execution_plan/ops/op_update.h
+++ b/src/execution_plan/ops/op_update.h
@@ -16,10 +16,11 @@
 
 // Context describing a pending update to perform.
 typedef struct {
-	const char *attribute;              /* Attribute name to update. */
 	Attribute_ID attr_id;               /* ID of attribute to update. */
-	Node n;
-	Edge e;
+	union {
+		Node n;                         /* Node to update if indicated by entity_type. */
+		Edge e;                         /* Edge to update if indicated by entity_type. */
+	};
 	GraphEntityType entity_type;        /* Graph entity type. */
 	SIValue new_value;                  /* Constant value to set. */
 } EntityUpdateCtx;
@@ -42,3 +43,4 @@ typedef struct {
 } OpUpdate;
 
 OpBase *NewUpdateOp(const ExecutionPlan *plan, EntityUpdateEvalCtx *update_exps);
+

--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -86,14 +86,14 @@ void Graph_AcquireReadLock(Graph *g);
 /* Acquire a lock for exclusive access to this graph's data */
 void Graph_AcquireWriteLock(Graph *g);
 
+/* Release the held lock */
+void Graph_ReleaseLock(Graph *g);
+
 /* Writer request access to graph. */
 void Graph_WriterEnter(Graph *g);
 
 /* Writer release access to graph. */
 void Graph_WriterLeave(Graph *g);
-
-/* Release the held lock */
-void Graph_ReleaseLock(Graph *g);
 
 /* Choose the current matrix synchronization policy. */
 void Graph_SetMatrixPolicy(Graph *g, MATRIX_POLICY policy);

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -53,6 +53,9 @@ static GraphContext *_GraphContext_New(const char *graph_name, size_t node_cap, 
 	gc->attributes = raxNew();
 	gc->slowlog = SlowLog_New();
 
+	// Initialize the read-write lock to protect access to the attributes rax.
+	assert(pthread_rwlock_init(&gc->_attribute_rwlock, NULL) == 0);
+
 	Graph_SetMatrixPolicy(gc->g, SYNC_AND_MINIMIZE_SPACE);
 	QueryCtx_SetGraphCtx(gc);
 
@@ -212,24 +215,36 @@ uint GraphContext_AttributeCount(GraphContext *gc) {
 }
 
 Attribute_ID GraphContext_FindOrAddAttribute(GraphContext *gc, const char *attribute) {
+	// Acquire a read lock for looking up the attribute.
+	pthread_rwlock_rdlock(&gc->_attribute_rwlock);
+
 	// See if attribute already exists.
-	Attribute_ID *pAttribute_id = NULL;
-	Attribute_ID attribute_id = GraphContext_GetAttributeID(gc, attribute);
+	void *attribute_id = raxFind(gc->attributes, (unsigned char *)attribute, strlen(attribute));
 
-	if(attribute_id == ATTRIBUTE_NOTFOUND) {
-		attribute_id = raxSize(gc->attributes);
-		pAttribute_id = rm_malloc(sizeof(Attribute_ID));
-		*pAttribute_id = attribute_id;
+	if(attribute_id == raxNotFound) {
+		// We are writing to the shared GraphContext; release the held lock and re-acquire as a writer.
+		pthread_rwlock_unlock(&gc->_attribute_rwlock);
+		pthread_rwlock_wrlock(&gc->_attribute_rwlock);
 
-		raxInsert(gc->attributes,
-				  (unsigned char *)attribute,
-				  strlen(attribute),
-				  pAttribute_id,
-				  NULL);
-		gc->string_mapping = array_append(gc->string_mapping, rm_strdup(attribute));
+		// Lookup the attribute again now that we are in a critical region.
+		attribute_id = raxFind(gc->attributes, (unsigned char *)attribute, strlen(attribute));
+		// If it has been set by another thread, use the retrieved value.
+		if(attribute_id == raxNotFound) {
+			// Otherwise, it will be assigned an ID equal to the current mapping size.
+			attribute_id = (void *)raxSize(gc->attributes);
+			// Insert the new attribute key and ID.
+			raxInsert(gc->attributes,
+					  (unsigned char *)attribute,
+					  strlen(attribute),
+					  attribute_id,
+					  NULL);
+			gc->string_mapping = array_append(gc->string_mapping, rm_strdup(attribute));
+		}
 	}
 
-	return attribute_id;
+	// Release the lock.
+	pthread_rwlock_unlock(&gc->_attribute_rwlock);
+	return (uintptr_t)attribute_id;
 }
 
 const char *GraphContext_GetAttributeString(const GraphContext *gc, Attribute_ID id) {
@@ -237,10 +252,17 @@ const char *GraphContext_GetAttributeString(const GraphContext *gc, Attribute_ID
 	return gc->string_mapping[id];
 }
 
-Attribute_ID GraphContext_GetAttributeID(const GraphContext *gc, const char *attribute) {
-	Attribute_ID *id = raxFind(gc->attributes, (unsigned char *)attribute, strlen(attribute));
+Attribute_ID GraphContext_GetAttributeID(GraphContext *gc, const char *attribute) {
+	// Acquire a read lock for looking up the attribute.
+	pthread_rwlock_rdlock(&gc->_attribute_rwlock);
+	// Look up the attribute ID.
+	void *id = raxFind(gc->attributes, (unsigned char *)attribute, strlen(attribute));
+	// Release the lock.
+	pthread_rwlock_unlock(&gc->_attribute_rwlock);
+
 	if(id == raxNotFound) return ATTRIBUTE_NOTFOUND;
-	return *id;
+
+	return (uintptr_t)id;
 }
 
 //------------------------------------------------------------------------------
@@ -373,7 +395,7 @@ static void _GraphContext_Free(void *arg) {
 	}
 
 	// Free attribute mappings
-	if(gc->attributes) raxFreeWithCallback(gc->attributes, rm_free);
+	if(gc->attributes) raxFree(gc->attributes);
 	if(gc->string_mapping) {
 		len = array_len(gc->string_mapping);
 		for(uint32_t i = 0; i < len; i ++) {
@@ -381,6 +403,7 @@ static void _GraphContext_Free(void *arg) {
 		}
 		array_free(gc->string_mapping);
 	}
+	assert(pthread_rwlock_destroy(&gc->_attribute_rwlock) == 0);
 
 	if(gc->slowlog) SlowLog_Free(gc->slowlog);
 

--- a/src/graph/graphcontext.h
+++ b/src/graph/graphcontext.h
@@ -15,15 +15,16 @@
 #include "graph.h"
 
 typedef struct {
-	Graph *g;                   // Container for all matrices and entity properties
-	int ref_count;              // Number of active references.
-	rax *attributes;            // From strings to attribute IDs
-	char *graph_name;           // String associated with graph
-	char **string_mapping;      // From attribute IDs to strings
-	Schema **node_schemas;      // Array of schemas for each node label
-	Schema **relation_schemas;  // Array of schemas for each relation type
-	unsigned short index_count; // Number of indicies.
-    SlowLog *slowlog;           // Slowlog associated with graph.
+	Graph *g;                               // Container for all matrices and entity properties
+	int ref_count;                          // Number of active references.
+	rax *attributes;                        // From strings to attribute IDs
+	pthread_rwlock_t _attribute_rwlock;     // Read-write lock to protect access to the attribute maps.
+	char *graph_name;                       // String associated with graph
+	char **string_mapping;                  // From attribute IDs to strings
+	Schema **node_schemas;                  // Array of schemas for each node label
+	Schema **relation_schemas;              // Array of schemas for each relation type
+	unsigned short index_count;             // Number of indicies.
+	SlowLog *slowlog;                       // Slowlog associated with graph.
 } GraphContext;
 
 /* GraphContext API */
@@ -58,7 +59,7 @@ Attribute_ID GraphContext_FindOrAddAttribute(GraphContext *gc, const char *attri
 // Retrieve an attribute string given an ID
 const char *GraphContext_GetAttributeString(const GraphContext *gc, Attribute_ID id);
 // Retrieve an attribute ID given a string, or ATTRIBUTE_NOTFOUND if attribute doesn't exist.
-Attribute_ID GraphContext_GetAttributeID(const GraphContext *gc, const char *str);
+Attribute_ID GraphContext_GetAttributeID(GraphContext *gc, const char *str);
 
 /* Index API */
 bool GraphContext_HasIndices(GraphContext *gc);
@@ -83,7 +84,7 @@ void GraphContext_RemoveFromRegistry(GraphContext *gc);
 void GraphContext_Rename(GraphContext *gc, const char *name);
 
 /* Slowlog API */
-SlowLog* GraphContext_GetSlowLog(const GraphContext *gc);
+SlowLog *GraphContext_GetSlowLog(const GraphContext *gc);
 
 #endif
 

--- a/tests/unit/test_algebraic_expression.cpp
+++ b/tests/unit/test_algebraic_expression.cpp
@@ -91,6 +91,7 @@ class AlgebraicExpressionTest: public ::testing::Test {
 		gc->index_count = 0;
 		gc->graph_name = strdup("G");
 		gc->attributes = raxNew();
+		pthread_rwlock_init(&gc->_attribute_rwlock, NULL);
 		gc->string_mapping = (char **)array_new(char *, 64);
 		gc->node_schemas = (Schema **)array_new(Schema *, GRAPH_DEFAULT_LABEL_CAP);
 		gc->relation_schemas = (Schema **)array_new(Schema *, GRAPH_DEFAULT_RELATION_TYPE_CAP);

--- a/tests/unit/test_filter_tree.cpp
+++ b/tests/unit/test_filter_tree.cpp
@@ -45,6 +45,7 @@ class FilterTreeTest: public ::testing::Test {
 		 * accessible via thread local storage, as such we're creating a
 		 * fake graph context and placing it within thread local storage. */
 		GraphContext *gc = (GraphContext *)malloc(sizeof(GraphContext));
+		pthread_rwlock_init(&gc->_attribute_rwlock, NULL);
 
 		// No indicies.
 		gc->index_count = 0;

--- a/tests/unit/test_index.cpp
+++ b/tests/unit/test_index.cpp
@@ -44,6 +44,7 @@ class IndexTest: public ::testing::Test {
 		gc->index_count = 0;
 		gc->graph_name = strdup("G");
 		gc->attributes = raxNew();
+		pthread_rwlock_init(&gc->_attribute_rwlock, NULL);
 		gc->string_mapping = (char **)array_new(char *, 64);
 		gc->node_schemas = (Schema **)array_new(Schema *, GRAPH_DEFAULT_LABEL_CAP);
 		gc->relation_schemas = (Schema **)array_new(Schema *, GRAPH_DEFAULT_RELATION_TYPE_CAP);


### PR DESCRIPTION
* Protect critical region of reading/updating GraphContext attributes

* Improve lock coverage

* Don't heap-alloc attribute ID values

* Change to QueryCtx lock check

* Bulk insert deadlock fix

* Remove FindOrAddAttribute calls from critical region

* Revert changes to QueryCtx

* Revert changes to Graph

* Introduce new rwlock for attribute mapping

* Only lookup property ID once

* Fix unit tests

* Fix possible duplicate entry

* Always retrieve attribute value in critical region

* Address PR comments

* Address PR comments

Co-authored-by: Roi Lipman <swilly22@users.noreply.github.com>
(cherry picked from commit d66affbf662090e298f6d8e7a475c71d809214b2)