### PR TITLE
added leading comments for a query

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -91,12 +91,27 @@ static void _AST_LimitResults(AST *ast, const cypher_astnode_t *root_clause,
 	}
 }
 
+static const cypher_astnode_t *_AST_parse_result_root(const cypher_parse_result_t *parse_result) {
+	uint nroots = cypher_parse_result_nroots(parse_result);
+	for(uint i = 0; i < nroots; i++) {
+		const cypher_astnode_t *root = cypher_parse_result_get_root(parse_result, i);
+		cypher_astnode_type_t root_type = cypher_astnode_type(root);
+		if(root_type != CYPHER_AST_STATEMENT) {
+			continue;
+		} else {
+			return root;
+		}
+	}
+	ASSERT("_AST_parse_result_root: Parse result should have a valid root" && false);
+	return NULL;
+}
+
 /* This method extracts the query given parameters values, convert them into
  * constant arithmetic expressions and store them in a map of <name, value>
  * in the query context. */
 static void _AST_Extract_Params(const cypher_parse_result_t *parse_result) {
 	// Retrieve the AST root node from a parsed query.
-	const cypher_astnode_t *statement = cypher_parse_result_get_root(parse_result, 0);
+	const cypher_astnode_t *statement = _AST_parse_result_root(parse_result);
 	uint noptions = cypher_ast_statement_noptions(statement);
 	if(noptions == 0) return;
 	rax *params = QueryCtx_GetParams();
@@ -270,7 +285,7 @@ AST *AST_Build(cypher_parse_result_t *parse_result) {
 	ast->anot_ctx_collection = AST_AnnotationCtxCollection_New();
 
 	// Retrieve the AST root node from a parsed query.
-	const cypher_astnode_t *statement = cypher_parse_result_get_root(parse_result, 0);
+	const cypher_astnode_t *statement = _AST_parse_result_root(parse_result);
 	// We are parsing with the CYPHER_PARSE_ONLY_STATEMENTS flag,
 	// and double-checking this in AST validations
 	assert(cypher_astnode_type(statement) == CYPHER_AST_STATEMENT);
@@ -463,7 +478,7 @@ const char **AST_BuildCallColumnNames(const cypher_astnode_t *call_clause) {
 
 const char *_AST_ExtractQueryString(const cypher_parse_result_t *partial_result) {
 	// Retrieve the AST root node from a parsed query.
-	const cypher_astnode_t *statement = cypher_parse_result_get_root(partial_result, 0);
+	const cypher_astnode_t *statement = _AST_parse_result_root(partial_result);
 	// We are parsing with the CYPHER_PARSE_ONLY_PARAMETERS flag.
 	// Given that, only the parameters were processed. extract the actual query and return to caller.
 	assert(cypher_astnode_type(statement) == CYPHER_AST_STATEMENT);
@@ -550,6 +565,7 @@ cypher_parse_result_t *parse_query(const char *query) {
 	}
 	return result;
 }
+
 
 cypher_parse_result_t *parse_params(const char *query, const char **query_body) {
 	cypher_parse_result_t *result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_PARAMETERS);

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -91,6 +91,9 @@ static void _AST_LimitResults(AST *ast, const cypher_astnode_t *root_clause,
 	}
 }
 
+/* This function returns the actual root of the query.
+ * As cypher_parse_result_t can have multiple roots such as comments, only a root with type
+ * CYPHER_AST_STATEMENT is considered as the actual root. Comment roots are ignored. */
 static const cypher_astnode_t *_AST_parse_result_root(const cypher_parse_result_t *parse_result) {
 	uint nroots = cypher_parse_result_nroots(parse_result);
 	for(uint i = 0; i < nroots; i++) {

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1608,8 +1608,6 @@ static AST_Validation _AST_Validate_ParseResultRoot(const cypher_parse_result_t 
 		   root_type == CYPHER_AST_COMMENT) {
 			continue;
 		} else if(root_type != CYPHER_AST_STATEMENT) {
-			// This should be unnecessary, as we're currently parsing
-			// with the CYPHER_PARSE_ONLY_STATEMENTS flag.
 			QueryCtx_SetError("Encountered unsupported query type '%s'", cypher_astnode_typestr(root_type));
 			return AST_INVALID;
 		} else {

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1592,29 +1592,35 @@ bool AST_ContainsErrors(const cypher_parse_result_t *result) {
 	return cypher_parse_result_nerrors(result) > 0;
 }
 
-static AST_Validation _AST_Validate_ParseResultRoot(const cypher_parse_result_t *result) {
+static AST_Validation _AST_Validate_ParseResultRoot(const cypher_parse_result_t *result,
+													int *index) {
 	// Check for failures in libcypher-parser
 	if(AST_ContainsErrors(result)) {
 		_AST_ReportErrors(result);
 		return AST_INVALID;
 	}
 
-	const cypher_astnode_t *root = cypher_parse_result_get_root(result, 0);
-	// Check for empty query
-	if(root == NULL) {
-		QueryCtx_SetError("Error: empty query.");
-		return AST_INVALID;
+	uint nroots = cypher_parse_result_nroots(result);
+	for(uint i = 0; i < nroots; i++) {
+		const cypher_astnode_t *root = cypher_parse_result_get_root(result, i);
+		cypher_astnode_type_t root_type = cypher_astnode_type(root);
+		if(root_type == CYPHER_AST_LINE_COMMENT || root_type == CYPHER_AST_BLOCK_COMMENT ||
+		   root_type == CYPHER_AST_COMMENT) {
+			continue;
+		} else if(root_type != CYPHER_AST_STATEMENT) {
+			// This should be unnecessary, as we're currently parsing
+			// with the CYPHER_PARSE_ONLY_STATEMENTS flag.
+			QueryCtx_SetError("Encountered unsupported query type '%s'", cypher_astnode_typestr(root_type));
+			return AST_INVALID;
+		} else {
+			// We got a statement.
+			*index = i;
+			return AST_VALID;
+		}
 	}
 
-	cypher_astnode_type_t root_type = cypher_astnode_type(root);
-	if(root_type != CYPHER_AST_STATEMENT) {
-		// This should be unnecessary, as we're currently parsing
-		// with the CYPHER_PARSE_ONLY_STATEMENTS flag.
-		QueryCtx_SetError("Encountered unsupported query type '%s'", cypher_astnode_typestr(root_type));
-		return AST_INVALID;
-	}
-
-	return AST_VALID;
+	QueryCtx_SetError("Error: empty query.");
+	return AST_INVALID;
 }
 
 static AST_Validation _AST_ValidateUnionQuery(AST *mock_ast) {
@@ -1646,11 +1652,12 @@ cleanup:
 }
 
 AST_Validation AST_Validate_Query(const cypher_parse_result_t *result) {
-	if(_AST_Validate_ParseResultRoot(result) != AST_VALID) {
+	int index;
+	if(_AST_Validate_ParseResultRoot(result, &index) != AST_VALID) {
 		return AST_INVALID;
 	}
 
-	const cypher_astnode_t *root = cypher_parse_result_get_root(result, 0);
+	const cypher_astnode_t *root = cypher_parse_result_get_root(result, index);
 
 	// Verify that the query does not contain any expressions not in the RedisGraph support whitelist
 	if(CypherWhitelist_ValidateQuery(root) != AST_VALID) return AST_INVALID;
@@ -1680,9 +1687,10 @@ AST_Validation AST_Validate_Query(const cypher_parse_result_t *result) {
 
 AST_Validation AST_Validate_QueryParams(const cypher_parse_result_t *result) {
 	char *err;
-	if(_AST_Validate_ParseResultRoot(result) != AST_VALID) return AST_INVALID;
+	int index;
+	if(_AST_Validate_ParseResultRoot(result, &index) != AST_VALID) return AST_INVALID;
 
-	const cypher_astnode_t *root = cypher_parse_result_get_root(result, 0);
+	const cypher_astnode_t *root = cypher_parse_result_get_root(result, index);
 
 	// In case of no parameters.
 	if(cypher_ast_statement_noptions(root) == 0) return AST_VALID;

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1592,6 +1592,9 @@ bool AST_ContainsErrors(const cypher_parse_result_t *result) {
 	return cypher_parse_result_nerrors(result) > 0;
 }
 
+/* This function checks for the existence a valid root in the query.
+ * As cypher_parse_result_t can have multiple roots such as comments, only a query that has
+ * a root with type CYPHER_AST_STATEMENT is considered valid. Comment roots are ignored. */
 static AST_Validation _AST_Validate_ParseResultRoot(const cypher_parse_result_t *result,
 													int *index) {
 	// Check for failures in libcypher-parser

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -290,3 +290,20 @@ class testQueryValidationFlow(FlowTestsBase):
         actual_result = redis_graph.query(query)
         expected_result = [[34]]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+        query = """/* A block comment*/ MATCH (n)  // This is a comment
+                /* This is a block comment */
+                WHERE EXISTS(n.age)
+                RETURN n.age /* Also a block comment*/"""
+        actual_result = redis_graph.query(query)
+        expected_result = [[34]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        query = """// This is a comment
+                MATCH (n)  // This is a comment
+                /* This is a block comment */
+                WHERE EXISTS(n.age)
+                RETURN n.age /* Also a block comment*/"""
+        actual_result = redis_graph.query(query)
+        expected_result = [[34]]
+        self.env.assertEquals(actual_result.result_set, expected_result)

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -307,3 +307,9 @@ class testQueryValidationFlow(FlowTestsBase):
         actual_result = redis_graph.query(query)
         expected_result = [[34]]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+        query = """MATCH (n)  /* This is a block comment */ WHERE EXISTS(n.age)
+                RETURN n.age /* Also a block comment*/"""
+        actual_result = redis_graph.query(query)
+        expected_result = [[34]]
+        self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
This PR adds support for parsing results with multiple nodes. Closes #1329 

This exposes a bug in libcypher-parser:
For the query 
```
/* hum */ MATCH (:Test) // hum 
RETURN true // oi
```
The parsing result is (see last identifier)
```
 @0   2..7   block_comment           /* hum */
 @1  10..49  statement               body=@2
 @2  10..49  > query                 clauses=[@3, @9]
 @3  10..32  > > MATCH               pattern=@4
 @4  16..23  > > > pattern           paths=[@5]
 @5  16..23  > > > > pattern path    (@6)
 @6  16..23  > > > > > node pattern  (:@7)
 @7  17..22  > > > > > > label       :`Test`
 @8  26..31  > > > line_comment      // hum 
 @9  32..49  > > RETURN              projections=[@10]
@10  39..49  > > > projection        expression=@11, alias=@13
@11  39..43  > > > > TRUE
@12  46..49  > > > > line_comment    // oi
@13  39..49  > > > > identifier      `true // oi`
```
