### PR TITLE
added init time NodeScanCtx update on label scan

### DIFF
--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -77,7 +77,7 @@ static OpResult NodeByLabelScanInit(OpBase *opBase) {
 		OpBase_UpdateConsume(opBase, NodeByLabelScanNoOp);
 		return OP_OK;
 	}
-	// For reused (cloned) NodeScanCtx, label_id needs to be updated.
+	// Resolve label ID at runtime.
 	op->n.label_id = schema->id;
 
 	// The iterator build may fail if the ID range does not match the matrix dimensions.
@@ -95,7 +95,6 @@ static inline void _UpdateRecord(NodeByLabelScan *op, Record r, GrB_Index node_i
 	// Populate the Record with the graph entity data.
 	Node n = GE_NEW_LABELED_NODE(op->n.label, op->n.label_id);
 	Graph_GetNode(op->g, node_id, &n);
-	// Get a pointer to the node's allocated space within the Record.
 	Record_AddNode(r, op->nodeRecIdx, n);
 }
 

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -77,6 +77,8 @@ static OpResult NodeByLabelScanInit(OpBase *opBase) {
 		OpBase_UpdateConsume(opBase, NodeByLabelScanNoOp);
 		return OP_OK;
 	}
+	// For reused (cloned) NodeScanCtx, label_id needs to be updated.
+	op->n.label_id = schema->id;
 
 	// The iterator build may fail if the ID range does not match the matrix dimensions.
 	GrB_Info iterator_built = _ConstructIterator(op, schema);

--- a/tests/flow/test_cache.py
+++ b/tests/flow/test_cache.py
@@ -187,3 +187,18 @@ class testCache(FlowTestsBase):
         self.env.assertEqual(0, cached_result.relationships_created)
         self.env.assertEqual(uncached_result.result_set, cached_result.result_set)
 
+    def test10_test_labelscan_update(self):
+        # In this scenario a label scan is made for non existing label
+        # than the label is created and the label scan query is re-used.
+        graph = Graph('Cache_test_labelscan_update', redis_con)
+        query = "MATCH (n:Label) return n"
+        result = graph.query(query)
+        self.env.assertEqual(0, len(result.result_set))
+        query = "MERGE (n:Label)"
+        result = graph.query(query)
+        self.env.assertEqual(1, result.nodes_created)
+        query = "MATCH (n:Label) return n"
+        result = graph.query(query)
+        self.env.assertEqual(1, len(result.result_set))
+        self.env.assertEqual("Label", result.result_set[0][0].label)
+


### PR DESCRIPTION
This PR updates the NodeScanCtx of op label scan during init time
If a label id is unknown during an execution plan template build time the label scan op's NodeScanCtx saves the label is as unkown. From this point forward, all the clones of this template will clone the id as unkown, even if it was created after the template was built (no label id resultion). This PR solves the label id resultion in op label scan initilization time.

Closes https://github.com/RedisGraph/JRedisGraph/issues/83