### PR TITLE
avoid deep recursions by introducing multiple RSQNodes under a single…

### DIFF
--- a/src/execution_plan/optimizations/utilize_indices.c
+++ b/src/execution_plan/optimizations/utilize_indices.c
@@ -1,4 +1,5 @@
 #include "utilize_indices.h"
+#include "../../RG.h"
 #include "../../value.h"
 #include "../../util/arr.h"
 #include "../../query_ctx.h"
@@ -9,42 +10,21 @@
 #include "../../datatypes/array.h"
 #include "../../arithmetic/arithmetic_op.h"
 
-static void _transformInToOrSequence(FT_FilterNode **filter) {
-	FT_FilterNode *filter_tree = *filter;
+//------------------------------------------------------------------------------
+// Filter normalization
+//------------------------------------------------------------------------------
 
-	AR_ExpNode *inOp = filter_tree->exp.exp;
-	SIValue list = inOp->op.children[1]->operand.constant;
-	uint listLen = SIArray_Length(list);
+void _normalize_in_filter(FT_FilterNode *filter_tree) {
+	// Left child should be variadic, while the right child should be constant
+	AR_ExpNode *left_child = filter_tree->exp.exp->op.children[0];
+	AR_ExpNode *right_child = filter_tree->exp.exp->op.children[1];
 
-	SIValue val;
-	FT_FilterNode *root;
-	AR_ExpNode *constant;
-
-	if(listLen == 0) {
-		constant = AR_EXP_NewConstOperandNode(SI_BoolVal(false));
-		root = FilterTree_CreateExpressionFilter(constant);
-	} else {
-		val = SIArray_Get(list, 0); // Retrieve the first array element.
-		SIValue_Persist(&val);      // Ensure the value doesn't go out of scope.
-		constant = AR_EXP_NewConstOperandNode(val);
-		AR_ExpNode *lhs = AR_EXP_Clone(inOp->op.children[0]);
-		root = FilterTree_CreatePredicateFilter(OP_EQUAL, lhs, constant);
-
-		for(uint i = 1; i < listLen; i ++) {
-			FT_FilterNode *orNode = FilterTree_CreateConditionFilter(OP_OR);
-			FilterTree_AppendLeftChild(orNode, root);
-			val = SIArray_Get(list, i); // Retrieve the next array element.
-			SIValue_Persist(&val);      // Ensure the value doesn't go out of scope.
-			constant = AR_EXP_NewConstOperandNode(val);
-			lhs = AR_EXP_Clone(inOp->op.children[0]);
-			FilterTree_AppendRightChild(orNode, FilterTree_CreatePredicateFilter(OP_EQUAL, lhs, constant));
-			root = orNode;
-		}
+	if(left_child->operand.type == AR_EXP_CONSTANT) {
+		// Swap!
+		AR_ExpNode *temp = left_child;
+		left_child = right_child;
+		right_child = temp;
 	}
-
-	// Replace and free original tree.
-	FilterTree_Free(filter_tree);
-	*filter = root;
 }
 
 /* Modifies filter tree such that the left-hand side
@@ -62,12 +42,12 @@ void _normalize_filter(FT_FilterNode **filter) {
 			filter_tree->pred.op = ArithmeticOp_ReverseOp(filter_tree->pred.op);
 		}
 		break;
-	case FT_N_EXP:
-		_transformInToOrSequence(filter);
-		break;
 	case FT_N_COND:
 		_normalize_filter(&filter_tree->cond.left);
 		_normalize_filter(&filter_tree->cond.right);
+		break;
+	case FT_N_EXP:
+		// NOP, expression already normalized
 		break;
 	default:
 		assert(false);
@@ -75,8 +55,75 @@ void _normalize_filter(FT_FilterNode **filter) {
 }
 
 //------------------------------------------------------------------------------
+// Validation functions
+//------------------------------------------------------------------------------
+
+static inline bool _isInFilter(const FT_FilterNode *filter) {
+	return (filter->t == FT_N_EXP &&
+			filter->exp.exp->type == AR_EXP_OP &&
+			strcasecmp(filter->exp.exp->op.func_name, "in") == 0);
+}
+
+static bool _validateInExpression(AR_ExpNode *exp) {
+	assert(exp->op.child_count == 2);
+
+	AR_ExpNode *list = exp->op.children[1];
+	SIValue listValue = SI_NullVal();
+	AR_EXP_ReduceToScalar(list, true, &listValue);
+	if(SI_TYPE(listValue) != T_ARRAY) return false;
+
+	uint list_len = SIArray_Length(listValue);
+	for(uint i = 0; i < list_len; i++) {
+		SIValue v = SIArray_Get(listValue, i);
+		// Ignore everything other than number, strings and booleans.
+		if(!(SI_TYPE(v) & (SI_NUMERIC | T_STRING | T_BOOL))) return false;
+	}
+	return true;
+}
+
+/* Tests to see if given filter tree is a simple predicate
+ * e.g. n.v = 2
+ * one side is variadic while the other side is constant. */
+bool _simple_predicates(FT_FilterNode *filter) {
+	bool res = false;
+
+	switch(filter->t) {
+	case FT_N_PRED:
+		if(filter->pred.rhs->type == AR_EXP_OPERAND &&
+		   filter->pred.lhs->type == AR_EXP_OPERAND) {
+			SIValue v_lhs = SI_NullVal();
+			SIValue v_rhs = SI_NullVal();
+			bool lhs_scalar = AR_EXP_ReduceToScalar(filter->pred.lhs, true, &v_lhs);
+			bool rhs_scalar = AR_EXP_ReduceToScalar(filter->pred.rhs, true, &v_rhs);
+			// Predicate should be in the form of variable=scalar or scalar=variadic
+			if((lhs_scalar && !rhs_scalar) || (!lhs_scalar && rhs_scalar)) {
+				// Validate constant type.
+				SIValue c = lhs_scalar ? v_lhs : v_rhs;
+				SIType t = SI_TYPE(c);
+				res = (t & (SI_NUMERIC | T_STRING | T_BOOL));
+			}
+		}
+		break;
+	case FT_N_EXP:
+		if(_isInFilter(filter)) {
+			_normalize_in_filter(filter);
+			res = _validateInExpression(filter->exp.exp);
+		}
+		break;
+	case FT_N_COND:
+		res = (_simple_predicates(filter->cond.left) && _simple_predicates(filter->cond.right));
+		break;
+	default:
+		assert(false);
+	}
+
+	return res;
+}
+
+//------------------------------------------------------------------------------
 // To RediSearch query node
 //------------------------------------------------------------------------------
+
 /* Create a RediSearch query node out of a numeric range object. */
 RSQNode *_NumericRangeToQueryNode(RSIndex *idx, const char *field, const NumericRange *range) {
 	double max = (range->max == INFINITY) ? RSRANGE_INF : range->max;
@@ -96,7 +143,56 @@ RSQNode *_StringRangeToQueryNode(RSIndex *idx, const char *field, const StringRa
 	return root;
 }
 
-/* Creates a RediSearch query node out of given filter tree. */
+// Creates a RediSearch query node out of given IN filter.
+RSQNode *_filterTreeToInQueryNode(FT_FilterNode *filter, RSIndex *sp) {
+	ASSERT(_isInFilter(filter));
+
+	// n.v IN [1,2,3]
+	// a single union node should hold a number of token/numeric nodes
+	// one for each element in the array.
+
+	// extract both field name and list from expression
+	AR_ExpNode *inOp = filter->exp.exp;
+	const char *field = inOp->op.children[0]->operand.variadic.entity_prop;
+	SIValue list = inOp->op.children[1]->operand.constant;
+	uint list_len = SIArray_Length(list);
+
+	if(list_len == 0) {
+		// Special case: "WHERE a.v in []"
+		return RediSearch_CreateEmptyNode(sp);
+	}
+
+	RSQNode *node = NULL;
+	RSQNode *parent = NULL;
+	RSQNode *U = RediSearch_CreateUnionNode(sp);
+
+	for(uint i = 0; i < list_len; i ++) {
+		double d;
+		SIValue v = SIArray_Get(list, i);
+		switch(SI_TYPE(v)) {
+			case T_STRING:
+				parent = RediSearch_CreateTagNode(sp, field);
+				node = RediSearch_CreateTokenNode(sp, field, v.stringval);
+				RediSearch_QueryNodeAddChild(parent, node);
+				node = parent;
+				break;
+			case T_DOUBLE:
+			case T_INT64:
+			case T_BOOL:
+				d = SI_GET_NUMERIC(v);
+				node = RediSearch_CreateNumericNode(sp, field, d, d, true, true);
+				break;
+			default:
+				assert(false && "unexpected conditional operation");
+				break;
+		}
+		RediSearch_QueryNodeAddChild(U, node);
+	}
+
+	return U;
+}
+
+// Creates a RediSearch query node out of given filter tree.
 RSQNode *_filterTreeToQueryNode(FT_FilterNode *filter, RSIndex *sp) {
 	RSQNode *node = NULL;
 	RSQNode *parent = NULL;
@@ -193,10 +289,7 @@ RSQNode *_filterTreeToQueryNode(FT_FilterNode *filter, RSIndex *sp) {
 		break;
 	}
 	case FT_N_EXP: {
-		// Special case: "WHERE a.v in []"
-		SIValue value = filter->exp.exp->operand.constant;
-		assert(SI_TYPE(value) == T_BOOL && value.longval == false);
-		node = RediSearch_CreateEmptyNode(sp);
+		node = _filterTreeToInQueryNode(filter, sp);
 		break;
 	}
 	default: {
@@ -204,67 +297,6 @@ RSQNode *_filterTreeToQueryNode(FT_FilterNode *filter, RSIndex *sp) {
 	}
 	}
 	return node;
-}
-
-//------------------------------------------------------------------------------
-
-static inline bool _isInFilter(const FT_FilterNode *filter) {
-	return (filter->t == FT_N_EXP &&
-			filter->exp.exp->type == AR_EXP_OP &&
-			strcasecmp(filter->exp.exp->op.func_name, "in") == 0);
-}
-
-static bool _validateInExpression(AR_ExpNode *exp) {
-	assert(exp->op.child_count == 2);
-
-	AR_ExpNode *list = exp->op.children[1];
-	SIValue listValue = SI_NullVal();
-	AR_EXP_ReduceToScalar(list, true, &listValue);
-	if(SI_TYPE(listValue) != T_ARRAY) return false;
-
-	uint listLen = SIArray_Length(listValue);
-	for(uint i = 0; i < listLen; i++) {
-		SIValue v = SIArray_Get(listValue, i);
-		// Ignore everything other than number, strings and booleans.
-		if(!(SI_TYPE(v) & (SI_NUMERIC | T_STRING | T_BOOL))) return false;
-	}
-	return true;
-}
-
-/* Tests to see if given filter tree is a simple predicate
- * e.g. n.v = 2
- * one side is variadic while the other side is constant. */
-bool _simple_predicates(const FT_FilterNode *filter) {
-	bool res = false;
-
-	switch(filter->t) {
-	case FT_N_PRED:
-		if(filter->pred.rhs->type == AR_EXP_OPERAND &&
-		   filter->pred.lhs->type == AR_EXP_OPERAND) {
-			SIValue v_lhs = SI_NullVal();
-			SIValue v_rhs = SI_NullVal();
-			bool lhs_scalar = AR_EXP_ReduceToScalar(filter->pred.lhs, true, &v_lhs);
-			bool rhs_scalar = AR_EXP_ReduceToScalar(filter->pred.rhs, true, &v_rhs);
-			// Predicate should be in the form of variable=scalar or scalar=variadic
-			if((lhs_scalar && !rhs_scalar) || (!lhs_scalar && rhs_scalar)) {
-				// Validate constant type.
-				SIValue c = lhs_scalar ? v_lhs : v_rhs;
-				SIType t = SI_TYPE(c);
-				res = (t & (SI_NUMERIC | T_STRING | T_BOOL));
-			}
-		}
-		break;
-	case FT_N_EXP:
-		res = (_isInFilter(filter) && _validateInExpression(filter->exp.exp));
-		break;
-	case FT_N_COND:
-		res = (_simple_predicates(filter->cond.left) && _simple_predicates(filter->cond.right));
-		break;
-	default:
-		assert(false);
-	}
-
-	return res;
 }
 
 /* Checks to see if given filter can be resolved by index. */
@@ -411,13 +443,24 @@ void reduce_scan_op(ExecutionPlan *plan, NodeByLabelScan *scan) {
 	for(uint i = 0; i < filters_count; i++) {
 		OpFilter *filter = filters[i];
 		FT_FilterNode *filter_tree = filter->filterTree;
+		RSQNode *rsqnode = NULL;
 
-		if(filter_tree->t == FT_N_PRED) {
-			_predicateTreeToRange(filter_tree, string_ranges, numeric_ranges);
-		} else {
-			// OR trees are directly converted into RSQnodes.
-			RSQNode *rsqnode = _filterTreeToQueryNode(filter_tree, rs_idx);
-			rsqnodes = array_append(rsqnodes, rsqnode);
+		switch(filter_tree->t) {
+			case FT_N_PRED:
+				_predicateTreeToRange(filter_tree, string_ranges, numeric_ranges);
+				break;
+			case FT_N_COND:
+				// OR trees are directly converted into RSQnodes.
+				rsqnode = _filterTreeToQueryNode(filter_tree, rs_idx);
+				rsqnodes = array_append(rsqnodes, rsqnode);
+				break;
+			case FT_N_EXP:
+				rsqnode = _filterTreeToInQueryNode(filter_tree, rs_idx);
+				rsqnodes = array_append(rsqnodes, rsqnode);
+				break;
+			default:
+				ASSERT("Unknown filter type" && false);
+				break;
 		}
 	}
 


### PR DESCRIPTION
This PR modifies the way we construct RediSearch queries for `IN` filters,
Consider: `MATCH (n) WHERE n.v IN [0,1,2,3,4,5,6,7,8,9] RETURN n`
This used to be translated in to a nested OR filter:
`n.v = 0 OR n.v = 1 OR n.v = 2 OR n.v = 3 OR ...`
and similarly a nested UNION RediSearch query, causing deep recursions as can be seen in the following image
![image (3)](https://user-images.githubusercontent.com/2638748/89411855-c8780e00-d72e-11ea-8d77-da7ff5c6de63.png)

This PR takes advantage of multi child UNION RediSearch query node(s) which reduces the depth of the query tree.