### PR TITLE
Forking no longer requires lock acquisition

### DIFF
--- a/src/module_event_handlers.c
+++ b/src/module_event_handlers.c
@@ -208,31 +208,6 @@ static void _RegisterServerEvents(RedisModuleCtx *ctx) {
 	}
 }
 
-static void RG_ForkPrepare() {
-	/* At this point, a fork call has been issued. (We assume that this is because BGSave was called.)
-	 * Acquire the read-write lock of each graph to ensure that no graph is being modified, or else
-	 * the child process will deadlock when attempting to acquire that lock.
-	 * 1. If a writer thread is active, we'll wait until the writer finishes and releases the lock.
-	 * 2. Otherwise, no write in progress. Acquire the lock and release it immediately after forking. */
-
-	uint graph_count = array_len(graphs_in_keyspace);
-	for(uint i = 0; i < graph_count; i++) {
-		// Acquire each read-write lock as a reader to guarantee that no graph is being modified.
-		Graph_AcquireReadLock(graphs_in_keyspace[i]->g);
-	}
-}
-
-static void RG_AfterForkParent() {
-	/* The process has forked, and the parent process is continuing.
-	 * Release all locks. */
-
-	uint graph_count = array_len(graphs_in_keyspace);
-	for(uint i = 0; i < graph_count; i++) {
-		// Release each read-write lock.
-		Graph_ReleaseLock(graphs_in_keyspace[i]->g);
-	}
-}
-
 static void RG_AfterForkChild() {
 	/* Restrict GraphBLAS to use a single thread this is done for 2 reasons:
 	 * 1. save resources.
@@ -246,8 +221,8 @@ static void RG_AfterForkChild() {
 
 static void _RegisterForkHooks() {
 	/* Register handlers to control the behavior of fork calls.
-	 * The child process does not require a handler. */
-	assert(pthread_atfork(RG_ForkPrepare, RG_AfterForkParent, RG_AfterForkChild) == 0);
+	 * Only the child process requires a handler, to prevent the acquisition of locks it doesn't own. */
+	assert(pthread_atfork(NULL, NULL, RG_AfterForkChild) == 0);
 }
 
 static void _ModuleEventHandler_TryClearKeyspace(void) {


### PR DESCRIPTION
This is a straightforward deletion of the lock acquisition logic before forking. As writers that are modifying data will be holding the GIL, there is no danger of the server forking (due to bgsave or RediSearch garbage collection) while the graph is in an inconsistent state.

We do need to retain the `AfterForkChild` child handler, which allows `bgsave` children to avoid deadlocks by not accessing synchronization primitives.