### PR TITLE
Always set GraphCtx in QueryCtx while decoding graph keys

### DIFF
--- a/src/serializers/decoders/current/v7/decode_graph.c
+++ b/src/serializers/decoders/current/v7/decode_graph.c
@@ -23,6 +23,9 @@ static GraphContext *_GetOrCreateGraphContext(char *graph_name) {
 	// Free the name string, as it either not in used or copied.
 	RedisModule_Free(graph_name);
 
+	// Set the GraphCtx in thread-local storage.
+	QueryCtx_SetGraphCtx(gc);
+
 	return gc;
 }
 

--- a/tests/flow/test_v7_encode_decode.py
+++ b/tests/flow/test_v7_encode_decode.py
@@ -24,7 +24,7 @@ class test_v7_encode_decode(FlowTestsBase):
         redis_con.execute_command("DEBUG", "RELOAD")
         actual = redis_graph.query(query)
         self.env.assertEquals(expected.result_set, actual.result_set)
-    
+
     def test02_no_compaction_on_nodes_delete(self):
         graph_name = "no_compaction_on_nodes_delete"
         redis_graph = Graph(graph_name, redis_con)
@@ -128,3 +128,28 @@ class test_v7_encode_decode(FlowTestsBase):
         plan = redis_graph.execution_plan(
             "MATCH (n:N {val:1}) RETURN n")
         self.env.assertIn("Index Scan", plan)
+
+    def test08_multiple_graphs_with_index(self):
+        # Create a multi-key graph.
+        graph1_name = "v7_graph_1"
+        graph1 = Graph(graph1_name, redis_con)
+        graph1.query("UNWIND range(0,21) AS i CREATE (a:L {v: i})-[:E]->(b:L2 {v: i})")
+
+        # Create a single-key graph.
+        graph2_name = "v7_graph_2"
+        graph2 = Graph(graph2_name, redis_con)
+        graph2.query("CREATE (a:L {v: 1})-[:E]->(b:L2 {v: 2})")
+
+        # Add an index to the multi-key graph.
+        graph1.query("CREATE INDEX ON :L(v)")
+
+        # Save RDB and reload from RDB
+        redis_con.execute_command("DEBUG", "RELOAD")
+
+        # The load should be successful and the index should still be built.
+        query = "MATCH (n:L {v:1}) RETURN n.v"
+        plan = graph1.execution_plan(query)
+        self.env.assertIn("Index Scan", plan)
+        expected = [[1]]
+        actual = graph1.query(query)
+        self.env.assertEquals(actual.result_set, expected)


### PR DESCRIPTION
This PR resolves a potential inconsistency or segfault when loading graph keys from v7 RDB files by setting the GraphCtx within the QueryCtx for every deserialized key.

- In the test case, Graph A is encoded across 6 virtual keys, and Graph B is encoded using 1.
- We begin to load Graph A, but begin and finish loading Graph B before this is finished, triggering a [QueryCtxFree](https://github.com/RedisGraph/RedisGraph/blob/master/src/serializers/decoders/current/v7/decode_graph.c#L163).
- Subsequent keys loaded for Graph A [find the partially-populated GraphContext](https://github.com/RedisGraph/RedisGraph/blob/master/src/serializers/decoders/current/v7/decode_graph.c#L15), so do not update the QueryCtx.
- When we try to build Graph A's index, we [retrieve a null pointer for the GraphContext](https://github.com/RedisGraph/RedisGraph/blob/master/src/index/index.c#L77) and segfault.

If `QueryCtx_Free` had not been triggered, the thread-local variable would have pointed to Graph B, causing the index to be loaded on the wrong graph and schema.

These misbehaviors are blocked by this PR by updating the QueryCtx with the appropriate pointer for every deserialized key, rather than just those that trigger `GraphContext_New`.