### PR TITLE
moved assert to runtime error -  locate op suitable for a filter

### DIFF
--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -356,13 +356,12 @@ void ExecutionPlan_RePositionFilterOp(ExecutionPlan *plan, OpBase *lower_bound,
 			for(uint64_t i = 1; i < references_count; i++) {
 				asprintf(&entities_str, "%s, %s", entities_str, entities[i]);
 			}
+			// Build-time error - execution plan will not run.
 			QueryCtx_SetError("Unable to place filter op for entities: %s", entities_str);
 			// Cleanup.
 			OpBase_Free(filter);
 			free(entities_str);
-			for(uint64_t i = 0; i < references_count; i++) {
-				rm_free(entities[i]);
-			}
+			for(uint64_t i = 0; i < references_count; i++) rm_free(entities[i]);
 			array_free(entities);
 			raxFree(references);
 			return;

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -340,10 +340,11 @@ static void _ExecutionPlan_PlaceApplyOps(ExecutionPlan *plan) {
 
 void ExecutionPlan_RePositionFilterOp(ExecutionPlan *plan, OpBase *lower_bound,
 									  const OpBase *upper_bound, OpBase *filter) {
-	assert(filter->type == OPType_FILTER);
+	ASSERT(filter->type == OPType_FILTER);
+	OpBase *op = NULL;
 	rax *references = FilterTree_CollectModified(((OpFilter *)filter)->filterTree);
-	OpBase *op;
 	uint64_t references_count = raxSize(references);
+	
 	if(references_count > 0) {
 		/* Scan execution plan, locate the earliest position where all
 		 * references been resolved. */
@@ -376,6 +377,7 @@ void ExecutionPlan_RePositionFilterOp(ExecutionPlan *plan, OpBase *lower_bound,
 			op = op->children[0];
 		}
 	}
+	ASSERT(op != NULL);
 
 	// In case this is a pre-existing filter (this function is not called out from ExecutionPlan_PlaceFilterOps)
 	if(filter->childCount > 0) {

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -354,10 +354,15 @@ void ExecutionPlan_RePositionFilterOp(ExecutionPlan *plan, OpBase *lower_bound,
 			char *entities_str;
 			asprintf(&entities_str, "%s", entities[0]);
 			for(uint64_t i = 1; i < references_count; i++) {
-				asprintf(&entities_str, "%s, %s", entities_str, entities[0]);
+				asprintf(&entities_str, "%s, %s", entities_str, entities[i]);
 			}
 			QueryCtx_SetError("Unable to place filter op for entities: %s", entities_str);
+			// Cleanup.
+			OpBase_Free(filter);
 			free(entities_str);
+			for(uint64_t i = 0; i < references_count; i++) {
+				rm_free(entities[i]);
+			}
 			array_free(entities);
 			raxFree(references);
 			return;

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -269,3 +269,15 @@ class testQueryValidationFlow(FlowTestsBase):
             # Expecting an error.
             assert("Only directed relationships" in e.message)
             pass
+
+    # Applying a filter for non existing entity.
+    def test20_non_existing_graph_entity(self):
+        try:
+            query = """match p=(n:Type) where p.name='value' return p"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError as e:
+            # Expecting an error.
+            assert("Unable to place filter op for entities" in e.message)
+            pass
+


### PR DESCRIPTION
Issue #1313 showed that a wrong user query where they access to a property of a path, causes the graph to crash since it cannot find a suitable operation to locate the filter after it. Since paths are functions built or runtime, they cannot be treated as entities such as nodes and edges (properties map), since no operation is creating them (e.g. Modifies record mapping). Due to this reason, the execution plan is unable to find a suitable operation that declares on creating the path entities, and an assertion was triggered.

closes #1313 