### PR TITLE
Remove redundant scan ops before applying index optimization

### DIFF
--- a/src/execution_plan/optimizations/optimizer.c
+++ b/src/execution_plan/optimizations/optimizer.c
@@ -17,33 +17,32 @@ void optimizePlan(ExecutionPlan *plan) {
 	 * 2. Try to use the indices. Given a label scan and an indexed property, apply index scan.
 	 * 3. Given a filter which checks id condition, and full or label scan, reduce it to id scan or label with id scan.
 	 *    Note: Due to the scan optimization order, label scan will be replaced with index scan when possible, so the id filter remains. */
-	/* Remove redundant SCAN operations. */
+	
+	// Remove redundant SCAN operations.
 	reduceScans(plan);
 
-	/* When possible, replace label scan and filter ops
-	 * with index scans. */
+	// When possible, replace label scan and filter ops with index scans.
 	utilizeIndices(plan);
 
 	// Try to reduce SCAN + FILTER to a node seek operation.
 	seekByID(plan);
 
-	/* Try to optimize cartesian product */
+	// Try to optimize cartesian product.
 	reduceCartesianProductStreamCount(plan);
 
-	/* Try to match disjoint entities by applying a join */
+	// Try to match disjoint entities by applying a join.
 	applyJoin(plan);
 
-	/* Try to reduce a number of filters into a single filter op. */
+	// Try to reduce a number of filters into a single filter op.
 	reduceFilters(plan);
 
-	/* reduce traversals where both src and dest nodes are already resolved
-	 * into an expand into operation. */
+	// Reduce traversals where both src and dest nodes are already resolved into an expand into operation.
 	reduceTraversal(plan);
 
-	/* Try to reduce distinct if it follows aggregation. */
+	// Try to reduce distinct if it follows aggregation.
 	reduceDistinct(plan);
 
-	/* Try to reduce execution plan incase it perform node or edge counting. */
+	// Try to reduce execution plan incase it perform node or edge counting.
 	reduceCount(plan);
 }
 

--- a/src/execution_plan/optimizations/optimizer.c
+++ b/src/execution_plan/optimizations/optimizer.c
@@ -13,10 +13,12 @@ void optimizePlan(ExecutionPlan *plan) {
 	compactFilters(plan);
 
 	/* Scan optimizations order:
-	 * 1. First try to use the indices. Given a label scan and an indexed property, apply index scan.
-	 * 2. Given a filter which checks id condition, and full or label scan, reduce it to id scan or label with id scan.
-	 *    Note: Due to the scan optimization order, label scan will be replaced with index scan when possible, so the id filter remains.
-	 * 3. Remove redundant scans which checks for the same node. */
+	 * 1. Remove redundant scans which checks for the same node.
+	 * 2. Try to use the indices. Given a label scan and an indexed property, apply index scan.
+	 * 3. Given a filter which checks id condition, and full or label scan, reduce it to id scan or label with id scan.
+	 *    Note: Due to the scan optimization order, label scan will be replaced with index scan when possible, so the id filter remains. */
+	/* Remove redundant SCAN operations. */
+	reduceScans(plan);
 
 	/* When possible, replace label scan and filter ops
 	 * with index scans. */
@@ -24,9 +26,6 @@ void optimizePlan(ExecutionPlan *plan) {
 
 	// Try to reduce SCAN + FILTER to a node seek operation.
 	seekByID(plan);
-
-	/* Remove redundant SCAN operations. */
-	reduceScans(plan);
 
 	/* Try to optimize cartesian product */
 	reduceCartesianProductStreamCount(plan);

--- a/tests/flow/test_index_scans.py
+++ b/tests/flow/test_index_scans.py
@@ -276,3 +276,10 @@ class testIndexScanFlow(FlowTestsBase):
         query_result = redis_graph.query(query)
         # Two new nodes should be created.
         self.env.assertEquals(query_result.nodes_created, 2)
+
+    def test12_remove_scans_before_index(self):
+        query = "MATCH (a:person {age: 32})-[]->(b) WHERE (b:person)-[]->(a) RETURN a"
+        plan = redis_graph.execution_plan(query)
+        # One index scan should be performed.
+        self.env.assertEqual(plan.count("Index Scan"), 1)
+


### PR DESCRIPTION
This PR corrects the order in which optimizations are applied such that redundant scan ops are removed prior to promoting scan ops to index scans.

This is expected to resolve #1281.