### PR TITLE
Improve label logic

### DIFF
--- a/src/algorithms/all_paths.c
+++ b/src/algorithms/all_paths.c
@@ -43,7 +43,7 @@ static void _addNeighbors(AllPathsCtx *ctx, LevelConnection *frontier, uint32_t 
 		// Don't follow the frontier edge again.
 		if(frontierId == ENTITY_GET_ID(ctx->neighbors + i)) continue;
 		// Set the neighbor by following the edge in the correct directoin.
-		Node neighbor = NEW_NODE();
+		Node neighbor = GE_NEW_NODE();
 		switch(dir) {
 		case GRAPH_EDGE_DIR_OUTGOING:
 			Graph_GetNode(ctx->g, Edge_GetDestNodeID(ctx->neighbors + i), &neighbor);

--- a/src/algorithms/all_paths.c
+++ b/src/algorithms/all_paths.c
@@ -43,7 +43,7 @@ static void _addNeighbors(AllPathsCtx *ctx, LevelConnection *frontier, uint32_t 
 		// Don't follow the frontier edge again.
 		if(frontierId == ENTITY_GET_ID(ctx->neighbors + i)) continue;
 		// Set the neighbor by following the edge in the correct directoin.
-		Node neighbor = Node_New();
+		Node neighbor = NEW_NODE();
 		switch(dir) {
 		case GRAPH_EDGE_DIR_OUTGOING:
 			Graph_GetNode(ctx->g, Edge_GetDestNodeID(ctx->neighbors + i), &neighbor);

--- a/src/algorithms/all_paths.c
+++ b/src/algorithms/all_paths.c
@@ -43,7 +43,7 @@ static void _addNeighbors(AllPathsCtx *ctx, LevelConnection *frontier, uint32_t 
 		// Don't follow the frontier edge again.
 		if(frontierId == ENTITY_GET_ID(ctx->neighbors + i)) continue;
 		// Set the neighbor by following the edge in the correct directoin.
-		Node neighbor;
+		Node neighbor = Node_New();
 		switch(dir) {
 		case GRAPH_EDGE_DIR_OUTGOING:
 			Graph_GetNode(ctx->g, Edge_GetDestNodeID(ctx->neighbors + i), &neighbor);

--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -70,7 +70,8 @@ static Record AllNodeScanConsumeFromChild(OpBase *opBase) {
 	Record r = OpBase_CloneRecord(op->child_record);
 
 	// Populate the Record with the graph entity data.
-	Node n = { .entity = en };
+	Node n = Node_New();
+	n.entity = en;
 	Record_AddNode(r, op->nodeRecIdx, n);
 
 	return r;
@@ -83,7 +84,8 @@ static Record AllNodeScanConsume(OpBase *opBase) {
 	if(en == NULL) return NULL;
 
 	Record r = OpBase_CreateRecord((OpBase *)op);
-	Node n = { .entity = en };
+	Node n = Node_New();
+	n.entity = en;
 	Record_AddNode(r, op->nodeRecIdx, n);
 
 	return r;

--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -70,7 +70,7 @@ static Record AllNodeScanConsumeFromChild(OpBase *opBase) {
 	Record r = OpBase_CloneRecord(op->child_record);
 
 	// Populate the Record with the graph entity data.
-	Node n = Node_New();
+	Node n = NEW_NODE();
 	n.entity = en;
 	Record_AddNode(r, op->nodeRecIdx, n);
 
@@ -84,7 +84,7 @@ static Record AllNodeScanConsume(OpBase *opBase) {
 	if(en == NULL) return NULL;
 
 	Record r = OpBase_CreateRecord((OpBase *)op);
-	Node n = Node_New();
+	Node n = NEW_NODE();
 	n.entity = en;
 	Record_AddNode(r, op->nodeRecIdx, n);
 

--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -70,7 +70,7 @@ static Record AllNodeScanConsumeFromChild(OpBase *opBase) {
 	Record r = OpBase_CloneRecord(op->child_record);
 
 	// Populate the Record with the graph entity data.
-	Node n = NEW_NODE();
+	Node n = GE_NEW_NODE();
 	n.entity = en;
 	Record_AddNode(r, op->nodeRecIdx, n);
 
@@ -84,7 +84,7 @@ static Record AllNodeScanConsume(OpBase *opBase) {
 	if(en == NULL) return NULL;
 
 	Record r = OpBase_CreateRecord((OpBase *)op);
-	Node n = NEW_NODE();
+	Node n = GE_NEW_NODE();
 	n.entity = en;
 	Record_AddNode(r, op->nodeRecIdx, n);
 

--- a/src/execution_plan/ops/op_cond_var_len_traverse.c
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.c
@@ -86,13 +86,22 @@ OpBase *NewCondVarLenTraverseOp(const ExecutionPlan *plan, Graph *g, AlgebraicEx
 	op->expandInto = false;
 	op->allPathsCtx = NULL;
 	op->edgeRelationTypes = NULL;
+	op->dest_label = NULL;
+	op->dest_label_id = GRAPH_NO_LABEL;
 
 	OpBase_Init((OpBase *)op, OPType_CONDITIONAL_VAR_LEN_TRAVERSE,
 				"Conditional Variable Length Traverse", NULL, CondVarLenTraverseConsume, CondVarLenTraverseReset,
 				CondVarLenTraverseToString, CondVarLenTraverseClone, CondVarLenTraverseFree, false, plan);
 
 	assert(OpBase_Aware((OpBase *)op, AlgebraicExpression_Source(ae), &op->srcNodeIdx));
-	op->destNodeIdx = OpBase_Modifies((OpBase *)op, AlgebraicExpression_Destination(ae));
+	const char *dest = AlgebraicExpression_Destination(ae);
+	op->destNodeIdx = OpBase_Modifies((OpBase *)op, dest);
+	// Check the QueryGraph node and retrieve label data if possible.
+	QGNode *dest_node = QueryGraph_GetNodeByAlias(plan->query_graph, dest);
+	if(dest_node->labelID != GRAPH_NO_LABEL) {
+		op->dest_label = dest_node->label;
+		op->dest_label_id = dest_node->labelID;
+	}
 
 	// Populate edge value in record only if it is referenced.
 	AST *ast = QueryCtx_GetAST();
@@ -140,7 +149,11 @@ static Record CondVarLenTraverseConsume(OpBase *opBase) {
 
 	Node n = Path_Head(p);
 
-	if(!op->expandInto) Record_AddNode(op->r, op->destNodeIdx, n);
+	if(!op->expandInto) {
+		// Populate destination node with label data if known.
+		if(op->dest_label) Node_SetLabel(&n, op->dest_label, op->dest_label_id);
+		Record_AddNode(op->r, op->destNodeIdx, n);
+	}
 	if(op->edgesIdx >= 0) {
 		// If we're returning a new path from a previously-used Record,
 		// free the previous path to avoid a memory leak.

--- a/src/execution_plan/ops/op_cond_var_len_traverse.c
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.c
@@ -151,7 +151,10 @@ static Record CondVarLenTraverseConsume(OpBase *opBase) {
 
 	if(!op->expandInto) {
 		// Populate destination node with label data if known.
-		if(op->dest_label) Node_SetLabel(&n, op->dest_label, op->dest_label_id);
+		if(op->dest_label) {
+			n.label = op->dest_label;
+			n.labelID = op->dest_label_id;
+		}
 		Record_AddNode(op->r, op->destNodeIdx, n);
 	}
 	if(op->edgesIdx >= 0) {

--- a/src/execution_plan/ops/op_cond_var_len_traverse.h
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.h
@@ -24,8 +24,6 @@ typedef struct {
 	bool expandInto;                /* Both src and dest already resolved. */
 	unsigned int minHops;           /* Maximum number of hops to perform. */
 	unsigned int maxHops;           /* Maximum number of hops to perform. */
-	NodeID dest_label_id;           /* ID of destination node label if known. */
-	const char *dest_label;         /* Label of destination node if known. */
 	int edgeRelationCount;          /* Length of edgeRelationTypes. */
 	int *edgeRelationTypes;         /* Relation(s) we're traversing. */
 	AllPathsCtx *allPathsCtx;

--- a/src/execution_plan/ops/op_cond_var_len_traverse.h
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.h
@@ -24,6 +24,8 @@ typedef struct {
 	bool expandInto;                /* Both src and dest already resolved. */
 	unsigned int minHops;           /* Maximum number of hops to perform. */
 	unsigned int maxHops;           /* Maximum number of hops to perform. */
+	NodeID dest_label_id;           /* ID of destination node label if known. */
+	const char *dest_label;         /* Label of destination node if known. */
 	int edgeRelationCount;          /* Length of edgeRelationTypes. */
 	int *edgeRelationTypes;         /* Relation(s) we're traversing. */
 	AllPathsCtx *allPathsCtx;

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -89,10 +89,8 @@ OpBase *NewCondTraverseOp(const ExecutionPlan *plan, Graph *g, AlgebraicExpressi
 	op->destNodeIdx = OpBase_Modifies((OpBase *)op, dest);
 	// Check the QueryGraph node and retrieve label data if possible.
 	QGNode *dest_node = QueryGraph_GetNodeByAlias(plan->query_graph, dest);
-	if(dest_node->labelID != GRAPH_NO_LABEL) {
-		op->dest_label = dest_node->label;
-		op->dest_label_id = dest_node->labelID;
-	}
+	op->dest_label = dest_node->label;
+	op->dest_label_id = dest_node->labelID;
 
 	const char *edge = AlgebraicExpression_Edge(ae);
 	if(edge) {
@@ -167,7 +165,7 @@ static Record CondTraverseConsume(OpBase *opBase) {
 	/* Get node from current column. */
 	op->r = op->records[src_id];
 	const char *label = op->dest_label; // label will be NULL if unknown.
-	Node destNode = (label) ? NEW_LABELED_NODE(label, op->dest_label_id) : NEW_NODE();
+	Node destNode = (label) ? GE_NEW_LABELED_NODE(label, op->dest_label_id) : GE_NEW_NODE();
 	Graph_GetNode(op->graph, dest_id, &destNode);
 	Record_AddNode(op->r, op->destNodeIdx, destNode);
 

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -166,10 +166,9 @@ static Record CondTraverseConsume(OpBase *opBase) {
 
 	/* Get node from current column. */
 	op->r = op->records[src_id];
-	Node destNode = Node_New();
+	const char *label = op->dest_label; // label will be NULL if unknown.
+	Node destNode = label ? Node_NewLabeledNode(label, op->dest_label_id) : Node_New();
 	Graph_GetNode(op->graph, dest_id, &destNode);
-	// Populate destination node with label data if known.
-	if(op->dest_label) Node_SetLabel(&destNode, op->dest_label, op->dest_label_id);
 	Record_AddNode(op->r, op->destNodeIdx, destNode);
 
 	if(op->edge_ctx) {

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -167,7 +167,7 @@ static Record CondTraverseConsume(OpBase *opBase) {
 	/* Get node from current column. */
 	op->r = op->records[src_id];
 	const char *label = op->dest_label; // label will be NULL if unknown.
-	Node destNode = (label) ? Node_NewLabeledNode(label, op->dest_label_id) : Node_New();
+	Node destNode = (label) ? NEW_LABELED_NODE(label, op->dest_label_id) : NEW_NODE();
 	Graph_GetNode(op->graph, dest_id, &destNode);
 	Record_AddNode(op->r, op->destNodeIdx, destNode);
 

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -164,8 +164,10 @@ static Record CondTraverseConsume(OpBase *opBase) {
 
 	/* Get node from current column. */
 	op->r = op->records[src_id];
-	const char *label = op->dest_label; // label will be NULL if unknown.
-	Node destNode = (label) ? GE_NEW_LABELED_NODE(label, op->dest_label_id) : GE_NEW_NODE();
+	/* Populate the destination node and add it to the Record.
+	 * Note that if the node's label is unknown, this will correctly
+	 * create an unlabeled node. */
+	Node destNode = GE_NEW_LABELED_NODE(op->dest_label, op->dest_label_id);
 	Graph_GetNode(op->graph, dest_id, &destNode);
 	Record_AddNode(op->r, op->destNodeIdx, destNode);
 

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -167,7 +167,7 @@ static Record CondTraverseConsume(OpBase *opBase) {
 	/* Get node from current column. */
 	op->r = op->records[src_id];
 	const char *label = op->dest_label; // label will be NULL if unknown.
-	Node destNode = label ? Node_NewLabeledNode(label, op->dest_label_id) : Node_New();
+	Node destNode = (label) ? Node_NewLabeledNode(label, op->dest_label_id) : Node_New();
 	Graph_GetNode(op->graph, dest_id, &destNode);
 	Record_AddNode(op->r, op->destNodeIdx, destNode);
 

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -157,7 +157,7 @@ static Record CondTraverseConsume(OpBase *opBase) {
 
 	/* Get node from current column. */
 	op->r = op->records[src_id];
-	Node destNode = {0};
+	Node destNode = Node_New();
 	Graph_GetNode(op->graph, dest_id, &destNode);
 	Record_AddNode(op->r, op->destNodeIdx, destNode);
 

--- a/src/execution_plan/ops/op_conditional_traverse.h
+++ b/src/execution_plan/ops/op_conditional_traverse.h
@@ -19,6 +19,8 @@ typedef struct {
 	AlgebraicExpression *ae;
 	GrB_Matrix F;               // Filter matrix.
 	GrB_Matrix M;               // Algebraic expression result.
+	NodeID dest_label_id;       // ID of destination node label if known.
+	const char *dest_label;     // Label of destination node if known.
 	EdgeTraverseCtx *edge_ctx;  // Edge collection data if the edge needs to be set.
 	GxB_MatrixTupleIter *iter;  // Iterator over M.
 	int srcNodeIdx;             // Source node index into record.

--- a/src/execution_plan/ops/op_create.c
+++ b/src/execution_plan/ops/op_create.c
@@ -46,7 +46,7 @@ static void _CreateNodes(OpCreate *op, Record r) {
 		QGNode *n = op->pending.nodes_to_create[i].node;
 
 		/* Create a new node. */
-		Node newNode = NEW_LABELED_NODE(n->label, n->labelID);
+		Node newNode = GE_NEW_LABELED_NODE(n->label, n->labelID);
 
 		/* Add new node to Record and save a reference to it. */
 		Node *node_ref = Record_AddNode(r, op->pending.nodes_to_create[i].node_idx, newNode);

--- a/src/execution_plan/ops/op_create.c
+++ b/src/execution_plan/ops/op_create.c
@@ -46,8 +46,7 @@ static void _CreateNodes(OpCreate *op, Record r) {
 		QGNode *n = op->pending.nodes_to_create[i].node;
 
 		/* Create a new node. */
-		Node newNode = Node_New();
-		Node_SetLabel(&newNode, n->label, n->labelID);
+		Node newNode = Node_NewLabeledNode(n->label, n->labelID);
 
 		/* Add new node to Record and save a reference to it. */
 		Node *node_ref = Record_AddNode(r, op->pending.nodes_to_create[i].node_idx, newNode);

--- a/src/execution_plan/ops/op_create.c
+++ b/src/execution_plan/ops/op_create.c
@@ -7,9 +7,7 @@
 #include "op_create.h"
 #include "../../util/arr.h"
 #include "../../query_ctx.h"
-#include "../../schema/schema.h"
 #include <assert.h>
-#include "../../query_ctx.h"
 
 /* Forward declarations. */
 static Record CreateConsume(OpBase *opBase);
@@ -48,11 +46,8 @@ static void _CreateNodes(OpCreate *op, Record r) {
 		QGNode *n = op->pending.nodes_to_create[i].node;
 
 		/* Create a new node. */
-		Node newNode = {
-			.entity = NULL,
-			.label = n->label,
-			.labelID = n->labelID
-		};
+		Node newNode = Node_New();
+		Node_SetLabel(&newNode, n->label, n->labelID);
 
 		/* Add new node to Record and save a reference to it. */
 		Node *node_ref = Record_AddNode(r, op->pending.nodes_to_create[i].node_idx, newNode);

--- a/src/execution_plan/ops/op_create.c
+++ b/src/execution_plan/ops/op_create.c
@@ -46,7 +46,7 @@ static void _CreateNodes(OpCreate *op, Record r) {
 		QGNode *n = op->pending.nodes_to_create[i].node;
 
 		/* Create a new node. */
-		Node newNode = Node_NewLabeledNode(n->label, n->labelID);
+		Node newNode = NEW_LABELED_NODE(n->label, n->labelID);
 
 		/* Add new node to Record and save a reference to it. */
 		Node *node_ref = Record_AddNode(r, op->pending.nodes_to_create[i].node_idx, newNode);

--- a/src/execution_plan/ops/op_expand_into.c
+++ b/src/execution_plan/ops/op_expand_into.c
@@ -144,7 +144,6 @@ static Record _handoff(OpExpandInto *op) {
 /* ExpandIntoConsume next operation
  * returns OP_DEPLETED when no additional updates are available */
 static Record ExpandIntoConsume(OpBase *opBase) {
-	Node *n;
 	Record r;
 	OpExpandInto *op = (OpExpandInto *)opBase;
 	OpBase *child = op->op.children[0];

--- a/src/execution_plan/ops/op_index_scan.c
+++ b/src/execution_plan/ops/op_index_scan.c
@@ -45,6 +45,8 @@ static inline void _UpdateRecord(IndexScan *op, Record r, EntityID node_id) {
 	// Populate the Record with the graph entity data.
 	Node n = Node_New();
 	assert(Graph_GetNode(op->g, node_id, &n));
+	// Add label data to the node.
+	Node_SetLabel(&n, op->n->label, op->n->labelID);
 	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);
 }

--- a/src/execution_plan/ops/op_index_scan.c
+++ b/src/execution_plan/ops/op_index_scan.c
@@ -43,7 +43,7 @@ static OpResult IndexScanInit(OpBase *opBase) {
 
 static inline void _UpdateRecord(IndexScan *op, Record r, EntityID node_id) {
 	// Populate the Record with the graph entity data.
-	Node n = Node_NewLabeledNode(op->n->label, op->n->labelID);
+	Node n = NEW_LABELED_NODE(op->n->label, op->n->labelID);
 	assert(Graph_GetNode(op->g, node_id, &n));
 	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);

--- a/src/execution_plan/ops/op_index_scan.c
+++ b/src/execution_plan/ops/op_index_scan.c
@@ -43,7 +43,7 @@ static OpResult IndexScanInit(OpBase *opBase) {
 
 static inline void _UpdateRecord(IndexScan *op, Record r, EntityID node_id) {
 	// Populate the Record with the graph entity data.
-	Node n = {0};
+	Node n = Node_New();
 	assert(Graph_GetNode(op->g, node_id, &n));
 	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);

--- a/src/execution_plan/ops/op_index_scan.c
+++ b/src/execution_plan/ops/op_index_scan.c
@@ -43,10 +43,8 @@ static OpResult IndexScanInit(OpBase *opBase) {
 
 static inline void _UpdateRecord(IndexScan *op, Record r, EntityID node_id) {
 	// Populate the Record with the graph entity data.
-	Node n = Node_New();
+	Node n = Node_NewLabeledNode(op->n->label, op->n->labelID);
 	assert(Graph_GetNode(op->g, node_id, &n));
-	// Add label data to the node.
-	Node_SetLabel(&n, op->n->label, op->n->labelID);
 	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);
 }

--- a/src/execution_plan/ops/op_index_scan.c
+++ b/src/execution_plan/ops/op_index_scan.c
@@ -43,7 +43,7 @@ static OpResult IndexScanInit(OpBase *opBase) {
 
 static inline void _UpdateRecord(IndexScan *op, Record r, EntityID node_id) {
 	// Populate the Record with the graph entity data.
-	Node n = NEW_LABELED_NODE(op->n->label, op->n->labelID);
+	Node n = GE_NEW_LABELED_NODE(op->n->label, op->n->labelID);
 	assert(Graph_GetNode(op->g, node_id, &n));
 	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);

--- a/src/execution_plan/ops/op_merge_create.c
+++ b/src/execution_plan/ops/op_merge_create.c
@@ -92,7 +92,7 @@ static bool _CreateEntities(OpMergeCreate *op, Record r) {
 		QGNode *n = op->pending.nodes_to_create[i].node;
 
 		/* Create a new node. */
-		Node newNode = Node_NewLabeledNode(n->label, n->labelID);
+		Node newNode = NEW_LABELED_NODE(n->label, n->labelID);
 
 		/* Add new node to Record and save a reference to it. */
 		Node *node_ref = Record_AddNode(r, op->pending.nodes_to_create[i].node_idx, newNode);

--- a/src/execution_plan/ops/op_merge_create.c
+++ b/src/execution_plan/ops/op_merge_create.c
@@ -93,11 +93,8 @@ static bool _CreateEntities(OpMergeCreate *op, Record r) {
 		QGNode *n = op->pending.nodes_to_create[i].node;
 
 		/* Create a new node. */
-		Node newNode = {
-			.entity = NULL,
-			.label = n->label,
-			.labelID = n->labelID
-		};
+		Node newNode = Node_New();
+		Node_SetLabel(&newNode, n->label, n->labelID);
 		/* Add new node to Record and save a reference to it. */
 		Node *node_ref = Record_AddNode(r, op->pending.nodes_to_create[i].node_idx, newNode);
 

--- a/src/execution_plan/ops/op_merge_create.c
+++ b/src/execution_plan/ops/op_merge_create.c
@@ -7,7 +7,6 @@
 #include "op_merge_create.h"
 #include "../../util/arr.h"
 #include "../../query_ctx.h"
-#include "../../schema/schema.h"
 #include <assert.h>
 
 /* Forward declarations. */

--- a/src/execution_plan/ops/op_merge_create.c
+++ b/src/execution_plan/ops/op_merge_create.c
@@ -92,7 +92,7 @@ static bool _CreateEntities(OpMergeCreate *op, Record r) {
 		QGNode *n = op->pending.nodes_to_create[i].node;
 
 		/* Create a new node. */
-		Node newNode = NEW_LABELED_NODE(n->label, n->labelID);
+		Node newNode = GE_NEW_LABELED_NODE(n->label, n->labelID);
 
 		/* Add new node to Record and save a reference to it. */
 		Node *node_ref = Record_AddNode(r, op->pending.nodes_to_create[i].node_idx, newNode);

--- a/src/execution_plan/ops/op_merge_create.c
+++ b/src/execution_plan/ops/op_merge_create.c
@@ -92,8 +92,8 @@ static bool _CreateEntities(OpMergeCreate *op, Record r) {
 		QGNode *n = op->pending.nodes_to_create[i].node;
 
 		/* Create a new node. */
-		Node newNode = Node_New();
-		Node_SetLabel(&newNode, n->label, n->labelID);
+		Node newNode = Node_NewLabeledNode(n->label, n->labelID);
+
 		/* Add new node to Record and save a reference to it. */
 		Node *node_ref = Record_AddNode(r, op->pending.nodes_to_create[i].node_idx, newNode);
 

--- a/src/execution_plan/ops/op_node_by_id_seek.c
+++ b/src/execution_plan/ops/op_node_by_id_seek.c
@@ -62,7 +62,7 @@ static OpResult NodeByIdSeekInit(OpBase *opBase) {
 }
 
 static inline Node _SeekNextNode(NodeByIdSeek *op) {
-	Node n = { .entity = NULL };
+	Node n = Node_New();
 
 	/* As long as we're within range bounds
 	 * and we've yet to get a node. */

--- a/src/execution_plan/ops/op_node_by_id_seek.c
+++ b/src/execution_plan/ops/op_node_by_id_seek.c
@@ -62,7 +62,7 @@ static OpResult NodeByIdSeekInit(OpBase *opBase) {
 }
 
 static inline Node _SeekNextNode(NodeByIdSeek *op) {
-	Node n = Node_New();
+	Node n = NEW_NODE();
 
 	/* As long as we're within range bounds
 	 * and we've yet to get a node. */

--- a/src/execution_plan/ops/op_node_by_id_seek.c
+++ b/src/execution_plan/ops/op_node_by_id_seek.c
@@ -74,12 +74,6 @@ static inline Node _SeekNextNode(NodeByIdSeek *op) {
 	// Advance id for next consume call.
 	op->currentId++;
 
-	// Did we manage to get an entity?
-	if(!n.entity) return n;
-	// Null-set the label in case an operation (like op_delete) accesses it.
-	// TODO If we're replacing a label scan, the correct label can be populated now.
-	n.label = NULL;
-
 	return n;
 }
 

--- a/src/execution_plan/ops/op_node_by_id_seek.c
+++ b/src/execution_plan/ops/op_node_by_id_seek.c
@@ -62,7 +62,7 @@ static OpResult NodeByIdSeekInit(OpBase *opBase) {
 }
 
 static inline Node _SeekNextNode(NodeByIdSeek *op) {
-	Node n = NEW_NODE();
+	Node n = GE_NEW_NODE();
 
 	/* As long as we're within range bounds
 	 * and we've yet to get a node. */

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -90,7 +90,7 @@ static OpResult NodeByLabelScanInit(OpBase *opBase) {
 
 static inline void _UpdateRecord(NodeByLabelScan *op, Record r, GrB_Index node_id) {
 	// Populate the Record with the graph entity data.
-	Node n = Node_NewLabeledNode(op->n->label, op->n->labelID);
+	Node n = NEW_LABELED_NODE(op->n->label, op->n->labelID);
 	Graph_GetNode(op->g, node_id, &n);
 	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -90,7 +90,7 @@ static OpResult NodeByLabelScanInit(OpBase *opBase) {
 
 static inline void _UpdateRecord(NodeByLabelScan *op, Record r, GrB_Index node_id) {
 	// Populate the Record with the graph entity data.
-	Node n = {0};
+	Node n = Node_New();
 	Graph_GetNode(op->g, node_id, &n);
 	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -92,6 +92,8 @@ static inline void _UpdateRecord(NodeByLabelScan *op, Record r, GrB_Index node_i
 	// Populate the Record with the graph entity data.
 	Node n = Node_New();
 	Graph_GetNode(op->g, node_id, &n);
+	// Add label data to the node.
+	Node_SetLabel(&n, op->n->label, op->n->labelID);
 	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);
 }

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -90,10 +90,8 @@ static OpResult NodeByLabelScanInit(OpBase *opBase) {
 
 static inline void _UpdateRecord(NodeByLabelScan *op, Record r, GrB_Index node_id) {
 	// Populate the Record with the graph entity data.
-	Node n = Node_New();
+	Node n = Node_NewLabeledNode(op->n->label, op->n->labelID);
 	Graph_GetNode(op->g, node_id, &n);
-	// Add label data to the node.
-	Node_SetLabel(&n, op->n->label, op->n->labelID);
 	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);
 }

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -90,7 +90,7 @@ static OpResult NodeByLabelScanInit(OpBase *opBase) {
 
 static inline void _UpdateRecord(NodeByLabelScan *op, Record r, GrB_Index node_id) {
 	// Populate the Record with the graph entity data.
-	Node n = NEW_LABELED_NODE(op->n->label, op->n->labelID);
+	Node n = GE_NEW_LABELED_NODE(op->n->label, op->n->labelID);
 	Graph_GetNode(op->g, node_id, &n);
 	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -151,7 +151,7 @@ static Record _handoff(OpUpdate *op) {
 
 static void _groupUpdateExps(OpUpdate *op, EntityUpdateEvalCtx *update_ctxs) {
 	// Sort update contexts by unique Record ID.
-	#define islt(a,b) (a->record_idx < b->record_idx)
+#define islt(a,b) (a->record_idx < b->record_idx)
 
 	uint n = array_len(update_ctxs);
 	QSORT(EntityUpdateEvalCtx, update_ctxs, n, islt);
@@ -188,8 +188,7 @@ static void _groupUpdateExps(OpUpdate *op, EntityUpdateEvalCtx *update_ctxs) {
 	}
 }
 
-OpBase *NewUpdateOp(const ExecutionPlan *plan, EntityUpdateEvalCtx
-		*update_exps) {
+OpBase *NewUpdateOp(const ExecutionPlan *plan, EntityUpdateEvalCtx *update_exps) {
 	OpUpdate *op = rm_calloc(1, sizeof(OpUpdate));
 	op->records = NULL;
 	op->update_ctxs = NULL;
@@ -244,15 +243,17 @@ static void _EvalEntityUpdates(EntityUpdateCtx *ctx, GraphContext *gc,
 	// If the entity is a node, set its label if possible.
 	if(type == GETYPE_NODE) {
 		Node *n = (Node *)entity;
-		label_id = Graph_GetNodeLabel(gc->g, ENTITY_GET_ID(entity));
+		if(n->labelID != GRAPH_NO_LABEL) {
+			label_id = n->labelID;
+			label = n->label;
+		} else {
+			label_id = Graph_GetNodeLabel(gc->g, ENTITY_GET_ID(entity));
 
-		if(label_id != GRAPH_NO_LABEL) {
-			s = GraphContext_GetSchemaByID(gc, label_id, SCHEMA_NODE);
-			label = Schema_GetName(s);
+			if(label_id != GRAPH_NO_LABEL) {
+				s = GraphContext_GetSchemaByID(gc, label_id, SCHEMA_NODE);
+				label = Schema_GetName(s);
+			}
 		}
-
-		n->label = label;
-		n->labelID = label_id;
 	}
 
 	uint exp_count = array_len(ctx->exps);

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -243,15 +243,17 @@ static void _EvalEntityUpdates(EntityUpdateCtx *ctx, GraphContext *gc,
 	// If the entity is a node, set its label if possible.
 	if(type == GETYPE_NODE) {
 		Node *n = (Node *)entity;
-		if(n->labelID != GRAPH_NO_LABEL) {
-			label_id = n->labelID;
-			label = n->label;
-		} else {
+		label_id = n->labelID;
+		label = n->label;
+		if(n->labelID == GRAPH_NO_LABEL) {
+			// Label is currently unknown, try to retrieve it.
 			label_id = Graph_GetNodeLabel(gc->g, ENTITY_GET_ID(entity));
-
 			if(label_id != GRAPH_NO_LABEL) {
+				// Label ID has been found, retrieve its name and update the node.
 				s = GraphContext_GetSchemaByID(gc, label_id, SCHEMA_NODE);
 				label = Schema_GetName(s);
+				n->label = label;
+				n->labelID = label_id;
 			}
 		}
 	}

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -252,7 +252,6 @@ static void _EvalEntityUpdates(EntityUpdateCtx *ctx, GraphContext *gc,
 			s = GraphContext_GetSchemaByID(gc, label_id, SCHEMA_NODE);
 			label = Schema_GetName(s);
 			n->label = label;
-			n->labelID = label_id;
 		}
 	}
 

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -243,18 +243,14 @@ static void _EvalEntityUpdates(EntityUpdateCtx *ctx, GraphContext *gc,
 	// If the entity is a node, set its label if possible.
 	if(type == GETYPE_NODE) {
 		Node *n = (Node *)entity;
-		label_id = n->labelID;
-		label = n->label;
-		if(n->labelID == GRAPH_NO_LABEL) {
-			// Label is currently unknown, try to retrieve it.
-			label_id = Graph_GetNodeLabel(gc->g, ENTITY_GET_ID(entity));
-			if(label_id != GRAPH_NO_LABEL) {
-				// Label ID has been found, retrieve its name and update the node.
-				s = GraphContext_GetSchemaByID(gc, label_id, SCHEMA_NODE);
-				label = Schema_GetName(s);
-				n->label = label;
-				n->labelID = label_id;
-			}
+		label = NODE_GET_LABEL(n);
+		label_id = NODE_GET_LABEL_ID(n, gc->g);
+		if(label_id != GRAPH_NO_LABEL) {
+			// Label ID has been found, retrieve its name and update the node.
+			s = GraphContext_GetSchemaByID(gc, label_id, SCHEMA_NODE);
+			label = Schema_GetName(s);
+			n->label = label;
+			n->labelID = label_id;
 		}
 	}
 

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -243,10 +243,12 @@ static void _EvalEntityUpdates(EntityUpdateCtx *ctx, GraphContext *gc,
 	// If the entity is a node, set its label if possible.
 	if(type == GETYPE_NODE) {
 		Node *n = (Node *)entity;
+		// Retrieve the node's local label if present.
 		label = NODE_GET_LABEL(n);
+		// Retrieve the node's Label ID from a local member or the graph.
 		label_id = NODE_GET_LABEL_ID(n, gc->g);
-		if(label_id != GRAPH_NO_LABEL) {
-			// Label ID has been found, retrieve its name and update the node.
+		if((label == NULL) && (label_id != GRAPH_NO_LABEL)) {
+			// Label ID has been found but its name is unknown, retrieve its name and update the node.
 			s = GraphContext_GetSchemaByID(gc, label_id, SCHEMA_NODE);
 			label = Schema_GetName(s);
 			n->label = label;

--- a/src/execution_plan/ops/shared/create_functions.c
+++ b/src/execution_plan/ops/shared/create_functions.c
@@ -52,6 +52,7 @@ static void _CommitNodes(PendingCreations *pending) {
 		if(n->label != NULL) {
 			s = GraphContext_GetSchema(gc, n->label, SCHEMA_NODE);
 			assert(s);
+			n->labelID = s->id; // Update the label ID within the node.
 			labelID = s->id;
 		}
 

--- a/src/graph/entities/node.c
+++ b/src/graph/entities/node.c
@@ -7,29 +7,6 @@
 #include <stdlib.h>
 
 #include "node.h"
-#include "edge.h"
-#include "assert.h"
-#include "graph_entity.h"
-#include "../graphcontext.h"
-#include "../../query_ctx.h"
-
-inline Node Node_New() {
-	Node n = {
-		.entity = NULL,
-		.label = NULL,
-		.labelID = GRAPH_NO_LABEL,
-	};
-	return n;
-}
-
-inline Node Node_NewLabeledNode(const char *label, int label_id) {
-	Node n = {
-		.entity = NULL,
-		.label = label,
-		.labelID = label_id,
-	};
-	return n;
-}
 
 void Node_ToString(const Node *n, char **buffer, size_t *bufferLen, size_t *bytesWritten,
 				   GraphEntityStringFromat format) {

--- a/src/graph/entities/node.c
+++ b/src/graph/entities/node.c
@@ -22,9 +22,13 @@ inline Node Node_New() {
 	return n;
 }
 
-inline void Node_SetLabel(Node *n, const char *label, int label_id) {
-	n->label = label;
-	n->labelID = label_id;
+inline Node Node_NewLabeledNode(const char *label, int label_id) {
+	Node n = {
+		.entity = NULL,
+		.label = label,
+		.labelID = label_id,
+	};
+	return n;
 }
 
 void Node_ToString(const Node *n, char **buffer, size_t *bufferLen, size_t *bytesWritten,

--- a/src/graph/entities/node.c
+++ b/src/graph/entities/node.c
@@ -13,56 +13,23 @@
 #include "../graphcontext.h"
 #include "../../query_ctx.h"
 
-Node *Node_New(const char *label) {
-	Node *n = calloc(1, sizeof(Node));
-	n->labelID = GRAPH_UNKNOWN_LABEL;
-	n->label = label;
-
+inline Node Node_New() {
+	Node n = {
+		.entity = NULL,
+		.label = NULL,
+		.labelID = GRAPH_NO_LABEL,
+	};
 	return n;
 }
 
-GrB_Matrix Node_GetMatrix(Node *n) {
-	/* Node's label must be set,
-	 * otherwise it doesn't make sense to refer to a matrix. */
-	assert(n && n->label);
-
-	// Retrieve matrix from graph if edge matrix isn't set.
-	if(!n->mat) {
-		Graph *g = QueryCtx_GetGraph();
-
-		/* Get label matrix:
-		 * There's no sense in calling Node_GetMatrix
-		 * if node isn't labeled. */
-		assert(n->labelID != GRAPH_NO_LABEL);
-		if(n->labelID == GRAPH_UNKNOWN_LABEL) {
-			// Label specified (n:Label), but doesn't exists.
-			n->mat = Graph_GetZeroMatrix(g);
-		} else {
-			n->mat = Graph_GetLabelMatrix(g, n->labelID);
-		}
-	}
-
-	return n->mat;
-}
-
-Node *Node_Clone(const Node *n) {
-	Node *clone = Node_New(n->label);
-	clone->mat = n->mat;
-	// TODO: consider setting labelID in Node_New.
-	clone->labelID = n->labelID;
-	return clone;
+inline void Node_SetLabel(Node *n, const char *label, int label_id) {
+	n->label = label;
+	n->labelID = label_id;
 }
 
 void Node_ToString(const Node *n, char **buffer, size_t *bufferLen, size_t *bytesWritten,
 				   GraphEntityStringFromat format) {
 	GraphEntity_ToString((const GraphEntity *)n, buffer, bufferLen, bytesWritten, format,
 						 GETYPE_NODE);
-}
-
-void Node_Free(Node *node) {
-	if(!node) return;
-
-	free(node);
-	node = NULL;
 }
 

--- a/src/graph/entities/node.h
+++ b/src/graph/entities/node.h
@@ -4,34 +4,25 @@
 * This file is available under the Redis Labs Source Available License Agreement
 */
 
-#ifndef NODE_H_
-#define NODE_H_
+#pragma once
 
 #include "../../value.h"
 #include "graph_entity.h"
 #include "../../../deps/GraphBLAS/Include/GraphBLAS.h"
 
 typedef struct {
-	Entity *entity;    /* MUST be the first property of Edge. */
-	const char *label; /* Label attached to node */
+	Entity *entity;    /* MUST be the first member of Node. */
+	const char *label; /* Label attached to Node. */
 	int labelID;       /* Label ID. */
-	GrB_Matrix mat;    /* Label matrix, associated with node. */
 } Node;
 
-/* Creates a new node. */
-Node *Node_New(const char *label);
+/* Instantiate a new unpopulated node. */
+Node Node_New(void);
 
-/* Retrieves node matrix. */
-GrB_Matrix Node_GetMatrix(Node *n); // AE
-
-/* Clones given node. */
-Node *Node_Clone(const Node *n); // QG
+/* Set the label and associated ID of the given node. */
+void Node_SetLabel(Node *n, const char *label, int label_id);
 
 /* Prints a string representation of the node to buffer, return the string length. */
 void Node_ToString(const Node *n, char **buffer, size_t *bufferLen, size_t *bytesWritten,
 				   GraphEntityStringFromat format);
 
-/* Frees allocated space by given node. */
-void Node_Free(Node *node);
-
-#endif

--- a/src/graph/entities/node.h
+++ b/src/graph/entities/node.h
@@ -17,10 +17,17 @@ typedef struct {
 } Node;
 
 /* Instantiate a new unpopulated node. */
-#define NEW_NODE() (Node){.entity = NULL, .label = NULL, .labelID = GRAPH_NO_LABEL}
+#define GE_NEW_NODE() (Node){.entity = NULL, .label = NULL, .labelID = GRAPH_NO_LABEL}
 
 /* Instantiate a new node with label data. */
-#define NEW_LABELED_NODE(l_str, l_id) (Node){.entity = NULL, .label = (l_str), .labelID = (l_id)}
+#define GE_NEW_LABELED_NODE(l_str, l_id) (Node){.entity = NULL, .label = (l_str), .labelID = (l_id)}
+
+/* Resolves to the label string of the given Node. */
+#define NODE_GET_LABEL(n) (n)->label
+
+/* Resolves to the label ID of the given Node. */
+#define NODE_GET_LABEL_ID(n) (n)->labelID
+
 
 /* Prints a string representation of the node to buffer, return the string length. */
 void Node_ToString(const Node *n, char **buffer, size_t *bufferLen, size_t *bytesWritten,

--- a/src/graph/entities/node.h
+++ b/src/graph/entities/node.h
@@ -19,8 +19,8 @@ typedef struct {
 /* Instantiate a new unpopulated node. */
 Node Node_New(void);
 
-/* Set the label and associated ID of the given node. */
-void Node_SetLabel(Node *n, const char *label, int label_id);
+/* Instantiate a new node with label data. */
+Node Node_NewLabeledNode(const char *label, int label_id);
 
 /* Prints a string representation of the node to buffer, return the string length. */
 void Node_ToString(const Node *n, char **buffer, size_t *bufferLen, size_t *bytesWritten,

--- a/src/graph/entities/node.h
+++ b/src/graph/entities/node.h
@@ -25,9 +25,11 @@ typedef struct {
 /* Resolves to the label string of the given Node. */
 #define NODE_GET_LABEL(n) (n)->label
 
-/* Resolves to the label ID of the given Node. */
-#define NODE_GET_LABEL_ID(n) (n)->labelID
-
+/* Resolves to the label ID of the given Node.
+ * We first attempt to retrieve it from the local entity, then check the graph if not found.
+ * If the Node is unlabeled, the return value will be GRAPH_NO_LABEL. */
+#define NODE_GET_LABEL_ID(n, g) ((n)->labelID != GRAPH_NO_LABEL) ? (n)->labelID \
+												 : Graph_GetNodeLabel((g), ENTITY_GET_ID(n))
 
 /* Prints a string representation of the node to buffer, return the string length. */
 void Node_ToString(const Node *n, char **buffer, size_t *bufferLen, size_t *bytesWritten,

--- a/src/graph/entities/node.h
+++ b/src/graph/entities/node.h
@@ -17,10 +17,10 @@ typedef struct {
 } Node;
 
 /* Instantiate a new unpopulated node. */
-Node Node_New(void);
+#define NEW_NODE() (Node){.entity = NULL, .label = NULL, .labelID = GRAPH_NO_LABEL}
 
 /* Instantiate a new node with label data. */
-Node Node_NewLabeledNode(const char *label, int label_id);
+#define NEW_LABELED_NODE(l_str, l_id) (Node){.entity = NULL, .label = (l_str), .labelID = (l_id)}
 
 /* Prints a string representation of the node to buffer, return the string length. */
 void Node_ToString(const Node *n, char **buffer, size_t *bufferLen, size_t *bytesWritten,

--- a/src/graph/entities/node.h
+++ b/src/graph/entities/node.h
@@ -28,8 +28,11 @@ typedef struct {
 /* Resolves to the label ID of the given Node.
  * We first attempt to retrieve it from the local entity, then check the graph if not found.
  * If the Node is unlabeled, the return value will be GRAPH_NO_LABEL. */
-#define NODE_GET_LABEL_ID(n, g) ((n)->labelID != GRAPH_NO_LABEL) ? (n)->labelID \
-												 : Graph_GetNodeLabel((g), ENTITY_GET_ID(n))
+#define NODE_GET_LABEL_ID(n, g)                                                                   \
+({                                                                                                \
+	if ((n)->labelID == GRAPH_NO_LABEL) (n)->labelID = Graph_GetNodeLabel((g), ENTITY_GET_ID(n)); \
+	(n)->labelID;                                                                                 \
+})
 
 /* Prints a string representation of the node to buffer, return the string length. */
 void Node_ToString(const Node *n, char **buffer, size_t *bufferLen, size_t *bytesWritten,

--- a/src/graph/entities/qg_node.c
+++ b/src/graph/entities/qg_node.c
@@ -21,10 +21,10 @@ static void _QGNode_RemoveEdge(QGEdge **edges, QGEdge *e) {
 	}
 }
 
-QGNode *QGNode_New(const char *label, const char *alias) {
+QGNode *QGNode_New(const char *alias) {
 	QGNode *n = rm_malloc(sizeof(QGNode));
+	n->label = NULL;
 	n->labelID = GRAPH_NO_LABEL;
-	n->label = label;
 	n->alias = alias;
 	n->incoming_edges = array_new(QGEdge *, 0);
 	n->outgoing_edges = array_new(QGEdge *, 0);

--- a/src/graph/entities/qg_node.h
+++ b/src/graph/entities/qg_node.h
@@ -22,7 +22,7 @@ typedef struct {
 } QGNode;
 
 /* Creates a new node. */
-QGNode *QGNode_New(const char *label, const char *alias);
+QGNode *QGNode_New(const char *alias);
 
 /* Returns number of edges pointing into node. */
 int QGNode_IncomeDegree(const QGNode *n);
@@ -50,3 +50,4 @@ int QGNode_ToString(const QGNode *n, char *buff, int buff_len);
 
 /* Frees allocated space by given node. */
 void QGNode_Free(QGNode *node);
+

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -501,8 +501,8 @@ void Graph_GetEdgesConnectingNodes(const Graph *g, NodeID srcID, NodeID destID, 
 	// MATCH ()-[:real_type|fake_type]->()
 	if(r == GRAPH_UNKNOWN_RELATION) return;
 
-	Node srcNode = Node_New();
-	Node destNode = Node_New();
+	Node srcNode = NEW_NODE();
+	Node destNode = NEW_NODE();
 	assert(Graph_GetNode(g, srcID, &srcNode));
 	assert(Graph_GetNode(g, destID, &destNode));
 
@@ -586,8 +586,8 @@ void Graph_FormConnection(Graph *g, NodeID src, NodeID dest, EdgeID edge_id, int
 }
 
 int Graph_ConnectNodes(Graph *g, NodeID src, NodeID dest, int r, Edge *e) {
-	Node srcNode = Node_New();
-	Node destNode = Node_New();
+	Node srcNode = NEW_NODE();
+	Node destNode = NEW_NODE();
 
 	assert(Graph_GetNode(g, src, &srcNode));
 	assert(Graph_GetNode(g, dest, &destNode));

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -501,8 +501,8 @@ void Graph_GetEdgesConnectingNodes(const Graph *g, NodeID srcID, NodeID destID, 
 	// MATCH ()-[:real_type|fake_type]->()
 	if(r == GRAPH_UNKNOWN_RELATION) return;
 
-	Node srcNode;
-	Node destNode;
+	Node srcNode = Node_New();
+	Node destNode = Node_New();
 	assert(Graph_GetNode(g, srcID, &srcNode));
 	assert(Graph_GetNode(g, destID, &destNode));
 
@@ -586,8 +586,8 @@ void Graph_FormConnection(Graph *g, NodeID src, NodeID dest, EdgeID edge_id, int
 }
 
 int Graph_ConnectNodes(Graph *g, NodeID src, NodeID dest, int r, Edge *e) {
-	Node srcNode;
-	Node destNode;
+	Node srcNode = Node_New();
+	Node destNode = Node_New();
 
 	assert(Graph_GetNode(g, src, &srcNode));
 	assert(Graph_GetNode(g, dest, &destNode));

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -501,8 +501,8 @@ void Graph_GetEdgesConnectingNodes(const Graph *g, NodeID srcID, NodeID destID, 
 	// MATCH ()-[:real_type|fake_type]->()
 	if(r == GRAPH_UNKNOWN_RELATION) return;
 
-	Node srcNode = NEW_NODE();
-	Node destNode = NEW_NODE();
+	Node srcNode = GE_NEW_NODE();
+	Node destNode = GE_NEW_NODE();
 	assert(Graph_GetNode(g, srcID, &srcNode));
 	assert(Graph_GetNode(g, destID, &destNode));
 
@@ -586,8 +586,8 @@ void Graph_FormConnection(Graph *g, NodeID src, NodeID dest, EdgeID edge_id, int
 }
 
 int Graph_ConnectNodes(Graph *g, NodeID src, NodeID dest, int r, Edge *e) {
-	Node srcNode = NEW_NODE();
-	Node destNode = NEW_NODE();
+	Node srcNode = GE_NEW_NODE();
+	Node destNode = GE_NEW_NODE();
 
 	assert(Graph_GetNode(g, src, &srcNode));
 	assert(Graph_GetNode(g, dest, &destNode));

--- a/src/graph/query_graph.c
+++ b/src/graph/query_graph.c
@@ -23,7 +23,7 @@ static void _BuildQueryGraphAddNode(QueryGraph *qg, const cypher_astnode_t *ast_
 
 	if(n == NULL) {
 		// Node has not been mapped; create it.
-		n = QGNode_New(NULL, alias);
+		n = QGNode_New(alias);
 		QueryGraph_AddNode(qg, n);
 	}
 

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -8,7 +8,7 @@
 
 static int _getNodeAttribute(void *ctx, const char *fieldName, const void *id, char **strVal,
 							 double *doubleVal) {
-	Node n = Node_New();
+	Node n = NEW_NODE();
 	NodeID nId = *(NodeID *)id;
 	GraphContext *gc = (GraphContext *)ctx;
 	Graph *g = gc->g;
@@ -42,7 +42,7 @@ static void _populateIndex
 	// Label doesn't exists.
 	if(s == NULL) return;
 
-	Node node = Node_New();
+	Node node = NEW_NODE();
 	NodeID node_id;
 	Graph *g = gc->g;
 	int label_id = s->id;

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -8,7 +8,7 @@
 
 static int _getNodeAttribute(void *ctx, const char *fieldName, const void *id, char **strVal,
 							 double *doubleVal) {
-	Node n;
+	Node n = Node_New();
 	NodeID nId = *(NodeID *)id;
 	GraphContext *gc = (GraphContext *)ctx;
 	Graph *g = gc->g;
@@ -42,7 +42,7 @@ static void _populateIndex
 	// Label doesn't exists.
 	if(s == NULL) return;
 
-	Node node;
+	Node node = Node_New();
 	NodeID node_id;
 	Graph *g = gc->g;
 	int label_id = s->id;

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -8,7 +8,7 @@
 
 static int _getNodeAttribute(void *ctx, const char *fieldName, const void *id, char **strVal,
 							 double *doubleVal) {
-	Node n = NEW_NODE();
+	Node n = GE_NEW_NODE();
 	NodeID nId = *(NodeID *)id;
 	GraphContext *gc = (GraphContext *)ctx;
 	Graph *g = gc->g;
@@ -42,7 +42,7 @@ static void _populateIndex
 	// Label doesn't exists.
 	if(s == NULL) return;
 
-	Node node = NEW_NODE();
+	Node node = GE_NEW_NODE();
 	NodeID node_id;
 	Graph *g = gc->g;
 	int label_id = s->id;

--- a/src/procedures/proc_fulltext_query.c
+++ b/src/procedures/proc_fulltext_query.c
@@ -48,6 +48,7 @@ ProcedureResult Proc_FulltextQueryNodeInvoke(ProcedureCtx *ctx, const SIValue *a
 	QueryNodeContext *pdata = ctx->privateData;
 	pdata->idx = idx;
 	pdata->g = gc->g;
+	pdata->n = Node_New();
 	pdata->output = array_new(SIValue, 2);
 	pdata->output = array_append(pdata->output, SI_ConstStringVal("node"));
 	pdata->output = array_append(pdata->output, SI_Node(&pdata->n));

--- a/src/procedures/proc_fulltext_query.c
+++ b/src/procedures/proc_fulltext_query.c
@@ -48,7 +48,7 @@ ProcedureResult Proc_FulltextQueryNodeInvoke(ProcedureCtx *ctx, const SIValue *a
 	QueryNodeContext *pdata = ctx->privateData;
 	pdata->idx = idx;
 	pdata->g = gc->g;
-	pdata->n = Node_New();
+	pdata->n = NEW_NODE();
 	pdata->output = array_new(SIValue, 2);
 	pdata->output = array_append(pdata->output, SI_ConstStringVal("node"));
 	pdata->output = array_append(pdata->output, SI_Node(&pdata->n));

--- a/src/procedures/proc_fulltext_query.c
+++ b/src/procedures/proc_fulltext_query.c
@@ -48,7 +48,7 @@ ProcedureResult Proc_FulltextQueryNodeInvoke(ProcedureCtx *ctx, const SIValue *a
 	QueryNodeContext *pdata = ctx->privateData;
 	pdata->idx = idx;
 	pdata->g = gc->g;
-	pdata->n = NEW_NODE();
+	pdata->n = GE_NEW_NODE();
 	pdata->output = array_new(SIValue, 2);
 	pdata->output = array_append(pdata->output, SI_ConstStringVal("node"));
 	pdata->output = array_append(pdata->output, SI_Node(&pdata->n));

--- a/src/procedures/proc_pagerank.c
+++ b/src/procedures/proc_pagerank.c
@@ -47,7 +47,7 @@ ProcedureResult Proc_PagerankInvoke(ProcedureCtx *ctx, const SIValue *args) {
 	pdata->n = n;
 	pdata->i = 0;
 	pdata->g = g;
-	pdata->node = NEW_NODE();
+	pdata->node = GE_NEW_NODE();
 	pdata->mappings = mappings;
 	pdata->rankings = rankings;
 	pdata->output = array_new(SIValue, 4);

--- a/src/procedures/proc_pagerank.c
+++ b/src/procedures/proc_pagerank.c
@@ -47,7 +47,7 @@ ProcedureResult Proc_PagerankInvoke(ProcedureCtx *ctx, const SIValue *args) {
 	pdata->n = n;
 	pdata->i = 0;
 	pdata->g = g;
-	pdata->node = Node_New();
+	pdata->node = NEW_NODE();
 	pdata->mappings = mappings;
 	pdata->rankings = rankings;
 	pdata->output = array_new(SIValue, 4);

--- a/src/procedures/proc_pagerank.c
+++ b/src/procedures/proc_pagerank.c
@@ -47,6 +47,7 @@ ProcedureResult Proc_PagerankInvoke(ProcedureCtx *ctx, const SIValue *args) {
 	pdata->n = n;
 	pdata->i = 0;
 	pdata->g = g;
+	pdata->node = Node_New();
 	pdata->mappings = mappings;
 	pdata->rankings = rankings;
 	pdata->output = array_new(SIValue, 4);
@@ -156,3 +157,4 @@ ProcedureCtx *Proc_PagerankCtx() {
 								   true);
 	return ctx;
 }
+

--- a/src/resultset/formatters/resultset_replycompact.c
+++ b/src/resultset/formatters/resultset_replycompact.c
@@ -116,9 +116,7 @@ static void _ResultSet_CompactReplyWithNode(RedisModuleCtx *ctx, GraphContext *g
 	RedisModule_ReplyWithLongLong(ctx, id);
 
 	// [label string index]
-	int label_id = NODE_GET_LABEL_ID(n);
-	// Retrieve label if it is not set on the node.
-	if(label_id == GRAPH_NO_LABEL) label_id = Graph_GetNodeLabel(gc->g, id);
+	int label_id = NODE_GET_LABEL_ID(n, gc->g);
 	if(label_id == GRAPH_NO_LABEL) {
 		// Emit an empty array for unlabeled nodes.
 		RedisModule_ReplyWithArray(ctx, 0);

--- a/src/resultset/formatters/resultset_replycompact.c
+++ b/src/resultset/formatters/resultset_replycompact.c
@@ -117,8 +117,8 @@ static void _ResultSet_CompactReplyWithNode(RedisModuleCtx *ctx, GraphContext *g
 
 	// [label string index]
 	// Print label in nested array for multi-label support
-	// Retrieve label
-	int label_id = Graph_GetNodeLabel(gc->g, id);
+	// Retrieve label if it is not set on the node.
+	int label_id = n->labelID != GRAPH_NO_LABEL ? n->labelID : Graph_GetNodeLabel(gc->g, id);
 	if(label_id == GRAPH_NO_LABEL) {
 		// Emit an empty array for unlabeled nodes
 		RedisModule_ReplyWithArray(ctx, 0);

--- a/src/resultset/formatters/resultset_replycompact.c
+++ b/src/resultset/formatters/resultset_replycompact.c
@@ -116,13 +116,14 @@ static void _ResultSet_CompactReplyWithNode(RedisModuleCtx *ctx, GraphContext *g
 	RedisModule_ReplyWithLongLong(ctx, id);
 
 	// [label string index]
-	// Print label in nested array for multi-label support
+	int label_id = NODE_GET_LABEL_ID(n);
 	// Retrieve label if it is not set on the node.
-	int label_id = n->labelID != GRAPH_NO_LABEL ? n->labelID : Graph_GetNodeLabel(gc->g, id);
+	if(label_id == GRAPH_NO_LABEL) label_id = Graph_GetNodeLabel(gc->g, id);
 	if(label_id == GRAPH_NO_LABEL) {
-		// Emit an empty array for unlabeled nodes
+		// Emit an empty array for unlabeled nodes.
 		RedisModule_ReplyWithArray(ctx, 0);
 	} else {
+		// Print label in nested array for multi-label support.
 		RedisModule_ReplyWithArray(ctx, 1);
 		RedisModule_ReplyWithLongLong(ctx, label_id);
 	}

--- a/src/resultset/formatters/resultset_replyverbose.c
+++ b/src/resultset/formatters/resultset_replyverbose.c
@@ -90,9 +90,9 @@ static void _ResultSet_VerboseReplyWithNode(RedisModuleCtx *ctx, GraphContext *g
 	RedisModule_ReplyWithArray(ctx, 2);
 	RedisModule_ReplyWithStringBuffer(ctx, "labels", 6);
 	// Print label in nested array for multi-label support
-	// Retrieve label
+	// Retrieve label if it is not set on the node.
 	// TODO Make a more efficient lookup for this string
-	const char *label = GraphContext_GetNodeLabel(gc, n);
+	const char *label = n->label ? n->label : GraphContext_GetNodeLabel(gc, n);
 	if(label == NULL) {
 		// Emit an empty array for unlabeled nodes
 		RedisModule_ReplyWithArray(ctx, 0);

--- a/src/resultset/formatters/resultset_replyverbose.c
+++ b/src/resultset/formatters/resultset_replyverbose.c
@@ -89,14 +89,15 @@ static void _ResultSet_VerboseReplyWithNode(RedisModuleCtx *ctx, GraphContext *g
 	// ["labels", [label (string)]]
 	RedisModule_ReplyWithArray(ctx, 2);
 	RedisModule_ReplyWithStringBuffer(ctx, "labels", 6);
-	// Print label in nested array for multi-label support
+	const char *label = NODE_GET_LABEL(n);
 	// Retrieve label if it is not set on the node.
 	// TODO Make a more efficient lookup for this string
-	const char *label = n->label ? n->label : GraphContext_GetNodeLabel(gc, n);
+	if(label == NULL) label = GraphContext_GetNodeLabel(gc, n);
 	if(label == NULL) {
-		// Emit an empty array for unlabeled nodes
+		// Emit an empty array for unlabeled nodes.
 		RedisModule_ReplyWithArray(ctx, 0);
 	} else {
+		// Print label in nested array for multi-label support.
 		RedisModule_ReplyWithArray(ctx, 1);
 		RedisModule_ReplyWithStringBuffer(ctx, label, strlen(label));
 	}

--- a/tests/unit/test_bfs.cpp
+++ b/tests/unit/test_bfs.cpp
@@ -45,13 +45,12 @@ class BFSTest: public ::testing::Test {
 		size_t edge_cap = 3;
 
 		// Create nodes.
-		const char *label = "L";
 		const char *relation = "R";
 
-		A = QGNode_New(label, "A");
-		B = QGNode_New(label, "B");
-		C = QGNode_New(label, "C");
-		D = QGNode_New(label, "D");
+		A = QGNode_New("A");
+		B = QGNode_New("B");
+		C = QGNode_New("C");
+		D = QGNode_New("D");
 
 		AB = QGEdge_New(A, B, relation, "AB");
 		BC = QGEdge_New(B, C, relation, "BC");
@@ -154,3 +153,4 @@ QGNode *BFSTest::D;
 QGEdge *BFSTest::AB;
 QGEdge *BFSTest::BC;
 QGEdge *BFSTest::BD;
+

--- a/tests/unit/test_detect_cycle.cpp
+++ b/tests/unit/test_detect_cycle.cpp
@@ -23,8 +23,8 @@ class DetectCycleTest: public ::testing::Test {
 
   protected:
 	static void SetUpTestCase() {
-        // Initialize GraphBLAS
-        GrB_init(GrB_NONBLOCKING);
+		// Initialize GraphBLAS
+		GrB_init(GrB_NONBLOCKING);
 
 		// Use the malloc family for allocations
 		Alloc_Reset();
@@ -36,12 +36,11 @@ class DetectCycleTest: public ::testing::Test {
 		size_t edge_cap = 2;
 
 		// Create nodes.
-		const char *label = "L";
 		const char *relation = "R";
 
-		QGNode *A = QGNode_New(label, "A");
-		QGNode *B = QGNode_New(label, "B");
-		QGNode *C = QGNode_New(label, "C");
+		QGNode *A = QGNode_New("A");
+		QGNode *B = QGNode_New("B");
+		QGNode *C = QGNode_New("C");
 
 		QGEdge *AB = QGEdge_New(A, B, relation, "AB");
 		QGEdge *BC = QGEdge_New(B, C, relation, "BC");
@@ -57,38 +56,37 @@ class DetectCycleTest: public ::testing::Test {
 		return g;
 	}
 
-    static QueryGraph *CyclicBuildGraph() {
+	static QueryGraph *CyclicBuildGraph() {
 		// (A)->(B)->(C)->(D)->(E)->(B)->(F)->(G)->(C)
 		size_t node_cap = 7;
 		size_t edge_cap = 8;
 
 		// Create nodes.
-		const char *label = "L";
 		const char *relation = "R";
 
-		QGNode *A = QGNode_New(label, "A");
-		QGNode *B = QGNode_New(label, "B");
-		QGNode *C = QGNode_New(label, "C");
-		QGNode *D = QGNode_New(label, "D");
-		QGNode *E = QGNode_New(label, "E");
-		QGNode *F = QGNode_New(label, "F");
-		QGNode *G = QGNode_New(label, "G");
+		QGNode *A = QGNode_New("A");
+		QGNode *B = QGNode_New("B");
+		QGNode *C = QGNode_New("C");
+		QGNode *D = QGNode_New("D");
+		QGNode *E = QGNode_New("E");
+		QGNode *F = QGNode_New("F");
+		QGNode *G = QGNode_New("G");
 
-        // (A)->(B)
+		// (A)->(B)
 		QGEdge *AB = QGEdge_New(A, B, relation, "AB");
-        // (B)->(C)
+		// (B)->(C)
 		QGEdge *BC = QGEdge_New(B, C, relation, "BC");
-        // (C)->(D)
+		// (C)->(D)
 		QGEdge *CD = QGEdge_New(C, D, relation, "CD");
-        // (D)->(E)
+		// (D)->(E)
 		QGEdge *DE = QGEdge_New(D, E, relation, "DE");
-        // (E)->(B)
+		// (E)->(B)
 		QGEdge *EB = QGEdge_New(E, B, relation, "EB");
-        // (B)->(F)
+		// (B)->(F)
 		QGEdge *BF = QGEdge_New(B, F, relation, "BF");
-        // (F)->(G)
+		// (F)->(G)
 		QGEdge *FG = QGEdge_New(F, G, relation, "FG");
-        // (G)->(C)
+		// (G)->(C)
 		QGEdge *GC = QGEdge_New(G, C, relation, "GC");
 
 		QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
@@ -101,28 +99,29 @@ class DetectCycleTest: public ::testing::Test {
 		QueryGraph_AddNode(g, G);
 
 		QueryGraph_ConnectNodes(g, A, B, AB);
-        QueryGraph_ConnectNodes(g, B, C, BC);
-        QueryGraph_ConnectNodes(g, C, D, CD);
-        QueryGraph_ConnectNodes(g, D, E, DE);
-        QueryGraph_ConnectNodes(g, E, B, EB);
-        QueryGraph_ConnectNodes(g, B, F, BF);
-        QueryGraph_ConnectNodes(g, F, G, FG);
-        QueryGraph_ConnectNodes(g, G, C, GC);
+		QueryGraph_ConnectNodes(g, B, C, BC);
+		QueryGraph_ConnectNodes(g, C, D, CD);
+		QueryGraph_ConnectNodes(g, D, E, DE);
+		QueryGraph_ConnectNodes(g, E, B, EB);
+		QueryGraph_ConnectNodes(g, B, F, BF);
+		QueryGraph_ConnectNodes(g, F, G, FG);
+		QueryGraph_ConnectNodes(g, G, C, GC);
 
 		return g;
 	}
 };
 
 TEST_F(DetectCycleTest, AcyclicGraph) {
-    QueryGraph *g = AcyclicBuildGraph();  // Graph traversed.
-    ASSERT_TRUE(IsAcyclicGraph(g));
+	QueryGraph *g = AcyclicBuildGraph();  // Graph traversed.
+	ASSERT_TRUE(IsAcyclicGraph(g));
 	// Clean up.
 	QueryGraph_Free(g);
 }
 
 TEST_F(DetectCycleTest, CyclicGraph) {
-    QueryGraph *g = CyclicBuildGraph();  // Graph traversed.
-    ASSERT_FALSE(IsAcyclicGraph(g));
+	QueryGraph *g = CyclicBuildGraph();  // Graph traversed.
+	ASSERT_FALSE(IsAcyclicGraph(g));
 	// Clean up.
 	QueryGraph_Free(g);
 }
+

--- a/tests/unit/test_dfs.cpp
+++ b/tests/unit/test_dfs.cpp
@@ -44,13 +44,12 @@ class DFSTest: public ::testing::Test {
 		size_t edge_cap = 3;
 
 		// Create nodes.
-		const char *label = "L";
 		const char *relation = "R";
 
-		A = QGNode_New(label, "A");
-		B = QGNode_New(label, "B");
-		C = QGNode_New(label, "C");
-		D = QGNode_New(label, "D");
+		A = QGNode_New("A");
+		B = QGNode_New("B");
+		C = QGNode_New("C");
+		D = QGNode_New("D");
 
 		AB = QGEdge_New(A, B, relation, "AB");
 		BC = QGEdge_New(B, C, relation, "BC");
@@ -127,3 +126,4 @@ QGNode *DFSTest::D;
 QGEdge *DFSTest::AB;
 QGEdge *DFSTest::BC;
 QGEdge *DFSTest::CD;
+

--- a/tests/unit/test_query_graph.cpp
+++ b/tests/unit/test_query_graph.cpp
@@ -67,9 +67,7 @@ class QueryGraphTest: public ::testing::Test {
 		size_t edge_cap = 0;
 
 		// Create nodes.
-		const char *label = "L";
-
-		QGNode *A = QGNode_New(label, "A");
+		QGNode *A = QGNode_New("A");
 		QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
 		QueryGraph_AddNode(g, A);
 
@@ -83,12 +81,11 @@ class QueryGraphTest: public ::testing::Test {
 		size_t edge_cap = 3;
 
 		// Create nodes.
-		const char *label = "L";
 		const char *relation = "R";
 
-		QGNode *A = QGNode_New(label, "A");
-		QGNode *B = QGNode_New(label, "B");
-		QGNode *C = QGNode_New(label, "C");
+		QGNode *A = QGNode_New("A");
+		QGNode *B = QGNode_New("B");
+		QGNode *C = QGNode_New("C");
 
 		QGEdge *AB = QGEdge_New(A, B, relation, "AB");
 		QGEdge *BC = QGEdge_New(B, C, relation, "BC");
@@ -113,12 +110,11 @@ class QueryGraphTest: public ::testing::Test {
 		size_t edge_cap = 1;
 
 		// Create nodes.
-		const char *label = "L";
 		const char *relation = "R";
 
-		QGNode *A = QGNode_New(label, "A");
-		QGNode *B = QGNode_New(label, "B");
-		QGNode *C = QGNode_New(label, "C");
+		QGNode *A = QGNode_New("A");
+		QGNode *B = QGNode_New("B");
+		QGNode *C = QGNode_New("C");
 
 		QGEdge *AB = QGEdge_New(A, B, relation, "AB");
 
@@ -139,10 +135,9 @@ class QueryGraphTest: public ::testing::Test {
 		size_t edge_cap = 1;
 
 		// Create nodes.
-		const char *label = "L";
 		const char *relation = "R";
 
-		QGNode *A = QGNode_New(label, "A");
+		QGNode *A = QGNode_New("A");
 		QGEdge *AA = QGEdge_New(A, A, relation, "AA");
 
 		QueryGraph *g = QueryGraph_New(node_cap, edge_cap);
@@ -161,12 +156,11 @@ TEST_F(QueryGraphTest, QueryGraphClone) {
 	size_t edge_cap = 3;
 
 	// Create nodes.
-	const char *label = "L";
 	const char *relation = "R";
 
-	QGNode *A = QGNode_New(label, "A");
-	QGNode *B = QGNode_New(label, "B");
-	QGNode *C = QGNode_New(label, "C");
+	QGNode *A = QGNode_New("A");
+	QGNode *B = QGNode_New("B");
+	QGNode *C = QGNode_New("C");
 
 	QGEdge *AB = QGEdge_New(A, B, relation, "AB");
 	QGEdge *BC = QGEdge_New(B, C, relation, "BC");
@@ -214,12 +208,11 @@ TEST_F(QueryGraphTest, QueryGraphRemoveEntities) {
 	size_t edge_cap = 3;
 
 	// Create nodes.
-	const char *label = "L";
 	const char *relation = "R";
 
-	QGNode *A = QGNode_New(label, "A");
-	QGNode *B = QGNode_New(label, "B");
-	QGNode *C = QGNode_New(label, "C");
+	QGNode *A = QGNode_New("A");
+	QGNode *B = QGNode_New("B");
+	QGNode *C = QGNode_New("C");
 
 	QGEdge *AB = QGEdge_New(A, B, relation, "AB");
 	QGEdge *BC = QGEdge_New(B, C, relation, "BC");
@@ -342,3 +335,4 @@ TEST_F(QueryGraphTest, QueryGraphConnectedComponents) {
 	}
 	array_free(connected_components);
 }
+

--- a/tests/unit/test_traversal_ordering.cpp
+++ b/tests/unit/test_traversal_ordering.cpp
@@ -73,10 +73,10 @@ TEST_F(TraversalOrderingTest, TransposeFree) {
 	 * Arrangement { [AB], [BC], [CD] }
 	 * Is the only one that doesn't requires any transposes. */
 
-	QGNode *A = QGNode_New(NULL, "A");
-	QGNode *B = QGNode_New(NULL, "B");
-	QGNode *C = QGNode_New(NULL, "C");
-	QGNode *D = QGNode_New(NULL, "D");
+	QGNode *A = QGNode_New("A");
+	QGNode *B = QGNode_New("B");
+	QGNode *C = QGNode_New("C");
+	QGNode *D = QGNode_New("D");
 
 	QGEdge *AB = QGEdge_New(A, B, "E", "AB");
 	QGEdge *BC = QGEdge_New(B, C, "E", "BC");
@@ -177,10 +177,10 @@ TEST_F(TraversalOrderingTest, FilterFirst) {
 	 * { [CD], [CB], [BA] } (A)<-(B)<-(C)->(D) (2 transposes) */
 
 	FT_FilterNode *filters;
-	QGNode *A = QGNode_New(NULL, "A");
-	QGNode *B = QGNode_New(NULL, "B");
-	QGNode *C = QGNode_New(NULL, "C");
-	QGNode *D = QGNode_New(NULL, "D");
+	QGNode *A = QGNode_New("A");
+	QGNode *B = QGNode_New("B");
+	QGNode *C = QGNode_New("C");
+	QGNode *D = QGNode_New("D");
 
 	QGEdge *AB = QGEdge_New(A, B, "E", "AB");
 	QGEdge *BC = QGEdge_New(B, C, "E", "BC");
@@ -197,7 +197,7 @@ TEST_F(TraversalOrderingTest, FilterFirst) {
 	QueryGraph_ConnectNodes(qg, C, D, CD);
 
 	AlgebraicExpression *set[3];
-    AlgebraicExpression *ExpAB = AlgebraicExpression_NewOperand(GrB_NULL, false, "A", "B", NULL, NULL);
+	AlgebraicExpression *ExpAB = AlgebraicExpression_NewOperand(GrB_NULL, false, "A", "B", NULL, NULL);
 	AlgebraicExpression *ExpBC = AlgebraicExpression_NewOperand(GrB_NULL, false, "B", "C", NULL, NULL);
 	AlgebraicExpression *ExpCD = AlgebraicExpression_NewOperand(GrB_NULL, false, "C", "D", NULL, NULL);
 
@@ -224,8 +224,8 @@ TEST_F(TraversalOrderingTest, FilterFirst) {
 	filters = build_filter_tree_from_query("MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE B.val = 1 RETURN *");
 
 	orderExpressions(qg, set, 3, filters, NULL);
-    
-    ASSERT_STREQ(AlgebraicExpression_Source(set[0]), "B");
+
+	ASSERT_STREQ(AlgebraicExpression_Source(set[0]), "B");
 
 	FilterTree_Free(filters);
 
@@ -237,7 +237,7 @@ TEST_F(TraversalOrderingTest, FilterFirst) {
 	filters = build_filter_tree_from_query("MATCH (A)-[]->(B)-[]->(C)-[]->(D) WHERE C.val = 1 RETURN *");
 
 	orderExpressions(qg, set, 3, filters, NULL);
-    ASSERT_STREQ(AlgebraicExpression_Source(set[0]), "C");
+	ASSERT_STREQ(AlgebraicExpression_Source(set[0]), "C");
 
 	FilterTree_Free(filters);
 
@@ -259,3 +259,4 @@ TEST_F(TraversalOrderingTest, FilterFirst) {
 	AlgebraicExpression_Free(ExpCD);
 	QueryGraph_Free(qg);
 }
+


### PR DESCRIPTION
Addresses #1248 and #1249 with respect to nodes.

Removes redundant lookups of node label data in the ResultSet formatters and OpUpdate, populates label data when possible in Scan and Traverse operations.