### PR TITLE
query validation should not check if procedure outputs been defined

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -47,16 +47,7 @@ static void _AST_GetIdentifiers(const cypher_astnode_t *node, rax *identifiers) 
 	}
 
 	uint child_count = cypher_astnode_nchildren(node);
-
-	/* In case current node is of type projection
-	 * inspect first child only,
-	 * @10  20..26  > > > projection           expression=@11, alias=@14
-	 * @11  20..26  > > > > apply              @12(@13)
-	 * @12  20..23  > > > > > function name    `max`
-	 * @13  24..25  > > > > > identifier       `z`
-	 * @14  20..26  > > > > identifier         `max(z)` */
 	cypher_astnode_type_t type = cypher_astnode_type(node);
-	if(type == CYPHER_AST_PROJECTION) child_count = 1;
 
 	/* In case current node is of type CALL
 	 * Process procedure call arguments, those should be defined prior
@@ -70,6 +61,15 @@ static void _AST_GetIdentifiers(const cypher_astnode_t *node, rax *identifiers) 
 		}
 		return;
 	}
+
+	/* In case current node is of type projection
+	 * inspect first child only,
+	 * @10  20..26  > > > projection           expression=@11, alias=@14
+	 * @11  20..26  > > > > apply              @12(@13)
+	 * @12  20..23  > > > > > function name    `max`
+	 * @13  24..25  > > > > > identifier       `z`
+	 * @14  20..26  > > > > identifier         `max(z)` */
+	if(type == CYPHER_AST_PROJECTION) child_count = 1;
 
 	for(uint i = 0; i < child_count; i++) {
 		const cypher_astnode_t *child = cypher_astnode_get_child(node, i);

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -313,3 +313,34 @@ class testQueryValidationFlow(FlowTestsBase):
         actual_result = redis_graph.query(query)
         expected_result = [[34]]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    # Validate procedure call refrences and definitions
+    def test22_procedure_validations(self):
+        try:
+            # procedure call refering to a none existing alias 'n'
+            query = """CALL db.idx.fulltext.queryNodes(n, 'B') YIELD node RETURN node"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError as e:
+            # Expecting an error.
+            assert("not defined" in e.message)
+            pass
+
+        # refer to procedure call original output when output is aliased.
+        try:
+            query = """CALL db.idx.fulltext.queryNodes('A', 'B') YIELD node AS n RETURN node"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError as e:
+            # Expecting an error.
+            assert("not defined" in e.message)
+            pass
+
+        # valid procedure call, no output aliasing
+        query = """CALL db.idx.fulltext.queryNodes('A', 'B') YIELD node RETURN node"""
+        redis_graph.query(query)
+
+        # valid procedure call, output aliasing
+        query = """CALL db.idx.fulltext.queryNodes('A', 'B') YIELD node AS n RETURN n"""
+        redis_graph.query(query)
+


### PR DESCRIPTION
#1405

When performing query validations, we shouldn't treat procedure outputs as elements that need to be defined
Moreover there should be a follow-up PR that validates that procedure outputs haven't been previously defined, e.g.

`WITH 1 AS node CALL db.idx.fulltext.queryNodes('Movie', 'Book') YIELD node RETURN node`

and

`WITH 1 AS m CALL db.idx.fulltext.queryNodes('Movie', 'Book') YIELD node AS m RETURN m`
