### PR TITLE
Remove qgnode references

### DIFF
--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -17,6 +17,7 @@
 #include "../graph/entities/edge.h"
 #include "../ast/ast_build_ar_exp.h"
 #include "./optimizations/optimizer.h"
+#include "ops/shared/scan_functions.h"
 #include "../ast/ast_build_op_contexts.h"
 #include "../ast/ast_build_filter_tree.h"
 #include "./optimizations/optimizations.h"
@@ -261,8 +262,12 @@ static void _ExecutionPlan_ProcessQueryGraph(ExecutionPlan *plan, QueryGraph *qg
 		if(edge_count == 0) {
 			/* If there are no edges in the component, we only need a node scan. */
 			QGNode *n = cc->nodes[0];
-			if(n->labelID != GRAPH_NO_LABEL) root = NewNodeByLabelScanOp(plan, n);
-			else root = NewAllNodeScanOp(plan, n);
+			if(n->labelID != GRAPH_NO_LABEL) {
+				LabeledNodeCtx ctx = NODE_CTX_NEW(n->alias, n->label, n->labelID);
+				root = NewNodeByLabelScanOp(plan, ctx);
+			} else {
+				root = NewAllNodeScanOp(plan, n->alias);
+			}
 		} else {
 			/* The component has edges, so we'll build a node scan and a chain of traversals. */
 			AlgebraicExpression **exps = AlgebraicExpression_FromQueryGraph(cc);
@@ -280,9 +285,10 @@ static void _ExecutionPlan_ProcessQueryGraph(ExecutionPlan *plan, QueryGraph *qg
 				if(AlgebraicExpression_DiagonalOperand(exps[0], 0)) {
 					AlgebraicExpression_Free(AlgebraicExpression_RemoveLeftmostNode(&exps[0]));
 				}
-				root = tail = NewNodeByLabelScanOp(plan, src);
+				LabeledNodeCtx ctx = NODE_CTX_NEW(src->alias, src->label, src->labelID);
+				root = tail = NewNodeByLabelScanOp(plan, ctx);
 			} else {
-				root = tail = NewAllNodeScanOp(plan, src);
+				root = tail = NewAllNodeScanOp(plan, src->alias);
 			}
 
 			/* For each expression, build the appropriate traversal operation. */

--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -17,12 +17,11 @@ static OpBase *AllNodeScanClone(const ExecutionPlan *plan, const OpBase *opBase)
 static void AllNodeScanFree(OpBase *opBase);
 
 static inline int AllNodeScanToString(const OpBase *ctx, char *buf, uint buf_len) {
-	return ScanToString(ctx, buf, buf_len, ((const AllNodeScan *)ctx)->n);
+	return ScanToString(ctx, buf, buf_len, ctx->modifies[0], NULL);
 }
 
-OpBase *NewAllNodeScanOp(const ExecutionPlan *plan, const QGNode *n) {
+OpBase *NewAllNodeScanOp(const ExecutionPlan *plan, const char *alias) {
 	AllNodeScan *op = rm_malloc(sizeof(AllNodeScan));
-	op->n = n;
 	op->iter = NULL;
 	op->child_record = NULL;
 
@@ -30,7 +29,7 @@ OpBase *NewAllNodeScanOp(const ExecutionPlan *plan, const QGNode *n) {
 	OpBase_Init((OpBase *)op, OPType_ALL_NODE_SCAN, "All Node Scan", AllNodeScanInit,
 				AllNodeScanConsume, AllNodeScanReset, AllNodeScanToString, AllNodeScanClone, AllNodeScanFree, false,
 				plan);
-	op->nodeRecIdx = OpBase_Modifies((OpBase *)op, n->alias);
+	op->nodeRecIdx = OpBase_Modifies((OpBase *)op, alias);
 	return (OpBase *)op;
 }
 
@@ -97,8 +96,7 @@ static OpResult AllNodeScanReset(OpBase *op) {
 
 static inline OpBase *AllNodeScanClone(const ExecutionPlan *plan, const OpBase *opBase) {
 	assert(opBase->type == OPType_ALL_NODE_SCAN);
-	AllNodeScan *allNodeScan = (AllNodeScan *)opBase;
-	return NewAllNodeScanOp(plan, allNodeScan->n);
+	return NewAllNodeScanOp(plan, opBase->modifies[0]);
 }
 
 static void AllNodeScanFree(OpBase *ctx) {

--- a/src/execution_plan/ops/op_all_node_scan.h
+++ b/src/execution_plan/ops/op_all_node_scan.h
@@ -17,11 +17,10 @@
  * Scans entire graph */
 typedef struct {
 	OpBase op;
-	const QGNode *n;
 	uint nodeRecIdx;
 	DataBlockIterator *iter;
 	Record child_record;        /* The Record this op acts on if it is not a tap. */
 } AllNodeScan;
 
-OpBase *NewAllNodeScanOp(const ExecutionPlan *plan, const QGNode *n);
+OpBase *NewAllNodeScanOp(const ExecutionPlan *plan, const char *alias);
 

--- a/src/execution_plan/ops/op_index_scan.h
+++ b/src/execution_plan/ops/op_index_scan.h
@@ -10,20 +10,21 @@
 #include "../execution_plan.h"
 #include "../../graph/graph.h"
 #include "../../index/index.h"
+#include "shared/scan_functions.h"
 #include "redisearch_api.h"
 
 typedef struct {
 	OpBase op;
 	Graph *g;
 	RSIndex *idx;
-	const QGNode *n;
-	uint nodeRecIdx;
+	LabeledNodeCtx n;           /* Label data of node being scanned. */
+	uint nodeRecIdx;            /* Index of the node being scanned in the Record. */
 	RSQNode *rs_query_node;     /* RediSearch query node used to construct iterator. */
 	RSResultsIterator *iter;    /* RediSearch iterator over an index with the appropriate filters. */
 	Record child_record;        /* The Record this op acts on if it is not a tap. */
 } IndexScan;
 
 /* Creates a new IndexScan operation */
-OpBase *NewIndexScanOp(const ExecutionPlan *plan, Graph *g, const QGNode *n, RSIndex *idx,
+OpBase *NewIndexScanOp(const ExecutionPlan *plan, Graph *g, LabeledNodeCtx n, RSIndex *idx,
 					   RSQNode *rs_query_node);
 

--- a/src/execution_plan/ops/op_node_by_id_seek.c
+++ b/src/execution_plan/ops/op_node_by_id_seek.c
@@ -17,7 +17,7 @@ static OpBase *NodeByIdSeekClone(const ExecutionPlan *plan, const OpBase *opBase
 static void NodeByIdSeekFree(OpBase *opBase);
 
 static inline int NodeByIdSeekToString(const OpBase *ctx, char *buf, uint buf_len) {
-	return ScanToString(ctx, buf, buf_len, ((const NodeByIdSeek *)ctx)->n);
+	return ScanToString(ctx, buf, buf_len, ctx->modifies[0], NULL);
 }
 
 // Checks to see if operation index is within its bounds.
@@ -28,11 +28,10 @@ static inline bool _outOfBounds(NodeByIdSeek *op) {
 	return false;
 }
 
-OpBase *NewNodeByIdSeekOp(const ExecutionPlan *plan, const QGNode *n, UnsignedRange *id_range) {
+OpBase *NewNodeByIdSeekOp(const ExecutionPlan *plan, const char *alias, UnsignedRange *id_range) {
 
 	NodeByIdSeek *op = rm_malloc(sizeof(NodeByIdSeek));
 	op->g = QueryCtx_GetGraph();
-	op->n = n;
 	op->child_record = NULL;
 
 	op->minId = id_range->include_min ? id_range->min : id_range->min + 1;
@@ -47,7 +46,7 @@ OpBase *NewNodeByIdSeekOp(const ExecutionPlan *plan, const QGNode *n, UnsignedRa
 				NodeByIdSeekConsume, NodeByIdSeekReset, NodeByIdSeekToString, NodeByIdSeekClone, NodeByIdSeekFree,
 				false, plan);
 
-	op->nodeRecIdx = OpBase_Modifies((OpBase *)op, n->alias);
+	op->nodeRecIdx = OpBase_Modifies((OpBase *)op, alias);
 
 	return (OpBase *)op;
 }
@@ -144,7 +143,7 @@ static OpBase *NodeByIdSeekClone(const ExecutionPlan *plan, const OpBase *opBase
 	 * the clone will set its values to be the same as in the origin. */
 	range.include_min = true;
 	range.include_max = true;
-	return NewNodeByIdSeekOp(plan, op->n, &range);
+	return NewNodeByIdSeekOp(plan, opBase->modifies[0], &range);
 }
 
 static void NodeByIdSeekFree(OpBase *opBase) {

--- a/src/execution_plan/ops/op_node_by_id_seek.h
+++ b/src/execution_plan/ops/op_node_by_id_seek.h
@@ -18,12 +18,11 @@ typedef struct {
 	OpBase op;
 	Graph *g;               // Graph object.
 	Record child_record;    // The Record this op acts on if it is not a tap.
-	const QGNode *n;        // The node being scanned.
 	NodeID currentId;       // Current ID fetched.
 	NodeID minId;           // Min ID to fetch.
 	NodeID maxId;           // Max ID to fetch.
 	int nodeRecIdx;         // Position of entity within record.
 } NodeByIdSeek;
 
-OpBase *NewNodeByIdSeekOp(const ExecutionPlan *plan, const QGNode *n, UnsignedRange *id_range);
+OpBase *NewNodeByIdSeekOp(const ExecutionPlan *plan, const char *alias, UnsignedRange *id_range);
 

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -19,10 +19,11 @@ static OpBase *NodeByLabelScanClone(const ExecutionPlan *plan, const OpBase *opB
 static void NodeByLabelScanFree(OpBase *opBase);
 
 static inline int NodeByLabelScanToString(const OpBase *ctx, char *buf, uint buf_len) {
-	return ScanToString(ctx, buf, buf_len, ((const NodeByLabelScan *)ctx)->n);
+	NodeByLabelScan *op = (NodeByLabelScan *)ctx;
+	return ScanToString(ctx, buf, buf_len, ctx->modifies[0], op->n.label);
 }
 
-OpBase *NewNodeByLabelScanOp(const ExecutionPlan *plan, const QGNode *n) {
+OpBase *NewNodeByLabelScanOp(const ExecutionPlan *plan, LabeledNodeCtx n) {
 	NodeByLabelScan *op = rm_malloc(sizeof(NodeByLabelScan));
 	GraphContext *gc = QueryCtx_GetGraphCtx();
 	op->g = gc->g;
@@ -37,7 +38,7 @@ OpBase *NewNodeByLabelScanOp(const ExecutionPlan *plan, const QGNode *n) {
 				NodeByLabelScanConsume, NodeByLabelScanReset, NodeByLabelScanToString, NodeByLabelScanClone,
 				NodeByLabelScanFree, false, plan);
 
-	op->nodeRecIdx = OpBase_Modifies((OpBase *)op, n->alias);
+	op->nodeRecIdx = OpBase_Modifies((OpBase *)op, n.alias);
 
 	return (OpBase *)op;
 }
@@ -70,7 +71,7 @@ static OpResult NodeByLabelScanInit(OpBase *opBase) {
 
 	// If we have no children, we can build the iterator now.
 	GraphContext *gc = QueryCtx_GetGraphCtx();
-	Schema *schema = GraphContext_GetSchema(gc, op->n->label, SCHEMA_NODE);
+	Schema *schema = GraphContext_GetSchema(gc, op->n.label, SCHEMA_NODE);
 	if(!schema) {
 		// Missing schema, use the NOP consume function.
 		OpBase_UpdateConsume(opBase, NodeByLabelScanNoOp);
@@ -90,7 +91,7 @@ static OpResult NodeByLabelScanInit(OpBase *opBase) {
 
 static inline void _UpdateRecord(NodeByLabelScan *op, Record r, GrB_Index node_id) {
 	// Populate the Record with the graph entity data.
-	Node n = GE_NEW_LABELED_NODE(op->n->label, op->n->labelID);
+	Node n = GE_NEW_LABELED_NODE(op->n.label, op->n.label_id);
 	Graph_GetNode(op->g, node_id, &n);
 	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);
@@ -125,7 +126,7 @@ static Record NodeByLabelScanConsumeFromChild(OpBase *opBase) {
 		if(!op->iter) {
 			// Iterator wasn't set up until now.
 			GraphContext *gc = QueryCtx_GetGraphCtx();
-			Schema *schema = GraphContext_GetSchema(gc, op->n->label, SCHEMA_NODE);
+			Schema *schema = GraphContext_GetSchema(gc, op->n.label, SCHEMA_NODE);
 			// No label matrix, it might be created in the next iteration.
 			if(!schema) continue;
 			_ConstructIterator(op, schema); // OK to fail (invalid range) iter will be depleted.

--- a/src/execution_plan/ops/op_node_by_label_scan.h
+++ b/src/execution_plan/ops/op_node_by_label_scan.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "op.h"
+#include "shared/scan_functions.h"
 #include "../execution_plan.h"
 #include "../../graph/graph.h"
 #include "../../graph/entities/node.h"
@@ -18,7 +19,7 @@
 typedef struct {
 	OpBase op;
 	Graph *g;
-	const QGNode *n;            /* Node being scanned. */
+	LabeledNodeCtx n;           /* Label data of node being scanned. */
 	unsigned int nodeRecIdx;    /* Node position within record. */
 	UnsignedRange *id_range;    /* ID range to iterate over. */
 	GxB_MatrixTupleIter *iter;
@@ -26,7 +27,8 @@ typedef struct {
 } NodeByLabelScan;
 
 /* Creates a new NodeByLabelScan operation */
-OpBase *NewNodeByLabelScanOp(const ExecutionPlan *plan, const QGNode *node);
+OpBase *NewNodeByLabelScanOp(const ExecutionPlan *plan, LabeledNodeCtx n);
 
 /* Transform a simple label scan to perform additional range query over the label  matrix. */
 void NodeByLabelScanOp_SetIDRange(NodeByLabelScan *op, UnsignedRange *id_range);
+

--- a/src/execution_plan/ops/shared/print_functions.c
+++ b/src/execution_plan/ops/shared/print_functions.c
@@ -43,9 +43,13 @@ int TraversalToString(const OpBase *op, char *buf, uint buf_len, AlgebraicExpres
 	return offset;
 }
 
-int ScanToString(const OpBase *op, char *buf, uint buf_len, const QGNode *n) {
+int ScanToString(const OpBase *op, char *buf, uint buf_len, const char *alias, const char *label) {
 	int offset = snprintf(buf, buf_len, "%s | ", op->name);
-	offset += QGNode_ToString(n, buf + offset, buf_len - offset);
+
+	offset += snprintf(buf + offset, buf_len - offset, "(");
+	if(alias) offset += snprintf(buf + offset, buf_len - offset, "%s", alias);
+	if(label) offset += snprintf(buf + offset, buf_len - offset, ":%s", label);
+	offset += snprintf(buf + offset, buf_len - offset, ")");
 	return offset;
 }
 

--- a/src/execution_plan/ops/shared/print_functions.h
+++ b/src/execution_plan/ops/shared/print_functions.h
@@ -11,5 +11,5 @@
 
 int TraversalToString(const OpBase *op, char *buf, uint buf_len, AlgebraicExpression *ae);
 
-int ScanToString(const OpBase *op, char *buf, uint buf_len, const QGNode *n);
+int ScanToString(const OpBase *op, char *buf, uint buf_len, const char *alias, const char *label);
 

--- a/src/execution_plan/ops/shared/scan_functions.h
+++ b/src/execution_plan/ops/shared/scan_functions.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018-2020 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+
+#pragma once
+
+// Storage struct for label data in node and index scans.
+typedef struct {
+	const char *alias;   // Alias of the node being traversed.
+	const char *label;   // Label of the node being traversed.
+	int label_id;        // Label ID of the node being traversed.
+} LabeledNodeCtx;
+
+// Instantiate a new labeled node context.
+#define NODE_CTX_NEW(_alias, _label, _label_id)  \
+(LabeledNodeCtx) {                               \
+	.alias = (_alias),                           \
+	.label = (_label),                           \
+	.label_id = (_label_id)                      \
+}
+

--- a/src/execution_plan/optimizations/reduce_count.c
+++ b/src/execution_plan/optimizations/reduce_count.c
@@ -67,8 +67,7 @@ static int _identifyNodeCountPattern(OpBase *root, OpResult **opResult, OpAggreg
 	*opScan = op;
 	if(op->type == OPType_NODE_BY_LABEL_SCAN) {
 		NodeByLabelScan *labelScan = (NodeByLabelScan *)op;
-		assert(labelScan->n->label);
-		*label = labelScan->n->label;
+		*label = labelScan->n.label;
 	}
 
 	return 1;

--- a/src/execution_plan/optimizations/reduce_scans.c
+++ b/src/execution_plan/optimizations/reduce_scans.c
@@ -12,13 +12,12 @@
 #include <assert.h>
 #include "../../query_ctx.h"
 
-static OpBase *_LabelScanToConditionalTraverse(NodeByLabelScan *label_scan) {
-	AST *ast = QueryCtx_GetAST();
+static OpBase *_LabelScanToConditionalTraverse(NodeByLabelScan *op) {
 	Graph *g = QueryCtx_GetGraph();
-	const QGNode *n = label_scan->n;
-	AlgebraicExpression *ae = AlgebraicExpression_NewOperand(GrB_NULL, true, n->alias, n->alias, NULL,
-															 n->label);
-	return NewCondTraverseOp(label_scan->op.plan, g, ae);
+	const char *alias = op->op.modifies[0];
+	AlgebraicExpression *ae = AlgebraicExpression_NewOperand(GrB_NULL, true, alias, alias, NULL,
+															 op->n.label);
+	return NewCondTraverseOp(op->op.plan, g, ae);
 }
 
 static void _reduceScans(ExecutionPlan *plan, OpBase *scan) {

--- a/src/execution_plan/optimizations/reduce_traversal.c
+++ b/src/execution_plan/optimizations/reduce_traversal.c
@@ -78,7 +78,7 @@ void reduceTraversal(ExecutionPlan *plan) {
 		}
 
 		/* Both src and dest are already known
-		 * perform expand into instaed of traverse. */
+		 * perform expand into instead of traverse. */
 		if(op->type == OPType_CONDITIONAL_TRAVERSE) {
 			CondTraverse *traverse = (CondTraverse *)op;
 			const ExecutionPlan *traverse_plan = traverse->op.plan;

--- a/src/execution_plan/optimizations/seek_by_id.c
+++ b/src/execution_plan/optimizations/seek_by_id.c
@@ -88,8 +88,8 @@ static void _UseIdOptimization(ExecutionPlan *plan, OpBase *scan_op) {
 			NodeByLabelScan *label_scan = (NodeByLabelScan *) scan_op;
 			NodeByLabelScanOp_SetIDRange(label_scan, id_range);
 		} else {
-			const QGNode *node = ((AllNodeScan *)scan_op)->n;
-			OpBase *opNodeByIdSeek = NewNodeByIdSeekOp(scan_op->plan, node, id_range);
+			const char *alias = scan_op->modifies[0];
+			OpBase *opNodeByIdSeek = NewNodeByIdSeekOp(scan_op->plan, alias, id_range);
 
 			// Managed to reduce!
 			ExecutionPlan_ReplaceOp(plan, scan_op, opNodeByIdSeek);

--- a/src/execution_plan/optimizations/utilize_indices.c
+++ b/src/execution_plan/optimizations/utilize_indices.c
@@ -419,7 +419,7 @@ void reduce_scan_op(ExecutionPlan *plan, NodeByLabelScan *scan) {
 	rax *numeric_ranges = NULL;
 
 	// Make sure there's an index for scanned label.
-	const char *label = scan->n->label;
+	const char *label = scan->n.label;
 	GraphContext *gc = QueryCtx_GetGraphCtx();
 	Index *idx = GraphContext_GetIndex(gc, label, NULL, IDX_EXACT_MATCH);
 	if(idx == NULL) return;

--- a/tests/flow/test_optional_match.py
+++ b/tests/flow/test_optional_match.py
@@ -215,3 +215,13 @@ class testOptionalFlow(FlowTestsBase):
                            [nodes['v1'], nodes['v2'], 'E1'],
                            [nodes['v2'], nodes['v3'], 'E2']]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    def test17_optional_label_introductions(self):
+        global redis_graph
+        query = """MATCH (a) OPTIONAL MATCH (a:L)-[]->(b:L) RETURN a.v, b.v ORDER BY a.v, b.v"""
+        actual_result = redis_graph.query(query)
+        expected_result = [['v1', 'v2'],
+                           ['v2', 'v3'],
+                           ['v3', None],
+                           ['v4', None]]
+        self.env.assertEquals(actual_result.result_set, expected_result)

--- a/tests/flow/test_path_filter.py
+++ b/tests/flow/test_path_filter.py
@@ -247,3 +247,20 @@ class testPathFilter(FlowTestsBase):
         expected_result = [['a'],
                            ['b']]
         self.env.assertEquals(result_set.result_set, expected_result)
+
+    def test12_label_introduced_in_path_filter(self):
+        # Build a graph with 2 nodes connected by 1 edge.
+        node0 = Node(node_id=0, label="L", properties={'x': 'a'})
+        node1 = Node(node_id=1, label="L", properties={'x': 'b'})
+        edge01 = Edge(src_node=node0, dest_node=node1, relation="R")
+        redis_graph.add_node(node0)
+        redis_graph.add_node(node1)
+        redis_graph.add_edge(edge01)
+        redis_graph.flush()
+
+        # Write a WHERE filter that introduces label data.
+        query = "MATCH (a1)-[]->(a2) WHERE (a1:L)-[]->(a2:L) return a1.x, a2.x"
+        result_set = redis_graph.query(query)
+        # The WHERE filter evaluates to false, no results should be returned.
+        expected_result = [['a', 'b']]
+        self.env.assertEquals(result_set.result_set, expected_result)


### PR DESCRIPTION
Label data built for QueryGraphs in temporary execution plans (OPTIONAL MATCH, MERGE, path filters) is not and should not be propagated into the master QueryGraph. However, this causes problems with queries like:
```
MATCH (a1)-[]->(a2) WHERE (a1:L)-[]->(a2:L) return a1.v
```
and
```
MATCH (a) OPTIONAL MATCH (a:L)-[]->(b:L) RETURN a.v, b.v
```
This PR addresses this problem by storing label data on the NodeByLabelScan and IndexScan ops themselves and removing QGNode references from scans altogether.

I'm currently using a `LabeledNodeCtx` container struct for this data, but it could be held as op struct members instead if preferred.

Resolves #1284