### PR TITLE
Avoid double free of heap-allocated values in CASE...WHEN statements

### DIFF
--- a/src/arithmetic/conditional_funcs/conditional_funcs.c
+++ b/src/arithmetic/conditional_funcs/conditional_funcs.c
@@ -29,7 +29,10 @@ SIValue AR_CASEWHEN(SIValue *argv, int argc) {
 			int disjointOrNull;
 			if((SIValue_Compare(v, a, &disjointOrNull) == 0) && (disjointOrNull != COMPARED_NULL)) {
 				// Return Result i.
-				return argv[i + 1];
+				// The value's ownership must be transferred to avoid a double free if it is an allocated value.
+				SIValue retval = argv[i + 1];
+				SIValue_MakeVolatile(&argv[i + 1]);
+				return retval;
 			}
 		}
 	} else {
@@ -45,11 +48,15 @@ SIValue AR_CASEWHEN(SIValue *argv, int argc) {
 			// Skip NULL and false options.
 			if(SIValue_IsNull(a) || ((SI_TYPE(a) & T_BOOL) && SIValue_IsFalse(a))) continue;
 			// The option was truthy, return the associated value.
-			return argv[i + 1];
+			// The value's ownership must be transferred to avoid a double free if it is an allocated value.
+			SIValue retval = argv[i + 1];
+			SIValue_MakeVolatile(&argv[i + 1]);
+			return retval;
 		}
 	}
 
 	//Did not match against any Option return default.
+	SIValue_MakeVolatile(&argv[argc - 1]);
 	return d;
 }
 

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -286,3 +286,16 @@ class testFunctionCallsFlow(FlowTestsBase):
                            [True, True],
                            [False, False]]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    # CASE...WHEN statements should manage allocated values properly.
+    def test14_case_when_memory_management(self):
+        # Simple case form: single value evaluation.
+        query = """WITH 'A' AS a with case a WHEN 'A' then toString(a) end AS key RETURN toLower(key)"""
+        actual_result = graph.query(query)
+        expected_result = [['a']]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+        # Generic case form: evaluation for each case.
+        query = """WITH 'A' AS a with case when true then toString(a) end AS key RETURN toLower(key)"""
+        actual_result = graph.query(query)
+        expected_result = [['a']]
+        self.env.assertEquals(actual_result.result_set, expected_result)

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -290,12 +290,12 @@ class testFunctionCallsFlow(FlowTestsBase):
     # CASE...WHEN statements should manage allocated values properly.
     def test14_case_when_memory_management(self):
         # Simple case form: single value evaluation.
-        query = """WITH 'A' AS a with case a WHEN 'A' then toString(a) end AS key RETURN toLower(key)"""
+        query = """WITH 'A' AS a WITH CASE a WHEN 'A' THEN toString(a) END AS key RETURN toLower(key)"""
         actual_result = graph.query(query)
         expected_result = [['a']]
         self.env.assertEquals(actual_result.result_set, expected_result)
         # Generic case form: evaluation for each case.
-        query = """WITH 'A' AS a with case when true then toString(a) end AS key RETURN toLower(key)"""
+        query = """WITH 'A' AS a WITH CASE WHEN true THEN toString(a) END AS key RETURN toLower(key)"""
         actual_result = graph.query(query)
         expected_result = [['a']]
         self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
This PR resolves an issue in which CASE...WHEN statements would directly copy SIValue outputs without first changing their ownership, which caused memory errors when the CASE expression evaluated to a heap-allocated result.
