### PR TITLE
migrate id from entity to both node and edge objects

### DIFF
--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -53,8 +53,9 @@ static Record AllNodeScanConsumeFromChild(OpBase *opBase) {
 		}
 	}
 
-	Entity *en = (Entity *)DataBlockIterator_Next(op->iter);
-	if(en == NULL) {
+	Node n = GE_NEW_NODE();
+	n.entity = (Entity *)DataBlockIterator_Next(op->iter, &n.id);
+	if(n.entity == NULL) {
 		OpBase_DeleteRecord(op->child_record); // Free old record.
 		// Pull a new record from child.
 		op->child_record = OpBase_Consume(op->op.children[0]);
@@ -62,16 +63,14 @@ static Record AllNodeScanConsumeFromChild(OpBase *opBase) {
 
 		// Reset iterator and evaluate again.
 		DataBlockIterator_Reset(op->iter);
-		en = DataBlockIterator_Next(op->iter);
-		if(!en) return NULL; // Iterator was empty; return immediately.
+		n.entity = DataBlockIterator_Next(op->iter, &n.id);
+		if(n.entity == NULL) return NULL; // Iterator was empty; return immediately.
 	}
 
 	// Clone the held Record, as it will be freed upstream.
 	Record r = OpBase_CloneRecord(op->child_record);
 
 	// Populate the Record with the graph entity data.
-	Node n = GE_NEW_NODE();
-	n.entity = en;
 	Record_AddNode(r, op->nodeRecIdx, n);
 
 	return r;
@@ -80,12 +79,11 @@ static Record AllNodeScanConsumeFromChild(OpBase *opBase) {
 static Record AllNodeScanConsume(OpBase *opBase) {
 	AllNodeScan *op = (AllNodeScan *)opBase;
 
-	Entity *en = (Entity *)DataBlockIterator_Next(op->iter);
-	if(en == NULL) return NULL;
+	Node n = GE_NEW_NODE();
+	n.entity = (Entity *)DataBlockIterator_Next(op->iter, &n.id);
+	if(n.entity == NULL) return NULL;
 
 	Record r = OpBase_CreateRecord((OpBase *)op);
-	Node n = GE_NEW_NODE();
-	n.entity = en;
 	Record_AddNode(r, op->nodeRecIdx, n);
 
 	return r;

--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -22,7 +22,7 @@ static void MergeFree(OpBase *opBase);
 //------------------------------------------------------------------------------
 // Perform necessary index updates.
 static void _UpdateIndices(GraphContext *gc, Node *n) {
-	int label_id = Graph_GetNodeLabel(gc->g, n->entity->id);
+	int label_id = Graph_GetNodeLabel(gc->g, ENTITY_GET_ID(n));
 	if(label_id == GRAPH_NO_LABEL) return; // Unlabeled node, no need to update.
 
 	Schema *s = GraphContext_GetSchemaByID(gc, label_id, SCHEMA_NODE);

--- a/src/graph/entities/edge.h
+++ b/src/graph/entities/edge.h
@@ -17,14 +17,15 @@
 /* TODO: note it is possible to get into an inconsistency
  * if we set src and srcNodeID to different nodes. */
 struct Edge {
-	Entity *entity;           /* MUST be the first property of Edge. */
-	const char *relationship; /* Label attached to edge. */
-	int relationID;           /* Relation ID. */
-	Node *src;                /* Pointer to source node. */
-	Node *dest;               /* Pointer to destination node. */
-	NodeID srcNodeID;         /* Source node ID. */
-	NodeID destNodeID;        /* Destination node ID. */
-	GrB_Matrix mat;           /* Adjacency matrix, associated with edge. */
+	Entity *entity;             // MUST be the first member
+	EntityID id;                // Unique id, MUST be the second member
+	const char *relationship;   // Label attached to edge
+	int relationID;             // Relation ID
+	Node *src;                  // Pointer to source node
+	Node *dest;                 // Pointer to destination node
+	NodeID srcNodeID;           // Source node ID
+	NodeID destNodeID;          // Destination node ID
+	GrB_Matrix mat;             // Adjacency matrix, associated with edge
 };
 
 typedef struct Edge Edge;

--- a/src/graph/entities/graph_entity.h
+++ b/src/graph/entities/graph_entity.h
@@ -15,7 +15,7 @@
 #define ENTITY_ID_ISLT(a, b) ((*a) < (*b))
 #define INVALID_ENTITY_ID -1l
 
-#define ENTITY_GET_ID(graphEntity) ((graphEntity)->entity ? (graphEntity)->entity->id : INVALID_ENTITY_ID)
+#define ENTITY_GET_ID(graphEntity) (graphEntity)->id
 #define ENTITY_PROP_COUNT(graphEntity) ((graphEntity)->entity->prop_count)
 #define ENTITY_PROPS(graphEntity) ((graphEntity)->entity->properties)
 
@@ -51,7 +51,6 @@ typedef struct {
 // Essence of a graph entity.
 // TODO: see if pragma pack 0 will cause memory access violation on ARM.
 typedef struct {
-	EntityID id;                // Unique id
 	int prop_count;             // Number of properties.
 	EntityProperty *properties; // Key value pair of attributes.
 } Entity;
@@ -59,6 +58,7 @@ typedef struct {
 // Common denominator between nodes and edges.
 typedef struct {
 	Entity *entity;
+	EntityID id;
 } GraphEntity;
 
 /* Adds property to entity

--- a/src/graph/entities/node.h
+++ b/src/graph/entities/node.h
@@ -11,16 +11,29 @@
 #include "../../../deps/GraphBLAS/Include/GraphBLAS.h"
 
 typedef struct {
-	Entity *entity;    /* MUST be the first member of Node. */
-	const char *label; /* Label attached to Node. */
-	int labelID;       /* Label ID. */
+	Entity *entity;     // MUST be the first member of Node
+	EntityID id;        // Unique id, MUST be the second member
+	const char *label;  // Label attached to Node
+	int labelID;        // Label ID
 } Node;
 
-/* Instantiate a new unpopulated node. */
-#define GE_NEW_NODE() (Node){.entity = NULL, .label = NULL, .labelID = GRAPH_NO_LABEL}
+// Instantiate a new unpopulated node.
+#define GE_NEW_NODE()			\
+(Node) {						\
+	.entity = NULL,				\
+	.id = INVALID_ENTITY_ID,	\
+	.label = NULL,				\
+	.labelID = GRAPH_NO_LABEL	\
+}
 
-/* Instantiate a new node with label data. */
-#define GE_NEW_LABELED_NODE(l_str, l_id) (Node){.entity = NULL, .label = (l_str), .labelID = (l_id)}
+// Instantiate a new node with label data.
+#define GE_NEW_LABELED_NODE(l_str, l_id)	\
+(Node) {									\
+	.entity = NULL,							\
+	.id = INVALID_ENTITY_ID,				\
+	.label = (l_str),						\
+	.labelID = (l_id)						\
+}											\
 
 /* Resolves to the label string of the given Node. */
 #define NODE_GET_LABEL(n) (n)->label

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -196,6 +196,7 @@ void _Graph_GetEdgesConnectingNodes(const Graph *g, NodeID src, NodeID dest, int
 		// Discard most significate bit.
 		edgeId = SINGLE_EDGE_ID(edgeId);
 		e.entity = DataBlock_GetItem(g->edges, edgeId);
+		e.id = edgeId;
 		assert(e.entity);
 		*edges = array_append(*edges, e);
 	} else {
@@ -207,6 +208,7 @@ void _Graph_GetEdgesConnectingNodes(const Graph *g, NodeID src, NodeID dest, int
 		for(int i = 0; i < edgeCount; i++) {
 			edgeId = edgeIds[i];
 			e.entity = DataBlock_GetItem(g->edges, edgeId);
+			e.id = edgeId;
 			assert(e.entity);
 			*edges = array_append(*edges, e);
 		}
@@ -428,12 +430,14 @@ void Graph_AllocateEdges(Graph *g, size_t n) {
 int Graph_GetNode(const Graph *g, NodeID id, Node *n) {
 	assert(g);
 	n->entity = _Graph_GetEntity(g->nodes, id);
+	n->id = id;
 	return (n->entity != NULL);
 }
 
 int Graph_GetEdge(const Graph *g, EdgeID id, Edge *e) {
 	assert(g && id < _Graph_EdgeCap(g));
 	e->entity = _Graph_GetEntity(g->edges, id);
+	e->id = id;
 	return (e->entity != NULL);
 }
 
@@ -522,10 +526,10 @@ void Graph_CreateNode(Graph *g, int label, Node *n) {
 
 	NodeID id;
 	Entity *en = DataBlock_AllocateItem(g->nodes, &id);
-	en->id = id;
+	n->id = id;
+	n->entity = en;
 	en->prop_count = 0;
 	en->properties = NULL;
-	n->entity = en;
 
 	if(label != GRAPH_NO_LABEL) {
 		// Try to set matrix at position [id, id]
@@ -595,9 +599,9 @@ int Graph_ConnectNodes(Graph *g, NodeID src, NodeID dest, int r, Edge *e) {
 
 	EdgeID id;
 	Entity *en = DataBlock_AllocateItem(g->edges, &id);
-	en->id = id;
 	en->prop_count = 0;
 	en->properties = NULL;
+	e->id = id;
 	e->entity = en;
 	e->relationID = r;
 	e->srcNodeID = src;
@@ -1274,13 +1278,13 @@ void Graph_Free(Graph *g) {
 	array_free(g->labels);
 
 	it = Graph_ScanNodes(g);
-	while((en = (Entity *)DataBlockIterator_Next(it)) != NULL)
+	while((en = (Entity *)DataBlockIterator_Next(it, NULL)) != NULL)
 		FreeEntity(en);
 
 	DataBlockIterator_Free(it);
 
 	it = Graph_ScanEdges(g);
-	while((en = DataBlockIterator_Next(it)) != NULL)
+	while((en = DataBlockIterator_Next(it, NULL)) != NULL)
 		FreeEntity(en);
 
 	DataBlockIterator_Free(it);

--- a/src/serializers/graph_extensions.c
+++ b/src/serializers/graph_extensions.c
@@ -23,9 +23,9 @@ void Serializer_Graph_SetNode(Graph *g, NodeID id, int label, Node *n) {
 	assert(g);
 
 	Entity *en = DataBlock_AllocateItemOutOfOrder(g->nodes, id);
-	en->id = id;
 	en->prop_count = 0;
 	en->properties = NULL;
+	n->id = id;
 	n->entity = en;
 	if(label != GRAPH_NO_LABEL) {
 		// Set matrix at position [id, id]
@@ -39,9 +39,9 @@ void Serializer_Graph_SetEdge(Graph *g, EdgeID edge_id, NodeID src, NodeID dest,
 	GrB_Info info;
 
 	Entity *en = DataBlock_AllocateItemOutOfOrder(g->edges, edge_id);
-	en->id = edge_id;
 	en->prop_count = 0;
 	en->properties = NULL;
+	e->id = edge_id;
 	e->entity = en;
 	e->relationID = r;
 	e->srcNodeID = src;

--- a/src/util/datablock/datablock_iterator.h
+++ b/src/util/datablock/datablock_iterator.h
@@ -12,20 +12,20 @@
 /* Datablock iterator iterates over items within a datablock. */
 
 typedef struct {
-	Block *_start_block;         // First block accessed by iterator.
-	Block *_current_block;       // Current block.
-	uint _start_pos;             // Iterator initial position.
-	uint _current_pos;           // Iterator current position.
-	uint _block_pos;             // Position within a block.
-	uint _end_pos;               // Iterator won't pass end position.
-	uint _step;                  // Increase current_pos by step each iteration.
+	Block *_start_block;			// First block accessed by iterator.
+	Block *_current_block;			// Current block.
+	uint _block_pos;				// Position within a block.
+	uint64_t _start_pos;			// Iterator initial position.
+	uint64_t _current_pos;			// Iterator current position.
+	uint64_t _end_pos;				// Iterator won't pass end position.
+	uint _step;						// Increase current_pos by step each iteration.
 } DataBlockIterator;
 
 // Creates a new datablock iterator.
 DataBlockIterator *DataBlockIterator_New(
 	Block *block,       // Block from which iteration begins.
-	uint start_pos,     // Iteration starts here.
-	uint end_pos,       // Iteration stops here.
+	uint64_t start_pos,	// Iteration starts here.
+	uint64_t end_pos,	// Iteration stops here.
 	uint step           // To scan entire range, set step to 1.
 );
 
@@ -38,7 +38,9 @@ DataBlockIterator *DataBlockIterator_Clone(
 
 // Returns the next item, unless we've reached the end
 // in which case NULL is returned.
-void *DataBlockIterator_Next(DataBlockIterator *iter);
+// if `id` is provided and an item is located
+// `id` will be set to the returned item index
+void *DataBlockIterator_Next(DataBlockIterator *iter, uint64_t *id);
 
 // Reset iterator to original position.
 void DataBlockIterator_Reset(DataBlockIterator *iter);

--- a/tests/unit/test_datablock.cpp
+++ b/tests/unit/test_datablock.cpp
@@ -104,16 +104,19 @@ TEST_F(DataBlockTest, Scan) {
 	}
 
 	// Scan through items.
-	int count = 0;
-	int *item = NULL;
+	int count = 0;		// items iterated so far
+	int *item = NULL;	// current iterated item
+	uint64_t idx = 0;	// iterated item index
+
 	DataBlockIterator *it = DataBlock_Scan(dataBlock);
-	while((item = (int *)DataBlockIterator_Next(it))) {
+	while((item = (int *)DataBlockIterator_Next(it, &idx))) {
+		ASSERT_EQ(count, idx);
 		ASSERT_EQ(*item, count);
 		count++;
 	}
 	ASSERT_EQ(count, itemCount);
 
-	item = (int *)DataBlockIterator_Next(it);
+	item = (int *)DataBlockIterator_Next(it, NULL);
 	ASSERT_TRUE(item == NULL);
 
 	DataBlockIterator_Reset(it);
@@ -121,13 +124,14 @@ TEST_F(DataBlockTest, Scan) {
 	// Re-scan through items.
 	count = 0;
 	item = NULL;
-	while((item = (int *)DataBlockIterator_Next(it))) {
+	while((item = (int *)DataBlockIterator_Next(it, &idx))) {
+		ASSERT_EQ(count, idx);
 		ASSERT_EQ(*item, count);
 		count++;
 	}
 	ASSERT_EQ(count, itemCount);
 
-	item = (int *)DataBlockIterator_Next(it);
+	item = (int *)DataBlockIterator_Next(it, NULL);
 	ASSERT_TRUE(item == NULL);
 
 	DataBlock_Free(dataBlock);
@@ -165,7 +169,7 @@ TEST_F(DataBlockTest, RemoveItem) {
 	// Iterate over datablock, deleted item should be skipped.
 	DataBlockIterator *it = DataBlock_Scan(dataBlock);
 	uint counter = 0;
-	while(DataBlockIterator_Next(it)) counter++;
+	while(DataBlockIterator_Next(it, NULL)) counter++;
 	ASSERT_EQ(counter, itemCount - 1);
 	DataBlockIterator_Free(it);
 
@@ -180,7 +184,7 @@ TEST_F(DataBlockTest, RemoveItem) {
 
 	it = DataBlock_Scan(dataBlock);
 	counter = 0;
-	while(DataBlockIterator_Next(it)) counter++;
+	while(DataBlockIterator_Next(it, NULL)) counter++;
 	ASSERT_EQ(counter, itemCount);
 	DataBlockIterator_Free(it);
 
@@ -224,10 +228,10 @@ TEST_F(DataBlockTest, OutOfOrderBuilding) {
 	// Validate
 	DataBlockIterator *it = DataBlock_Scan(dataBlock);
 	for(int i = 0; i < 8; i++) {
-		int *item = (int *)DataBlockIterator_Next(it);
+		int *item = (int *)DataBlockIterator_Next(it, NULL);
 		ASSERT_EQ(*item, expected[i]);
 	}
-	ASSERT_FALSE(DataBlockIterator_Next(it));
+	ASSERT_FALSE(DataBlockIterator_Next(it, NULL));
 
 	ASSERT_TRUE(dataBlock->deletedIdx[0] == 4 || dataBlock->deletedIdx[0] == 7);
 	ASSERT_TRUE(dataBlock->deletedIdx[1] == 4 || dataBlock->deletedIdx[1] == 7);

--- a/tests/unit/test_graph.cpp
+++ b/tests/unit/test_graph.cpp
@@ -150,7 +150,7 @@ class GraphTest : public ::testing::Test {
 		Node *n;
 		unsigned int new_node_count = 0;
 		DataBlockIterator *it = Graph_ScanNodes(g);
-		while((n = (Node *)DataBlockIterator_Next(it)) != NULL) new_node_count++;
+		while((n = (Node *)DataBlockIterator_Next(it, NULL)) != NULL) new_node_count++;
 		ASSERT_EQ(new_node_count, prev_node_count + additional_node_count);
 		DataBlockIterator_Free(it);
 
@@ -697,7 +697,7 @@ TEST_F(GraphTest, GetEdge) {
 	for(EdgeID i = 0; i < edgeCount; i++) {
 		Graph_GetEdge(g, i, &e);
 		ASSERT_TRUE(e.entity != NULL);
-		ASSERT_EQ(e.entity->id, i);
+		ASSERT_EQ(e.id, i);
 	}
 
 	// Try to get edges connecting source to destination node.

--- a/tests/unit/test_value.cpp
+++ b/tests/unit/test_value.cpp
@@ -129,14 +129,13 @@ TEST_F(ValueTest, TestHashDouble) {
 
 TEST_F(ValueTest, TestEdge) {
 	Entity entity;
-	entity.id = 0;
 
 	Edge e0;
+	e0.id = 0;
 	e0.entity = &entity;
 	SIValue edge = SI_Edge(&e0);
 
-	Edge e0Other;
-	e0Other.entity = &entity;
+	Edge e0Other = e0;
 	SIValue edgeOther = SI_Edge(&e0Other);
 
 	// Validate same hashCode for the same value, different address.
@@ -145,9 +144,8 @@ TEST_F(ValueTest, TestEdge) {
 	ASSERT_EQ(origHashCode, otherHashCode);
 
 	// Change entity id.
-	Edge e1;
-	entity.id = 1;
-	e1.entity = &entity;
+	Edge e1 = e0;
+	e1.id = 1;
 	edgeOther = SI_Edge(&e1);
 	otherHashCode = SIValue_HashCode(edgeOther);
 	ASSERT_NE(origHashCode, otherHashCode);
@@ -155,14 +153,13 @@ TEST_F(ValueTest, TestEdge) {
 
 TEST_F(ValueTest, TestNode) {
 	Entity entity;
-	entity.id = 0;
 
 	Node n0;
+	n0.id = 0;
 	n0.entity = &entity;
 	SIValue node = SI_Node(&n0);
 
-	Node n0Other;
-	n0Other.entity = &entity;
+	Node n0Other = n0;
 	SIValue nodeOther = SI_Node(&n0Other);
 
 	// Validate same hashCode for the same value, different address.
@@ -171,9 +168,8 @@ TEST_F(ValueTest, TestNode) {
 	ASSERT_EQ(origHashCode, otherHashCode);
 
 	// Change entity id.
-	entity.id = 1;
-	Node n1;
-	n1.entity = & entity;
+	Node n1 = n0;
+	n1.id = 1;
 	nodeOther = SI_Node(&n1);
 	otherHashCode = SIValue_HashCode(nodeOther);
 	ASSERT_NE(origHashCode, otherHashCode);
@@ -240,9 +236,9 @@ TEST_F(ValueTest, TestHashLongAndDouble) {
 // Test for entities with same id, different types
 TEST_F(ValueTest, TestEdgeAndNode) {
 	Entity entity;
-	entity.id = 0;
 
 	Edge e0;
+	e0.id = 0;
 	e0.entity = &entity;
 	SIValue edge = SI_Edge(&e0);
 
@@ -264,8 +260,9 @@ TEST_F(ValueTest, TestSet) {
 	Node n;
 	Edge e;
 	Entity entity;
-	entity.id = 0;
+	n.id = 0;
 	n.entity = &entity;
+	e.id = 0;
 	e.entity = &entity;
 	SIValue arr = SI_Array(2);
 


### PR DESCRIPTION
Move entity `id` from field from the `entity` struct, this structure is saved within the datablock, by doing so we can cut down on the amount of memory both node and edge require, the `id` is set in runtime whenever an entity is retrieved from the graph, entity's id is synced with the entity position with the datablock.