### PR TITLE
updated query graph on template before clone

### DIFF
--- a/src/execution_plan/execution_plan_clone.c
+++ b/src/execution_plan/execution_plan_clone.c
@@ -15,7 +15,7 @@ static ExecutionPlan *_ClonePlanInternals(const ExecutionPlan *template) {
 	clone->record_map = raxClone(template->record_map);
 	if(template->ast_segment) clone->ast_segment = AST_ShallowCopy(template->ast_segment);
 	if(template->query_graph) {
-		QueryGraph_Update(template->query_graph);
+		QueryGraph_ResolveUnknownRelIDs(template->query_graph);
 		clone->query_graph = QueryGraph_Clone(template->query_graph);
 	}
 	// TODO improve QueryGraph logic so that we do not need to store or clone connected_components.

--- a/src/execution_plan/execution_plan_clone.c
+++ b/src/execution_plan/execution_plan_clone.c
@@ -14,7 +14,10 @@ static ExecutionPlan *_ClonePlanInternals(const ExecutionPlan *template) {
 
 	clone->record_map = raxClone(template->record_map);
 	if(template->ast_segment) clone->ast_segment = AST_ShallowCopy(template->ast_segment);
-	if(template->query_graph) clone->query_graph = QueryGraph_Clone(template->query_graph);
+	if(template->query_graph) {
+		QueryGraph_Update(template->query_graph);
+		clone->query_graph = QueryGraph_Clone(template->query_graph);
+	}
 	// TODO improve QueryGraph logic so that we do not need to store or clone connected_components.
 	if(template->connected_components) {
 		array_clone_with_cb(clone->connected_components, template->connected_components, QueryGraph_Clone);

--- a/src/graph/query_graph.c
+++ b/src/graph/query_graph.c
@@ -227,27 +227,25 @@ EntityType QueryGraph_GetEntityTypeByAlias(const QueryGraph *qg, const char *ali
 void QueryGraph_ResolveUnknownRelIDs(QueryGraph *qg) {
 	// No unknown relationships - no need to updated.
 	if(!qg->unknown_reltype_ids) return;
-	uint edge_count = QueryGraph_EdgeCount(qg);
+
+	Schema *s = NULL;
 	bool unkown_relationships = false;
 	GraphContext *gc = QueryCtx_GetGraphCtx();
+	uint edge_count = QueryGraph_EdgeCount(qg);
+
 	// Update edges.
 	for(uint i = 0; i < edge_count; i++) {
 		QGEdge *edge = qg->edges[i];
 		uint rel_types_count = array_len(edge->reltypeIDs);
-		if(rel_types_count == 0) continue;
 		for(uint j = 0; j < rel_types_count; j++) {
 			if(edge->reltypeIDs[j] == GRAPH_UNKNOWN_RELATION) {
-				gc = gc ? gc : QueryCtx_GetGraphCtx();
-				Schema *s = GraphContext_GetSchema(gc, edge->reltypes[j], SCHEMA_EDGE);
-				if(s) {
-					edge->reltypeIDs[j] = s->id;
-				} else {
-					// Cannot update the unkown relationship.
-					unkown_relationships = true;
-				}
+				s = GraphContext_GetSchema(gc, edge->reltypes[j], SCHEMA_EDGE);
+				if(s) edge->reltypeIDs[j] = s->id;
+				else unkown_relationships = true; // Cannot update the unkown relationship.
 			}
 		}
 	}
+
 	qg->unknown_reltype_ids = unkown_relationships;
 }
 

--- a/src/graph/query_graph.c
+++ b/src/graph/query_graph.c
@@ -39,11 +39,7 @@ static void _BuildQueryGraphAddNode(QueryGraph *qg, const cypher_astnode_t *ast_
 			Schema *s = GraphContext_GetSchema(gc, label, SCHEMA_NODE);
 			uint label_id = GRAPH_UNKNOWN_LABEL;
 			// If a schema is found, the AST refers to a real label.
-			if(s) {
-				label_id = s->id;
-			} else {
-				qg->unkown_label_ids++;
-			}
+			if(s) label_id = s->id;
 			n->label = label;
 			n->labelID = label_id;
 		} else {
@@ -75,7 +71,7 @@ static void _BuildQueryGraphAddEdge(QueryGraph *qg, const cypher_astnode_t *ast_
 		Schema *s = GraphContext_GetSchema(gc, reltype, SCHEMA_EDGE);
 		if(!s) {
 			edge->reltypeIDs = array_append(edge->reltypeIDs, GRAPH_UNKNOWN_RELATION);
-			qg->unkown_label_ids++;
+			qg->unknown_reltype_ids = true;
 			continue;
 		}
 		edge->reltypeIDs = array_append(edge->reltypeIDs, s->id);
@@ -102,7 +98,7 @@ QueryGraph *QueryGraph_New(uint node_cap, uint edge_cap) {
 
 	qg->nodes = array_new(QGNode *, node_cap);
 	qg->edges = array_new(QGEdge *, edge_cap);
-	qg->unkown_label_ids = 0;
+	qg->unknown_reltype_ids = false;
 
 	return qg;
 }
@@ -228,53 +224,31 @@ EntityType QueryGraph_GetEntityTypeByAlias(const QueryGraph *qg, const char *ali
 	return ENTITY_UNKNOWN;
 }
 
-// Returns if there was an update for an unkown label id.
-static bool _QGNode_Update(QGNode *node) {
-	bool updated = false;
-	if(node->labelID == GRAPH_UNKNOWN_LABEL) {
-		GraphContext *gc = QueryCtx_GetGraphCtx();
-		Schema *s = GraphContext_GetSchema(gc, node->label, SCHEMA_NODE);
-		if(s) {
-			node->labelID = s->id;
-			updated = true;
-		}
-	}
-	return updated;
-}
-
-// Returns the amount of updates to unkowns relationship types of the query graph edge.
-static uint _QGEdge_Update(QGEdge *edge) {
-	uint updates = 0;
-	GraphContext *gc = NULL;
-	uint rel_types_count = array_len(edge->reltypeIDs);
-	for(uint i = 0; i < rel_types_count; i++) {
-		if(edge->reltypeIDs[i] == GRAPH_UNKNOWN_RELATION) {
-			gc = gc ? gc : QueryCtx_GetGraphCtx();
-			Schema *s = GraphContext_GetSchema(gc, edge->reltypes[i], SCHEMA_EDGE);
-			if(s) {
-				edge->reltypeIDs[i] = s->id;
-				updates++;
+void QueryGraph_ResolveUnknownRelIDs(QueryGraph *qg) {
+	// No unknown relationships - no need to updated.
+	if(!qg->unknown_reltype_ids) return;
+	uint edge_count = QueryGraph_EdgeCount(qg);
+	bool unkown_relationships = false;
+	GraphContext *gc = QueryCtx_GetGraphCtx();
+	// Update edges.
+	for(uint i = 0; i < edge_count; i++) {
+		QGEdge *edge = qg->edges[i];
+		uint rel_types_count = array_len(edge->reltypeIDs);
+		if(rel_types_count == 0) continue;
+		for(uint j = 0; j < rel_types_count; j++) {
+			if(edge->reltypeIDs[j] == GRAPH_UNKNOWN_RELATION) {
+				gc = gc ? gc : QueryCtx_GetGraphCtx();
+				Schema *s = GraphContext_GetSchema(gc, edge->reltypes[j], SCHEMA_EDGE);
+				if(s) {
+					edge->reltypeIDs[j] = s->id;
+				} else {
+					// Cannot update the unkown relationship.
+					unkown_relationships = true;
+				}
 			}
 		}
 	}
-	return updates;
-}
-
-void QueryGraph_Update(QueryGraph *qg) {
-	// No unknown labels or relationships - no need to updated.
-	if(qg->unkown_label_ids == 0) return;
-	uint node_count = QueryGraph_NodeCount(qg);
-	uint edge_count = QueryGraph_EdgeCount(qg);
-
-	// Update nodes.
-	for(uint i = 0; i < node_count; i++) {
-		if(_QGNode_Update(qg->nodes[i])) qg->unkown_label_ids--;
-	}
-
-	// Update edges.
-	for(uint i = 0; i < edge_count; i++) {
-		qg->unkown_label_ids -= _QGEdge_Update(qg->edges[i]);
-	}
+	qg->unknown_reltype_ids = unkown_relationships;
 }
 
 QueryGraph *QueryGraph_Clone(const QueryGraph *qg) {

--- a/src/graph/query_graph.h
+++ b/src/graph/query_graph.h
@@ -18,7 +18,7 @@
 typedef struct {
 	QGNode **nodes;             // Nodes contained in QueryGraph
 	QGEdge **edges;             // Edges contained in QueryGraph
-	uint unkown_label_ids;      // Indicates if the query graph contains unknown entities labels or relationship ids.
+	bool unknown_reltype_ids;   // Indicates if the query graph contains unknown relationship ids.
 } QueryGraph;
 
 typedef enum {
@@ -59,8 +59,8 @@ QGEdge *QueryGraph_GetEdgeByAlias(const QueryGraph *qg, const char *alias);
 /* Determine whether a given alias refers to a node or relation. */
 EntityType QueryGraph_GetEntityTypeByAlias(const QueryGraph *qg, const char *alias);
 
-/* Validates that query graph's entities label/relationship ids are updated. */
-void QueryGraph_Update(QueryGraph *g);
+/* Tries to update the query graph's unknown relationship ids. */
+void QueryGraph_ResolveUnknownRelIDs(QueryGraph *g);
 
 /* Performs deep copy of input query graph. */
 QueryGraph *QueryGraph_Clone(const QueryGraph *g);

--- a/src/graph/query_graph.h
+++ b/src/graph/query_graph.h
@@ -18,6 +18,7 @@
 typedef struct {
 	QGNode **nodes;             // Nodes contained in QueryGraph
 	QGEdge **edges;             // Edges contained in QueryGraph
+	uint unkown_label_ids;      // Indicates if the query graph contains unknown entities labels or relationship ids.
 } QueryGraph;
 
 typedef enum {
@@ -57,6 +58,9 @@ QGEdge *QueryGraph_GetEdgeByAlias(const QueryGraph *qg, const char *alias);
 
 /* Determine whether a given alias refers to a node or relation. */
 EntityType QueryGraph_GetEntityTypeByAlias(const QueryGraph *qg, const char *alias);
+
+/* Validates that query graph's entities label/relationship ids are updated. */
+void QueryGraph_Update(QueryGraph *g);
 
 /* Performs deep copy of input query graph. */
 QueryGraph *QueryGraph_Clone(const QueryGraph *g);

--- a/tests/flow/test_cache.py
+++ b/tests/flow/test_cache.py
@@ -171,4 +171,15 @@ class testCache(FlowTestsBase):
         self.env.assertEqual([[3, 4]], cached_result.result_set)
         graph.delete()
 
+    def test09_test_edge_merge(self):
+        graph = Graph('Cache_Test_Edge_Merge', redis_con)
+        query = "CREATE ({val:1}), ({val:2})"
+        graph.query(query)
+        query = "MATCH (a {val:1}), (b {val:2}) MERGE (a)-[e:leads]->(b) RETURN e"
+        self.compare_uncached_to_cached_query_plans(query)
+        uncached_result = graph.query(query)
+        self.env.assertEqual(1, uncached_result.relationships_created)
+        cached_result = graph.query(query)
+        self.env.assertEqual(0, cached_result.relationships_created)
+        self.env.assertEqual(uncached_result.result_set, cached_result.result_set)
 

--- a/tests/flow/test_cache.py
+++ b/tests/flow/test_cache.py
@@ -172,6 +172,10 @@ class testCache(FlowTestsBase):
         graph.delete()
 
     def test09_test_edge_merge(self):
+        # In this scenario, the same query is executed twice.
+        # In the first time, the relationship `leads` is unknown to the graph so it is created.
+        # In the second time the relationship should be known to the graph, so it will be returned by the match.
+        # The test validates that a valid edge is returned.
         graph = Graph('Cache_Test_Edge_Merge', redis_con)
         query = "CREATE ({val:1}), ({val:2})"
         graph.query(query)


### PR DESCRIPTION
this PR adds an update to query graphs stored in execution plan templates which contains unknown ids for labels or relationship types
the update happen only for those kinds of query graph before the template is cloned.