### PR TITLE
Build apply ops in correct ExecutionPlan scope

### DIFF
--- a/src/execution_plan/execution_plan_reduce_to_apply.c
+++ b/src/execution_plan/execution_plan_reduce_to_apply.c
@@ -90,8 +90,9 @@ void ExecutionPlan_ReduceFilterToApply(ExecutionPlan *plan, OpFilter *filter) {
 	// Collect the variable names from bound_vars to populate the Argument ops we will build.
 	const char **vars = (const char **)raxValues(bound_vars);
 
+	ExecutionPlan *filter_plan = (ExecutionPlan *)filter->op.plan;
 	// Reduce.
-	OpBase *apply_op = _ReduceFilterToOp(plan, vars, filter->filterTree);
+	OpBase *apply_op = _ReduceFilterToOp(filter_plan, vars, filter->filterTree);
 	// Replace operations.
 	ExecutionPlan_ReplaceOp(plan, (OpBase *)filter, apply_op);
 	// Bounded branch is now the last child (after ops replacement). Make it the first.

--- a/tests/flow/test_path_filter.py
+++ b/tests/flow/test_path_filter.py
@@ -263,3 +263,25 @@ class testPathFilter(FlowTestsBase):
         result_set = redis_graph.query(query)
         expected_result = [['a', 'b']]
         self.env.assertEquals(result_set.result_set, expected_result)
+
+    def test13_path_filter_in_different_scope(self):
+        # Create a graph of the form:
+        # (c)-[]->(a)-[]->(b)
+        node0 = Node(node_id=0, label="L", properties={'x': 'a'})
+        node1 = Node(node_id=1, label="L", properties={'x': 'b'})
+        node2 = Node(node_id=2, label="L", properties={'x': 'c'})
+        edge01 = Edge(src_node=node0, dest_node=node1, relation="R")
+        edge12 = Edge(src_node=node1, dest_node=node2, relation="R")
+        redis_graph.add_node(node0)
+        redis_graph.add_node(node1)
+        redis_graph.add_node(node2)
+        redis_graph.add_edge(edge01)
+        redis_graph.add_edge(edge12)
+        redis_graph.flush()
+
+        # Match nodes with an outgoing edge that optionally have an incoming edge.
+        query = "MATCH (a) OPTIONAL MATCH (a)<-[]-() WITH a WHERE (a)-[]->() return a.x ORDER BY a.x"
+        result_set = redis_graph.query(query)
+        expected_result = [['a'],
+                           ['b']]
+        self.env.assertEquals(result_set.result_set, expected_result)


### PR DESCRIPTION
This PR changes the ExecutionPlan to which SemiApply branches and similar from the topmost plan to the plan that is bound to the op it is replacing.

This fixes the assertion failure observed in #1309 wherein `Record_Merge` did not accept that the SemiApply branch belonged to the same scope as the matching branch.