### PR TITLE
fix gcc-10 breaking changes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -16,7 +16,7 @@ endif
 # Default CFLAGS
 CFLAGS = \
 	-Wall -Wno-unused-function -Wno-unused-variable -Wno-unused-result \
-	-fPIC \
+	-fPIC -fcommon \
 	-D_GNU_SOURCE -DREDIS_MODULE_TARGET -DREDISMODULE_EXPERIMENTAL_API -DXXH_STATIC_LINKING_ONLY
 CFLAGS += $(DEBUGFLAGS)
 


### PR DESCRIPTION
This PR address the issue #1243.

If this is only useful on macOS this flag need to be placed [here](https://github.com/RedisGraph/RedisGraph/blob/master/src/Makefile#L28).