### PR TITLE
Ignore NULL values in ValueHashJoin

### DIFF
--- a/tests/flow/test_null_handling.py
+++ b/tests/flow/test_null_handling.py
@@ -114,3 +114,20 @@ class testNullHandlingFlow(FlowTestsBase):
         # Expect no results.
         expected_result = []
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    # ValueHashJoin ops should not treat null values as equal.
+    def test08_null_value_hash_join(self):
+        query = """MATCH (a), (b) WHERE a.fakeval = b.fakeval RETURN a, b"""
+        plan = redis_graph.execution_plan(query)
+        # Verify that we are performing a ValueHashJoin
+        self.env.assertIn("Value Hash Join", plan)
+        actual_result = redis_graph.query(query)
+        # Expect no results.
+        expected_result = []
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        # Perform a sanity check on a ValueHashJoin that returns a result
+        query = """MATCH (a), (b) WHERE a.v = b.v RETURN a.v, b.v"""
+        actual_result = redis_graph.query(query)
+        expected_result = [['v1', 'v1']]
+        self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
Resolves #1261 

NULL != NULL, so NULL join values should be discarded in ValueHashJoins.