### PR TITLE
Replace rightmost operand if traversing from dest->src

### DIFF
--- a/src/arithmetic/algebraic_expression/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression.c
@@ -347,12 +347,15 @@ AlgebraicExpression *AlgebraicExpression_RemoveLeftmostNode
 	AlgebraicExpression **root  // Root from which to remove left most child.
 ) {
 	assert(*root);
+	bool transpose = false;
 	AlgebraicExpression *prev = *root;
 	AlgebraicExpression *current = *root;
 
 	while(current->type == AL_OPERATION) {
+		if(current->operation.op == AL_EXP_TRANSPOSE) transpose = !transpose;
 		prev = current;
-		current = FIRST_CHILD(current);
+		if(transpose) current = LAST_CHILD(current);
+		else current = FIRST_CHILD(current);
 	}
 	assert(current->type == AL_OPERAND);
 
@@ -368,7 +371,8 @@ AlgebraicExpression *AlgebraicExpression_RemoveLeftmostNode
 	 * MUL(A,B) after removing A will become just B
 	 * TRANSPOSE(A) after removing A should become NULL. */
 	if(prev->type == AL_OPERATION) {
-		_AlgebraicExpression_OperationRemoveLeftmostChild(prev);
+		if(transpose) _AlgebraicExpression_OperationRemoveRightmostChild(prev);
+		else _AlgebraicExpression_OperationRemoveLeftmostChild(prev);
 		uint child_count = AlgebraicExpression_ChildCount(prev);
 		if(child_count < 2) {
 			if(child_count == 1) {
@@ -388,12 +392,15 @@ AlgebraicExpression *AlgebraicExpression_RemoveRightmostNode
 	AlgebraicExpression **root  // Root from which to remove left most child.
 ) {
 	assert(*root);
+	bool transpose = false;
 	AlgebraicExpression *prev = *root;
 	AlgebraicExpression *current = *root;
 
 	while(current->type == AL_OPERATION) {
+		if(current->operation.op == AL_EXP_TRANSPOSE) transpose = !transpose;
 		prev = current;
-		current = LAST_CHILD(current);
+		if(transpose) current = FIRST_CHILD(current);
+		else current = LAST_CHILD(current);
 	}
 	assert(current->type == AL_OPERAND);
 
@@ -409,7 +416,8 @@ AlgebraicExpression *AlgebraicExpression_RemoveRightmostNode
 	 * MUL(A,B) after removing A the expression will become just B.
 	 * TRANSPOSE(A) after removing A should become NULL. */
 	if(prev->type == AL_OPERATION) {
-		_AlgebraicExpression_OperationRemoveRightmostChild(prev);
+		if(transpose) _AlgebraicExpression_OperationRemoveLeftmostChild(prev);
+		else _AlgebraicExpression_OperationRemoveRightmostChild(prev);
 		uint child_count = AlgebraicExpression_ChildCount(prev);
 		if(child_count == 1) {
 			AlgebraicExpression *replacement = _AlgebraicExpression_OperationRemoveRightmostChild(prev);

--- a/tests/flow/test_algebraic_expression_order.py
+++ b/tests/flow/test_algebraic_expression_order.py
@@ -1,0 +1,74 @@
+import os
+import sys
+from RLTest import Env
+from redisgraph import Graph, Node, Edge
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from base import FlowTestsBase
+
+graph = None
+
+GRAPH_ID = "AlgebraicExpressionOrder"
+
+class testAlgebraicExpressionOrder(FlowTestsBase):
+    def __init__(self):
+        self.env = Env()
+        global graph
+        redis_con = self.env.getConnection()
+        graph = Graph(GRAPH_ID, redis_con)
+        self.populate_graph()
+
+    def populate_graph(self):
+        # Construct a graph with the form:
+        # (v1:A)-[:E]->(v2:B), (v3:C)-[:E]->(v2)
+        v1 = Node(label="A", properties={"v": 1})
+        graph.add_node(v1)
+
+        v2 = Node(label="B", properties={"v": 2})
+        graph.add_node(v2)
+
+        v3 = Node(label="C", properties={"v": 3})
+        graph.add_node(v3)
+
+        edge = Edge(v1, "E", v2)
+        graph.add_edge(edge)
+
+        edge = Edge(v3, "E", v2)
+        graph.add_edge(edge)
+
+        graph.commit()
+
+    # Test differing patterns with the same destination node.
+    def test01_same_destination_permutations(self):
+        # Each query should return the same two records.
+        expected_result = [[1, 2],
+                           [3, 2]]
+
+        # Neither the source nor the destination is labeled, perform an AllNodeScan from the source node.
+        query = """MATCH (a)-[:E]->(b) RETURN a.v, b.v ORDER BY a.v, b.v"""
+        plan = graph.execution_plan(query)
+        self.env.assertIn("All Node Scan | (a)", plan)
+        result = graph.query(query)
+        self.env.assertEquals(result.result_set, expected_result)
+
+        # Destination is labeled, perform a LabelScan from the destination node.
+        query = """MATCH (a)-[:E]->(b:B) RETURN a.v, b.v ORDER BY a.v, b.v"""
+        plan = graph.execution_plan(query)
+        self.env.assertIn("Node By Label Scan | (b:B)", plan)
+        result = graph.query(query)
+        self.env.assertEquals(result.result_set, expected_result)
+
+        # Destination is filtered, perform an AllNodeScan from the destination node.
+        query = """MATCH (a)-[:E]->(b) WHERE b.v = 2 RETURN a.v, b.v ORDER BY a.v, b.v"""
+        plan = graph.execution_plan(query)
+        self.env.assertIn("All Node Scan | (b)", plan)
+        result = graph.query(query)
+        self.env.assertEquals(result.result_set, expected_result)
+
+        # Destination is labeled but source is filtered, perform an AllNodeScan from the source node.
+        query = """MATCH (a)-[:E]->(b:B) WHERE a.v = 1 OR a.v = 3 RETURN a.v, b.v ORDER BY a.v, b.v"""
+        plan = graph.execution_plan(query)
+        self.env.assertIn("All Node Scan | (a)", plan)
+        result = graph.query(query)
+        self.env.assertEquals(result.result_set, expected_result)


### PR DESCRIPTION
Fixes a bug in which the routine to removes an AlgebraicExpression operand made redundant by a Scan op did not pay attention to transpose ops, instead always removing the leftmost operand.

This caused destination->source traversals to remove label data on the source endpoint, as observed in the issue #1288.