### PR TITLE
Replace rightmost operand if traversing from dest->src (#1295)

### DIFF
--- a/src/arithmetic/algebraic_expression.h
+++ b/src/arithmetic/algebraic_expression.h
@@ -158,14 +158,14 @@ void AlgebraicExpression_AddChild
     AlgebraicExpression *child  // Child node to attach.
 );
 
-// Remove leftmost child node from root.
-AlgebraicExpression *AlgebraicExpression_RemoveLeftmostNode
+// Remove source of algebraic expression from root.
+AlgebraicExpression *AlgebraicExpression_RemoveSource
 (
     AlgebraicExpression **root   // Root from which to remove a child.
 );
 
-// Remove rightmost child node from root.
-AlgebraicExpression *AlgebraicExpression_RemoveRightmostNode
+// Remove destination of algebraic expression from root.
+AlgebraicExpression *AlgebraicExpression_RemoveDest
 (
     AlgebraicExpression **root   // Root from which to remove a child.
 );

--- a/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
@@ -112,7 +112,7 @@ static AlgebraicExpression **_AlgebraicExpression_IsolateVariableLenExps(
 		// src is the destination of the previous expression.
 		if(expIdx == 0 && src->label) {
 			// Remove src node matrix from expression.
-			AlgebraicExpression *op = AlgebraicExpression_RemoveLeftmostNode(&exp);
+			AlgebraicExpression *op = AlgebraicExpression_RemoveSource(&exp);
 			res = array_append(res, op);
 		}
 
@@ -122,7 +122,7 @@ static AlgebraicExpression **_AlgebraicExpression_IsolateVariableLenExps(
 		QGNode *dest = QueryGraph_GetNodeByAlias(qg, AlgebraicExpression_Destination(exp));
 		if(dest->label) {
 			// Remove dest node matrix from expression.
-			AlgebraicExpression *op = AlgebraicExpression_RemoveRightmostNode(&exp);
+			AlgebraicExpression *op = AlgebraicExpression_RemoveDest(&exp);
 
 			/* See if dest mat can be prepended to the following expression.
 			 * If not create a new expression. */
@@ -503,7 +503,7 @@ AlgebraicExpression **AlgebraicExpression_FromQueryGraph
 				if(src->label) {
 					/* exp[i] shares a label matrix with exp[i-1]
 					 * remove redundancy. */
-					AlgebraicExpression *redundent = AlgebraicExpression_RemoveLeftmostNode(&exp);
+					AlgebraicExpression *redundent = AlgebraicExpression_RemoveSource(&exp);
 					AlgebraicExpression_Free(redundent);
 				}
 			}

--- a/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_optimization.c
@@ -65,10 +65,10 @@ static bool __AlgebraicExpression_MulOverSum(AlgebraicExpression **root) {
 			AlgebraicExpression **right_ops = array_new(AlgebraicExpression *, right_op_count);
 
 			for(uint i = 0; i < left_op_count; i++) {
-				left_ops = array_append(left_ops, _AlgebraicExpression_OperationRemoveLeftmostChild(l));
+				left_ops = array_append(left_ops, _AlgebraicExpression_OperationRemoveSource(l));
 			}
 			for(uint i = 0; i < right_op_count; i++) {
-				right_ops = array_append(right_ops, _AlgebraicExpression_OperationRemoveLeftmostChild(r));
+				right_ops = array_append(right_ops, _AlgebraicExpression_OperationRemoveSource(r));
 			}
 
 			assert(AlgebraicExpression_ChildCount(l) == 0 && AlgebraicExpression_ChildCount(r) == 0);
@@ -110,8 +110,8 @@ static bool __AlgebraicExpression_MulOverSum(AlgebraicExpression **root) {
 				(_AlgebraicExpression_IsAdditionNode(r) && !_AlgebraicExpression_IsAdditionNode(l))) {
 
 			// Disconnect left and right children from root.
-			r = _AlgebraicExpression_OperationRemoveRightmostChild((*root));
-			l = _AlgebraicExpression_OperationRemoveRightmostChild((*root));
+			r = _AlgebraicExpression_OperationRemoveDest((*root));
+			l = _AlgebraicExpression_OperationRemoveDest((*root));
 			assert(AlgebraicExpression_ChildCount(*root) == 0);
 
 			AlgebraicExpression *add = AlgebraicExpression_NewOperation(AL_EXP_ADD);
@@ -129,8 +129,8 @@ static bool __AlgebraicExpression_MulOverSum(AlgebraicExpression **root) {
 				// Lefthand side is addition.
 				// (A + B) * C = (A * C) + (B * C)
 
-				A = _AlgebraicExpression_OperationRemoveLeftmostChild(l);
-				B = _AlgebraicExpression_OperationRemoveRightmostChild(l);
+				A = _AlgebraicExpression_OperationRemoveSource(l);
+				B = _AlgebraicExpression_OperationRemoveDest(l);
 				C = r;
 
 				AlgebraicExpression_Free(l);
@@ -142,8 +142,8 @@ static bool __AlgebraicExpression_MulOverSum(AlgebraicExpression **root) {
 				// Righthand side is addition.
 				// C * (A + B) = (C * A) + (C * B)
 
-				A = _AlgebraicExpression_OperationRemoveLeftmostChild(r);
-				B = _AlgebraicExpression_OperationRemoveRightmostChild(r);
+				A = _AlgebraicExpression_OperationRemoveSource(r);
+				B = _AlgebraicExpression_OperationRemoveDest(r);
 				C = l;
 
 				AlgebraicExpression_Free(r);
@@ -273,7 +273,7 @@ static void _Pushdown_TransposeTranspose
 	// T(T(A)) = A
 	// Expecting just a single operand.
 	assert(AlgebraicExpression_ChildCount(exp) == 1);
-	AlgebraicExpression *only_child = _AlgebraicExpression_OperationRemoveRightmostChild(exp);
+	AlgebraicExpression *only_child = _AlgebraicExpression_OperationRemoveDest(exp);
 
 	// Replace Transpose operation with its child.
 	_AlgebraicExpression_InplaceRepurpose(exp, only_child);
@@ -394,7 +394,7 @@ static void _AlgebraicExpression_PushDownTranspose(AlgebraicExpression *root) {
 				_Pushdown_TransposeExp(child);
 				/* Replace Transpose root with transposed expression.
 				 * Remove root only child. */
-				_AlgebraicExpression_OperationRemoveRightmostChild(root);
+				_AlgebraicExpression_OperationRemoveDest(root);
 				_AlgebraicExpression_InplaceRepurpose(root, child);
 
 				/* It is possible for `root` to contain a transpose subexpression

--- a/src/arithmetic/algebraic_expression/utils.c
+++ b/src/arithmetic/algebraic_expression/utils.c
@@ -36,7 +36,7 @@ void _AlgebraicExpression_InplaceRepurpose
 }
 
 // Removes the rightmost direct child node of root.
-AlgebraicExpression *_AlgebraicExpression_OperationRemoveRightmostChild
+AlgebraicExpression *_AlgebraicExpression_OperationRemoveDest
 (
 	AlgebraicExpression *root  // Root from which to remove a child.
 ) {
@@ -52,7 +52,7 @@ AlgebraicExpression *_AlgebraicExpression_OperationRemoveRightmostChild
 }
 
 // Removes the leftmost direct child node of root.
-AlgebraicExpression *_AlgebraicExpression_OperationRemoveLeftmostChild
+AlgebraicExpression *_AlgebraicExpression_OperationRemoveSource
 (
 	AlgebraicExpression *root   // Root from which to remove a child.
 ) {

--- a/src/arithmetic/algebraic_expression/utils.h
+++ b/src/arithmetic/algebraic_expression/utils.h
@@ -29,13 +29,13 @@ void _AlgebraicExpression_InplaceRepurpose
 );
 
 // Removes the rightmost direct child node of root.
-AlgebraicExpression *_AlgebraicExpression_OperationRemoveRightmostChild
+AlgebraicExpression *_AlgebraicExpression_OperationRemoveDest
 (
 	AlgebraicExpression *root  // Root from which to remove a child.
 );
 
 // Removes the leftmost direct child node of root.
-AlgebraicExpression *_AlgebraicExpression_OperationRemoveLeftmostChild
+AlgebraicExpression *_AlgebraicExpression_OperationRemoveSource
 (
 	AlgebraicExpression *root   // Root from which to remove a child.
 );

--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -277,7 +277,7 @@ static void _ExecutionPlan_ProcessQueryGraph(ExecutionPlan *plan, QueryGraph *qg
 				 * in which case if the first algebraic expression operand
 				 * is a label matrix (diagonal) remove it. */
 				if(AlgebraicExpression_DiagonalOperand(exps[0], 0)) {
-					AlgebraicExpression_Free(AlgebraicExpression_RemoveLeftmostNode(&exps[0]));
+					AlgebraicExpression_Free(AlgebraicExpression_RemoveSource(&exps[0]));
 				}
 				root = tail = NewNodeByLabelScanOp(plan, src);
 			} else {

--- a/tests/flow/test_algebraic_expression_order.py
+++ b/tests/flow/test_algebraic_expression_order.py
@@ -1,0 +1,90 @@
+import os
+import sys
+from RLTest import Env
+from redisgraph import Graph, Node, Edge
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from base import FlowTestsBase
+
+graph = None
+
+GRAPH_ID = "AlgebraicExpressionOrder"
+
+class testAlgebraicExpressionOrder(FlowTestsBase):
+    def __init__(self):
+        self.env = Env()
+        global graph
+        redis_con = self.env.getConnection()
+        graph = Graph(GRAPH_ID, redis_con)
+        self.populate_graph()
+
+    def populate_graph(self):
+        # Construct a graph with the form:
+        # (a:A)-[:E]->(b:B), (c:C)-[:E]->(b)
+        a = Node(label="A", properties={"v": 1})
+        graph.add_node(a)
+
+        b = Node(label="B", properties={"v": 2})
+        graph.add_node(b)
+
+        c = Node(label="C", properties={"v": 3})
+        graph.add_node(c)
+
+        edge = Edge(a, "E", b)
+        graph.add_edge(edge)
+
+        edge = Edge(c, "E", b)
+        graph.add_edge(edge)
+
+        graph.commit()
+
+    # Test differing patterns with the same destination node.
+    def test01_same_destination_permutations(self):
+        # Each query should return the same two records.
+        expected_result = [[1, 2],
+                           [3, 2]]
+
+        # Neither the source nor the destination is labeled, perform an AllNodeScan from the source node.
+        query = """MATCH (a)-[:E]->(b) RETURN a.v, b.v ORDER BY a.v, b.v"""
+        plan = graph.execution_plan(query)
+        self.env.assertIn("All Node Scan | (a)", plan)
+        result = graph.query(query)
+        self.env.assertEquals(result.result_set, expected_result)
+
+        # Destination is labeled, perform a LabelScan from the destination node.
+        query = """MATCH (a)-[:E]->(b:B) RETURN a.v, b.v ORDER BY a.v, b.v"""
+        plan = graph.execution_plan(query)
+        self.env.assertIn("Node By Label Scan | (b:B)", plan)
+        result = graph.query(query)
+        self.env.assertEquals(result.result_set, expected_result)
+
+        # Destination is filtered, perform an AllNodeScan from the destination node.
+        query = """MATCH (a)-[:E]->(b) WHERE b.v = 2 RETURN a.v, b.v ORDER BY a.v, b.v"""
+        plan = graph.execution_plan(query)
+        self.env.assertIn("All Node Scan | (b)", plan)
+        result = graph.query(query)
+        self.env.assertEquals(result.result_set, expected_result)
+
+        # Destination is labeled but source is filtered, perform an AllNodeScan from the source node.
+        query = """MATCH (a)-[:E]->(b:B) WHERE a.v = 1 OR a.v = 3 RETURN a.v, b.v ORDER BY a.v, b.v"""
+        plan = graph.execution_plan(query)
+        self.env.assertIn("All Node Scan | (a)", plan)
+        result = graph.query(query)
+        self.env.assertEquals(result.result_set, expected_result)
+
+        # The subsequent queries will only return one record.
+        expected_result = [[3, 2]]
+        # Both are labeled and source is filtered, perform a LabelScan from the source node.
+        query = """MATCH (a:C)-[:E]->(b:B) WHERE a.v = 3 RETURN a.v, b.v ORDER BY a.v, b.v"""
+        plan = graph.execution_plan(query)
+        self.env.assertIn("Node By Label Scan | (a:C)", plan)
+        result = graph.query(query)
+        self.env.assertEquals(result.result_set, expected_result)
+
+        # Both are labeled and dest is filtered, perform a LabelScan from the dest node.
+        query = """MATCH (a:C)-[:E]->(b:B) WHERE b.v = 2 RETURN a.v, b.v ORDER BY a.v, b.v"""
+        plan = graph.execution_plan(query)
+        self.env.assertIn("Node By Label Scan | (b:B)", plan)
+        result = graph.query(query)
+        self.env.assertEquals(result.result_set, expected_result)


### PR DESCRIPTION
* Replace rightmost operand if traversing from dest->src

* Address PR comments

* rename nodes

* Address PR comments

* consider transpose when traversing expression

Co-authored-by: Roi Lipman <swilly22@users.noreply.github.com>
Co-authored-by: swilly22 <roi@redislabs.com>
(cherry picked from commit 770d257b3013a3fffae9fc117b229870e7e265ad)