### PR TITLE
Change struct member order to eliminate Valgrind complaint

### DIFF
--- a/src/arithmetic/algebraic_expression.h
+++ b/src/arithmetic/algebraic_expression.h
@@ -31,6 +31,7 @@ typedef enum {
 typedef struct AlgebraicExpression AlgebraicExpression;
 
 struct AlgebraicExpression {
+	AlgebraicExpressionType type;   // Type of node, either an operation or an operand.
 	union {
 		struct {
 			bool diagonal;          // Diagonal matrix.
@@ -46,7 +47,6 @@ struct AlgebraicExpression {
 			AlgebraicExpression **children; // Child nodes.
 		} operation;
 	};
-	AlgebraicExpressionType type;   // Type of node, either an operation or an operand.
 };
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This is a strange fix to a Valgrind error that occurs on O3 compilation:
```
==11956== Conditional jump or move depends on uninitialised value(s)
==11956==    at 0x62D4BBA: _AlgebraicExpression_IsAdditionNode (algebraic_expression_optimization.c:17)
==11956==    by 0x62D4BBA: __AlgebraicExpression_MulOverAdd (algebraic_expression_optimization.c:60)
==11956==    by 0x62D4B69: __AlgebraicExpression_MulOverAdd (algebraic_expression_optimization.c:169)
==11956==    by 0x62D4B69: __AlgebraicExpression_MulOverAdd (algebraic_expression_optimization.c:169)
==11956==    by 0x62D57AF: _AlgebraicExpression_MulOverAdd (algebraic_expression_optimization.c:195)
==11956==    by 0x62D57AF: AlgebraicExpression_Optimize (algebraic_expression_optimization.c:532)
==11956==    by 0x62EB855: _traverse (op_expand_into.c:51)
[...]
==11956==  Uninitialised value was created by a heap allocation
==11956==    at 0x4C2FDB3: malloc (vg_replace_malloc.c:309)
==11956==    by 0x14F17A: zmalloc (zmalloc.c:99)
==11956==    by 0x1D50A4: RM_Alloc (module.c:396)
==11956==    by 0x62D6A87: rm_malloc (rmalloc.h:11)
==11956==    by 0x62D6A87: AlgebraicExpression_NewOperand (algebraic_expression.c:88)
==11956==    by 0x62D3D32: _AlgebraicExpression_OperandFromNode (algebraic_expression_construction.c:182)
[...]
```
No members of the AlgebraicExpression node are actually uninitialized, but the struct padding is, which causes this complaint.

I'm unsure whether this report has actually caused bugs, but I've seen buggy executions that report this error, so feel that we may as well fix it.