### PR TITLE
Fuzzy test crashes

### DIFF
--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -9,6 +9,7 @@
 #include "../RG.h"
 #include "funcs.h"
 #include "rax.h"
+#include "../errors.h"
 #include "./aggregate.h"
 #include "../util/arr.h"
 #include "./repository.h"
@@ -275,13 +276,10 @@ static bool _AR_EXP_ValidateInvocation(AR_FuncDesc *fdesc, SIValue *argv, uint a
 			expected_type = fdesc->types[i];
 		}
 		if(!(actual_type & expected_type)) {
-			const char *actual_type_str = SIType_ToString(actual_type);
-			const char *expected_type_str = SIType_ToString(expected_type);
 			/* TODO extend string-building logic to better express multiple acceptable types, like:
 			 * RETURN 'a' * 2
 			 * "Type mismatch: expected Float, Integer or Duration but was String" */
-			// Set the query-level error.
-			QueryCtx_SetError("Type mismatch: expected %s but was %s", expected_type_str, actual_type_str);
+			Error_SITypeMismatch(SIType_ToString(actual_type), SIType_ToString(expected_type));
 			return false;
 		}
 	}

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -279,7 +279,7 @@ static bool _AR_EXP_ValidateInvocation(AR_FuncDesc *fdesc, SIValue *argv, uint a
 			/* TODO extend string-building logic to better express multiple acceptable types, like:
 			 * RETURN 'a' * 2
 			 * "Type mismatch: expected Float, Integer or Duration but was String" */
-			Error_SITypeMismatch(SIType_ToString(actual_type), SIType_ToString(expected_type));
+			Error_SITypeMismatch(argv[i], expected_type);
 			return false;
 		}
 	}

--- a/src/arithmetic/arithmetic_expression_construct.c
+++ b/src/arithmetic/arithmetic_expression_construct.c
@@ -7,6 +7,7 @@
 #include "arithmetic_expression_construct.h"
 #include "../RG.h"
 #include "funcs.h"
+#include "../errors.h"
 #include "../query_ctx.h"
 #include "../util/rmalloc.h"
 #include "../ast/ast_build_filter_tree.h"
@@ -477,8 +478,7 @@ static AR_ExpNode *_AR_EXP_FromASTNode(const cypher_astnode_t *expr) {
 		   CYPHER_AST_PATTERN_COMPREHENSION
 		   CYPHER_AST_REDUCE
 		*/
-		const char *type_str = cypher_astnode_typestr(t);
-		QueryCtx_SetError("RedisGraph does not currently support the type '%s'", type_str);
+		Error_UnsupportedType(cypher_astnode_typestr(t));
 		return AR_EXP_NewConstOperandNode(SI_NullVal());
 	}
 

--- a/src/arithmetic/arithmetic_expression_construct.c
+++ b/src/arithmetic/arithmetic_expression_construct.c
@@ -478,7 +478,7 @@ static AR_ExpNode *_AR_EXP_FromASTNode(const cypher_astnode_t *expr) {
 		   CYPHER_AST_PATTERN_COMPREHENSION
 		   CYPHER_AST_REDUCE
 		*/
-		Error_UnsupportedType(cypher_astnode_typestr(t));
+		Error_UnsupportedASTNodeType(cypher_astnode_typestr(t));
 		return AR_EXP_NewConstOperandNode(SI_NullVal());
 	}
 

--- a/src/arithmetic/arithmetic_expression_construct.c
+++ b/src/arithmetic/arithmetic_expression_construct.c
@@ -478,7 +478,7 @@ static AR_ExpNode *_AR_EXP_FromASTNode(const cypher_astnode_t *expr) {
 		   CYPHER_AST_PATTERN_COMPREHENSION
 		   CYPHER_AST_REDUCE
 		*/
-		Error_UnsupportedASTNodeType(cypher_astnode_typestr(t));
+		Error_UnsupportedASTNodeType(expr);
 		return AR_EXP_NewConstOperandNode(SI_NullVal());
 	}
 

--- a/src/arithmetic/boolean_funcs/boolean_funcs.c
+++ b/src/arithmetic/boolean_funcs/boolean_funcs.c
@@ -5,6 +5,7 @@
 */
 
 #include "boolean_funcs.h"
+#include "../../errors.h"
 #include "../func_desc.h"
 #include "../../util/arr.h"
 #include "../../query_ctx.h"
@@ -79,8 +80,7 @@ SIValue AR_GT(SIValue *argv, int argc) {
 		return SI_NullVal();
 	} else if(disjointOrNull == DISJOINT) {
 		// Emit error when attempting to compare invalid types
-		QueryCtx_SetError("Type mismatch: expected %s but was %s", SIType_ToString(SI_TYPE(a)),
-						  SIType_ToString(SI_TYPE(b)));
+		Error_SITypeMismatch(SIType_ToString(SI_TYPE(a)), SIType_ToString(SI_TYPE(b)));
 		return SI_NullVal(); // The return doesn't matter, as the caller will check for errors.
 	}
 
@@ -93,8 +93,7 @@ SIValue AR_GE(SIValue *argv, int argc) {
 
 	// Emit error when attempting to compare invalid types
 	if(!SI_VALUES_ARE_COMPARABLE(a, b)) {
-		QueryCtx_SetError("Type mismatch: expected %s but was %s", SIType_ToString(SI_TYPE(a)),
-						  SIType_ToString(SI_TYPE(b)));
+		Error_SITypeMismatch(SIType_ToString(SI_TYPE(a)), SIType_ToString(SI_TYPE(b)));
 		return SI_NullVal(); // The return doesn't matter, as the caller will check for errors.
 	}
 
@@ -117,8 +116,7 @@ SIValue AR_LT(SIValue *argv, int argc) {
 		return SI_NullVal();
 	} else if(disjointOrNull == DISJOINT) {
 		// Emit error when attempting to compare invalid types
-		QueryCtx_SetError("Type mismatch: expected %s but was %s", SIType_ToString(SI_TYPE(a)),
-						  SIType_ToString(SI_TYPE(b)));
+		Error_SITypeMismatch(SIType_ToString(SI_TYPE(a)), SIType_ToString(SI_TYPE(b)));
 		return SI_NullVal(); // The return doesn't matter, as the caller will check for errors.
 	}
 
@@ -136,8 +134,7 @@ SIValue AR_LE(SIValue *argv, int argc) {
 		return SI_NullVal();
 	} else if(disjointOrNull == DISJOINT) {
 		// Emit error when attempting to compare invalid types
-		QueryCtx_SetError("Type mismatch: expected %s but was %s", SIType_ToString(SI_TYPE(a)),
-						  SIType_ToString(SI_TYPE(b)));
+		Error_SITypeMismatch(SIType_ToString(SI_TYPE(a)), SIType_ToString(SI_TYPE(b)));
 		return SI_NullVal(); // The return doesn't matter, as the caller will check for errors.
 	}
 
@@ -251,3 +248,4 @@ void Register_BooleanFuncs() {
 	func_desc = AR_FuncDescNew("is not null", AR_IS_NOT_NULL, 1, 1, types, true);
 	AR_RegFunc(func_desc);
 }
+

--- a/src/arithmetic/boolean_funcs/boolean_funcs.c
+++ b/src/arithmetic/boolean_funcs/boolean_funcs.c
@@ -80,7 +80,7 @@ SIValue AR_GT(SIValue *argv, int argc) {
 		return SI_NullVal();
 	} else if(disjointOrNull == DISJOINT) {
 		// Emit error when attempting to compare invalid types
-		Error_SITypeMismatch(SIType_ToString(SI_TYPE(a)), SIType_ToString(SI_TYPE(b)));
+		Error_SITypeMismatch(b, SI_TYPE(a));
 		return SI_NullVal(); // The return doesn't matter, as the caller will check for errors.
 	}
 
@@ -93,7 +93,7 @@ SIValue AR_GE(SIValue *argv, int argc) {
 
 	// Emit error when attempting to compare invalid types
 	if(!SI_VALUES_ARE_COMPARABLE(a, b)) {
-		Error_SITypeMismatch(SIType_ToString(SI_TYPE(a)), SIType_ToString(SI_TYPE(b)));
+		Error_SITypeMismatch(b, SI_TYPE(a));
 		return SI_NullVal(); // The return doesn't matter, as the caller will check for errors.
 	}
 
@@ -116,7 +116,7 @@ SIValue AR_LT(SIValue *argv, int argc) {
 		return SI_NullVal();
 	} else if(disjointOrNull == DISJOINT) {
 		// Emit error when attempting to compare invalid types
-		Error_SITypeMismatch(SIType_ToString(SI_TYPE(a)), SIType_ToString(SI_TYPE(b)));
+		Error_SITypeMismatch(b, SI_TYPE(a));
 		return SI_NullVal(); // The return doesn't matter, as the caller will check for errors.
 	}
 
@@ -134,7 +134,7 @@ SIValue AR_LE(SIValue *argv, int argc) {
 		return SI_NullVal();
 	} else if(disjointOrNull == DISJOINT) {
 		// Emit error when attempting to compare invalid types
-		Error_SITypeMismatch(SIType_ToString(SI_TYPE(a)), SIType_ToString(SI_TYPE(b)));
+		Error_SITypeMismatch(b, SI_TYPE(a));
 		return SI_NullVal(); // The return doesn't matter, as the caller will check for errors.
 	}
 

--- a/src/ast/cypher_whitelist.c
+++ b/src/ast/cypher_whitelist.c
@@ -8,6 +8,7 @@
 #include "../../deps/libcypher-parser/lib/src/operators.h" // TODO safe?
 #include "rax.h"
 #include <assert.h>
+#include "../errors.h"
 #include "../query_ctx.h"
 
 /* Whitelist of all accepted cypher_astnode types:
@@ -205,7 +206,7 @@ static AST_Validation _CypherWhitelist_ValidateQuery(const cypher_astnode_t *ele
 	cypher_astnode_type_t type = cypher_astnode_type(elem);
 	// Validate the type of the AST node
 	if(raxFind(_astnode_type_whitelist, (unsigned char *)&type, sizeof(type)) == raxNotFound) {
-		QueryCtx_SetError("RedisGraph does not currently support %s", cypher_astnode_typestr(type));
+		Error_UnsupportedType(cypher_astnode_typestr(type));
 		return AST_INVALID;
 	}
 
@@ -221,7 +222,7 @@ static AST_Validation _CypherWhitelist_ValidateQuery(const cypher_astnode_t *ele
 	}
 	if(operator) {
 		if(raxFind(_operator_whitelist, (unsigned char *)operator, sizeof(*operator)) == raxNotFound) {
-			QueryCtx_SetError("RedisGraph does not currently support %s", operator->str);
+			Error_UnsupportedType(operator->str);
 			return AST_INVALID;
 		}
 	}

--- a/src/ast/cypher_whitelist.c
+++ b/src/ast/cypher_whitelist.c
@@ -206,7 +206,7 @@ static AST_Validation _CypherWhitelist_ValidateQuery(const cypher_astnode_t *ele
 	cypher_astnode_type_t type = cypher_astnode_type(elem);
 	// Validate the type of the AST node
 	if(raxFind(_astnode_type_whitelist, (unsigned char *)&type, sizeof(type)) == raxNotFound) {
-		Error_UnsupportedASTNodeType(cypher_astnode_typestr(type));
+		Error_UnsupportedASTNodeType(elem);
 		return AST_INVALID;
 	}
 
@@ -222,7 +222,7 @@ static AST_Validation _CypherWhitelist_ValidateQuery(const cypher_astnode_t *ele
 	}
 	if(operator) {
 		if(raxFind(_operator_whitelist, (unsigned char *)operator, sizeof(*operator)) == raxNotFound) {
-			Error_UnsupportedASTNodeType(operator->str);
+			Error_UnsupportedASTOperator(operator);
 			return AST_INVALID;
 		}
 	}

--- a/src/ast/cypher_whitelist.c
+++ b/src/ast/cypher_whitelist.c
@@ -206,7 +206,7 @@ static AST_Validation _CypherWhitelist_ValidateQuery(const cypher_astnode_t *ele
 	cypher_astnode_type_t type = cypher_astnode_type(elem);
 	// Validate the type of the AST node
 	if(raxFind(_astnode_type_whitelist, (unsigned char *)&type, sizeof(type)) == raxNotFound) {
-		Error_UnsupportedType(cypher_astnode_typestr(type));
+		Error_UnsupportedASTNodeType(cypher_astnode_typestr(type));
 		return AST_INVALID;
 	}
 
@@ -222,7 +222,7 @@ static AST_Validation _CypherWhitelist_ValidateQuery(const cypher_astnode_t *ele
 	}
 	if(operator) {
 		if(raxFind(_operator_whitelist, (unsigned char *)operator, sizeof(*operator)) == raxNotFound) {
-			Error_UnsupportedType(operator->str);
+			Error_UnsupportedASTNodeType(operator->str);
 			return AST_INVALID;
 		}
 	}

--- a/src/errors.c
+++ b/src/errors.c
@@ -1,0 +1,29 @@
+#include "errors.h"
+#include "util/arr.h"
+#include "query_ctx.h"
+#include "util/rax_extensions.h"
+
+void Error_InvalidFilterPlacement(rax *entitiesRax) {
+	// Something is wrong - could not find a matching op where all references are solved.
+	raxIterator it;
+	raxStart(&it, entitiesRax);
+	// Retrieve the first key in the rax.
+	raxSeek(&it, "^", NULL, 0);
+	raxNext(&it);
+	// Build invalid entity string on the stack to add null terminator.
+	char *invalid_entity[it.key_len + 1];
+	memcpy(invalid_entity, it.key, it.key_len);
+	invalid_entity[it.key_len] = 0;
+	// Emit compile-time error.
+	QueryCtx_SetError("Unable to resolve filtered alias '%s'", invalid_entity);
+	raxFree(entitiesRax);
+}
+
+inline void Error_SITypeMismatch(const char *received, const char *expected) {
+	QueryCtx_SetError("Type mismatch: expected %s but was %s", expected, received);
+}
+
+inline void Error_UnsupportedType(const char *type) {
+	QueryCtx_SetError("RedisGraph does not currently support %s", type);
+}
+

--- a/src/errors.c
+++ b/src/errors.c
@@ -11,7 +11,7 @@ void Error_InvalidFilterPlacement(rax *entitiesRax) {
 	raxSeek(&it, "^", NULL, 0);
 	raxNext(&it);
 	// Build invalid entity string on the stack to add null terminator.
-	char *invalid_entity[it.key_len + 1];
+	char invalid_entity[it.key_len + 1];
 	memcpy(invalid_entity, it.key, it.key_len);
 	invalid_entity[it.key_len] = 0;
 	// Emit compile-time error.

--- a/src/errors.c
+++ b/src/errors.c
@@ -1,9 +1,13 @@
+#include "RG.h"
 #include "errors.h"
 #include "util/arr.h"
 #include "query_ctx.h"
 #include "util/rax_extensions.h"
+#include "../deps/libcypher-parser/lib/src/operators.h"
 
 void Error_InvalidFilterPlacement(rax *entitiesRax) {
+	ASSERT(entitiesRax != NULL);
+
 	// Something is wrong - could not find a matching op where all references are solved.
 	raxIterator it;
 	raxStart(&it, entitiesRax);
@@ -19,12 +23,22 @@ void Error_InvalidFilterPlacement(rax *entitiesRax) {
 	raxFree(entitiesRax);
 }
 
-inline void Error_SITypeMismatch(SIValue received, SIType expected) {
+void Error_SITypeMismatch(SIValue received, SIType expected) {
 	QueryCtx_SetError("Type mismatch: expected %s but was %s", SIType_ToString(expected),
 					  SIType_ToString(SI_TYPE(received)));
 }
 
-inline void Error_UnsupportedASTNodeType(const char *type) {
-	QueryCtx_SetError("RedisGraph does not currently support %s", type);
+void Error_UnsupportedASTNodeType(const cypher_astnode_t *node) {
+	ASSERT(node != NULL);
+
+	cypher_astnode_type_t type = cypher_astnode_type(node);
+	const char *type_str = cypher_astnode_typestr(type);
+	QueryCtx_SetError("RedisGraph does not currently support %s", type_str);
+}
+
+void Error_UnsupportedASTOperator(const cypher_operator_t *op) {
+	ASSERT(op != NULL);
+
+	QueryCtx_SetError("RedisGraph does not currently support %s", op->str);
 }
 

--- a/src/errors.c
+++ b/src/errors.c
@@ -19,11 +19,12 @@ void Error_InvalidFilterPlacement(rax *entitiesRax) {
 	raxFree(entitiesRax);
 }
 
-inline void Error_SITypeMismatch(const char *received, const char *expected) {
-	QueryCtx_SetError("Type mismatch: expected %s but was %s", expected, received);
+inline void Error_SITypeMismatch(SIValue received, SIType expected) {
+	QueryCtx_SetError("Type mismatch: expected %s but was %s", SIType_ToString(expected),
+					  SIType_ToString(SI_TYPE(received)));
 }
 
-inline void Error_UnsupportedType(const char *type) {
+inline void Error_UnsupportedASTNodeType(const char *type) {
 	QueryCtx_SetError("RedisGraph does not currently support %s", type);
 }
 

--- a/src/errors.h
+++ b/src/errors.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2018-2020 Redis Labs Ltd. and Contributors
+ *
+ * This file is available under the Redis Labs Source Available License Agreement
+ */
+
+#pragma once
+
+#include <stddef.h>
+#include "rax.h"
+
+// Report an error in filter placement with the first unresolved entity.
+void Error_InvalidFilterPlacement(rax *entitiesRax);
+
+// Report an error when an SIValue resolves to an unhandled type.
+void Error_SITypeMismatch(const char *received, const char *expected);
+
+// Report an error on receiving an unhandled AST node type.
+void Error_UnsupportedType(const char *type);

--- a/src/errors.h
+++ b/src/errors.h
@@ -8,12 +8,13 @@
 
 #include <stddef.h>
 #include "rax.h"
+#include "value.h"
 
 // Report an error in filter placement with the first unresolved entity.
 void Error_InvalidFilterPlacement(rax *entitiesRax);
 
 // Report an error when an SIValue resolves to an unhandled type.
-void Error_SITypeMismatch(const char *received, const char *expected);
+void Error_SITypeMismatch(SIValue received, SIType expected);
 
 // Report an error on receiving an unhandled AST node type.
-void Error_UnsupportedType(const char *type);
+void Error_UnsupportedASTNodeType(const char *type);

--- a/src/errors.h
+++ b/src/errors.h
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include "rax.h"
 #include "value.h"
+#include "cypher-parser.h"
 
 // Report an error in filter placement with the first unresolved entity.
 void Error_InvalidFilterPlacement(rax *entitiesRax);
@@ -17,4 +18,8 @@ void Error_InvalidFilterPlacement(rax *entitiesRax);
 void Error_SITypeMismatch(SIValue received, SIType expected);
 
 // Report an error on receiving an unhandled AST node type.
-void Error_UnsupportedASTNodeType(const char *type);
+void Error_UnsupportedASTNodeType(const cypher_astnode_t *node);
+
+// Report an error on receiving an unhandled AST operator.
+void Error_UnsupportedASTOperator(const cypher_operator_t *op);
+

--- a/src/execution_plan/execution_plan_build/execution_plan_construct.h
+++ b/src/execution_plan/execution_plan_build/execution_plan_construct.h
@@ -34,6 +34,9 @@ void buildMergeOp(ExecutionPlan *plan, AST *ast, const cypher_astnode_t *clause,
 // Reduce a filter operation into an apply operation
 void ExecutionPlan_ReduceFilterToApply(ExecutionPlan *plan, OpFilter *filter);
 
+// Report an error in filter placement with a list of unmatched entities.
+void ExecutionPlan_FilterPlacementError(rax *entitiesRax);
+
 // Place filter ops at the appropriate positions within the op tree
 void ExecutionPlan_PlaceFilterOps(ExecutionPlan *plan, OpBase *root, const OpBase *recurse_limit,
 								  FT_FilterNode *ft);

--- a/src/execution_plan/execution_plan_build/execution_plan_construct.h
+++ b/src/execution_plan/execution_plan_build/execution_plan_construct.h
@@ -34,9 +34,6 @@ void buildMergeOp(ExecutionPlan *plan, AST *ast, const cypher_astnode_t *clause,
 // Reduce a filter operation into an apply operation
 void ExecutionPlan_ReduceFilterToApply(ExecutionPlan *plan, OpFilter *filter);
 
-// Report an error in filter placement with a list of unmatched entities.
-void ExecutionPlan_FilterPlacementError(rax *entitiesRax);
-
 // Place filter ops at the appropriate positions within the op tree
 void ExecutionPlan_PlaceFilterOps(ExecutionPlan *plan, OpBase *root, const OpBase *recurse_limit,
 								  FT_FilterNode *ft);

--- a/src/execution_plan/ops/op_cond_var_len_traverse.c
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.c
@@ -121,7 +121,7 @@ static Record CondVarLenTraverseConsume(OpBase *opBase) {
 		if(srcNode == NULL) {
 			/* The child Record may not contain the source node in scenarios like
 			 * a failed OPTIONAL MATCH. In this case, delete the Record and try again. */
-			OpBase_DeleteRecord(childRecord);
+			OpBase_DeleteRecord(op->r);
 			continue;
 		}
 

--- a/src/execution_plan/ops/op_cond_var_len_traverse.c
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.c
@@ -117,6 +117,14 @@ static Record CondVarLenTraverseConsume(OpBase *opBase) {
 		if(op->r) OpBase_DeleteRecord(op->r);
 		op->r = childRecord;
 
+		Node *srcNode = Record_GetNode(op->r, op->srcNodeIdx);
+		if(srcNode == NULL) {
+			/* The child Record may not contain the source node in scenarios like
+			 * a failed OPTIONAL MATCH. In this case, delete the Record and try again. */
+			OpBase_DeleteRecord(childRecord);
+			continue;
+		}
+
 		// Create edge relation type array on first call to consume.
 		if(!op->edgeRelationTypes) {
 			_setupTraversedRelations(op);
@@ -128,7 +136,6 @@ static Record CondVarLenTraverseConsume(OpBase *opBase) {
 		}
 
 		Node *destNode = NULL;
-		Node *srcNode = Record_GetNode(op->r, op->srcNodeIdx);
 		// The destination node is known in advance if we're performing an ExpandInto.
 		if(op->expandInto) destNode = Record_GetNode(op->r, op->destNodeIdx);
 

--- a/src/execution_plan/ops/op_unwind.c
+++ b/src/execution_plan/ops/op_unwind.c
@@ -43,7 +43,7 @@ static void _initList(OpUnwind *op) {
 	op->list = SI_NullVal(); // Null-set the list value to avoid memory errors if evaluation fails.
 	SIValue new_list = AR_EXP_Evaluate(op->exp, op->currentRecord);
 	if(SI_TYPE(new_list) != T_ARRAY) {
-		Error_SITypeMismatch("List", SIType_ToString(SI_TYPE(new_list)));
+		Error_SITypeMismatch(new_list, T_ARRAY);
 		SIValue_Free(new_list);
 		QueryCtx_RaiseRuntimeException();
 	}

--- a/src/execution_plan/ops/op_unwind.c
+++ b/src/execution_plan/ops/op_unwind.c
@@ -39,11 +39,14 @@ OpBase *NewUnwindOp(const ExecutionPlan *plan, AR_ExpNode *exp) {
 /* Evaluate list expression, raise runtime exception
  * if expression did not returned a list type value. */
 static void _initList(OpUnwind *op) {
-	op->list = AR_EXP_Evaluate(op->exp, op->currentRecord);
-	if(op->list.type != T_ARRAY) {
+	op->list = SI_NullVal(); // Null-set the list value to avoid memory errors if evaluation fails.
+	SIValue new_list = AR_EXP_Evaluate(op->exp, op->currentRecord);
+	if(SI_TYPE(new_list) != T_ARRAY) {
 		QueryCtx_SetError("Type mismatch: expected List but was %s", SIType_ToString(op->list.type));
 		QueryCtx_RaiseRuntimeException();
 	}
+	// Update the list value.
+	op->list = new_list;
 }
 
 static OpResult UnwindInit(OpBase *opBase) {
@@ -134,3 +137,4 @@ static void UnwindFree(OpBase *ctx) {
 		op->currentRecord = NULL;
 	}
 }
+

--- a/src/execution_plan/ops/op_unwind.c
+++ b/src/execution_plan/ops/op_unwind.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include "op_unwind.h"
+#include "../../errors.h"
 #include "../../query_ctx.h"
 #include "../../datatypes/array.h"
 #include "../../arithmetic/arithmetic_expression.h"
@@ -42,7 +43,8 @@ static void _initList(OpUnwind *op) {
 	op->list = SI_NullVal(); // Null-set the list value to avoid memory errors if evaluation fails.
 	SIValue new_list = AR_EXP_Evaluate(op->exp, op->currentRecord);
 	if(SI_TYPE(new_list) != T_ARRAY) {
-		QueryCtx_SetError("Type mismatch: expected List but was %s", SIType_ToString(op->list.type));
+		Error_SITypeMismatch("List", SIType_ToString(SI_TYPE(new_list)));
+		SIValue_Free(new_list);
 		QueryCtx_RaiseRuntimeException();
 	}
 	// Update the list value.

--- a/src/execution_plan/optimizations/compact_filters.c
+++ b/src/execution_plan/optimizations/compact_filters.c
@@ -5,6 +5,7 @@
 */
 
 #include "compact_filters.h"
+#include "../../query_ctx.h"
 #include "../ops/op_filter.h"
 #include "../../filter_tree/filter_tree.h"
 #include "../execution_plan_build/execution_plan_modify.h"
@@ -25,7 +26,11 @@ static void _removeTrueFilter(ExecutionPlan *plan, OpBase *op) {
 	assert(root->t == FT_N_EXP);
 	// Evaluate the expression, and check if it is a 'true' value.
 	SIValue bool_val = AR_EXP_Evaluate(root->exp.exp, NULL);
-	assert(SI_TYPE(bool_val) == T_BOOL);
+	SIType type = SI_TYPE(bool_val);
+	if(type != T_BOOL) {
+		QueryCtx_SetError("Expected boolean predicate but received %s", SIType_ToString(type));
+		return;
+	}
 	if(SIValue_IsTrue(bool_val)) {
 		ExecutionPlan_RemoveOp(plan, op);
 		OpBase_Free(op);

--- a/src/execution_plan/optimizations/compact_filters.c
+++ b/src/execution_plan/optimizations/compact_filters.c
@@ -5,6 +5,7 @@
 */
 
 #include "compact_filters.h"
+#include "../../RG.h"
 #include "../../query_ctx.h"
 #include "../ops/op_filter.h"
 #include "../../filter_tree/filter_tree.h"
@@ -12,23 +13,24 @@
 
 // Try to compact a filter.
 static inline bool _compactFilter(OpBase *op) {
-	assert(op->type == OPType_FILTER);
+	ASSERT(op->type == OPType_FILTER);
 	OpFilter *filter_op = (OpFilter *)op;
 	return FilterTree_Compact(filter_op->filterTree);
 }
 
 // In case the compacted filter resolved to 'true', remove it from the execution plan.
 static void _removeTrueFilter(ExecutionPlan *plan, OpBase *op) {
-	assert(op->type == OPType_FILTER);
+	ASSERT(op->type == OPType_FILTER);
 	OpFilter *filter_op = (OpFilter *)op;
 	FT_FilterNode *root = filter_op->filterTree;
 	// We can only have a contant expression in this point (after compaction).
-	assert(root->t == FT_N_EXP);
+	ASSERT(root->t == FT_N_EXP);
 	// Evaluate the expression, and check if it is a 'true' value.
 	SIValue bool_val = AR_EXP_Evaluate(root->exp.exp, NULL);
 	SIType type = SI_TYPE(bool_val);
 	if(type != T_BOOL) {
 		QueryCtx_SetError("Expected boolean predicate but received %s", SIType_ToString(type));
+		SIValue_Free(bool_val);
 		return;
 	}
 	if(SIValue_IsTrue(bool_val)) {

--- a/tests/flow/test_optimizations_plan.py
+++ b/tests/flow/test_optimizations_plan.py
@@ -399,3 +399,8 @@ class testOptimizationsPlan(FlowTestsBase):
         # traversal from a to b shouldn't be effected by the limit.
         self.env.assertNotIn("Conditional Traverse | (a)->(b) | Records produced: 64", profile)
 
+    # "WHERE true" predicates should not build filter ops.
+    def test24_compact_true_predicates(self):
+        query = """MATCH (a) WHERE true RETURN a"""
+        executionPlan = graph.execution_plan(query)
+        self.env.assertNotIn("Filter", executionPlan)

--- a/tests/flow/test_optional_match.py
+++ b/tests/flow/test_optional_match.py
@@ -262,6 +262,16 @@ class testOptionalFlow(FlowTestsBase):
         self.env.assertEquals(actual_result.result_set, expected_result)
 
         query = """OPTIONAL MATCH (n {v: 'v1'}) OPTIONAL MATCH (m {v: 'v2'}) WHERE (n)--(m) RETURN n.v, m.v"""
+
+    # Test placement of filters that don't rely on variable references.
+    def test21_optional_filters_without_references(self):
+        global redis_graph
+        query = """OPTIONAL MATCH (a {v: 'v1'}), (b {v: 'v2'}) WHERE false RETURN a, b"""
+        actual_result = redis_graph.query(query)
+        expected_result = [[None, None]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        query = """OPTIONAL MATCH (a {v: 'v1'}), (b {v: 'v2'}) WHERE true RETURN a.v, b.v"""
         actual_result = redis_graph.query(query)
         expected_result = [['v1', 'v2']]
         self.env.assertEquals(actual_result.result_set, expected_result)

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -344,3 +344,9 @@ class testQueryValidationFlow(FlowTestsBase):
         query = """CALL db.idx.fulltext.queryNodes('A', 'B') YIELD node AS n RETURN n"""
         redis_graph.query(query)
 
+    # Applying a filter for a non-boolean constant should raise a compile-time error.
+    def test23_invalid_constant_filter(self):
+        try:
+            query = """MATCH (a) WHERE 1 RETURN a"""
+            assert("Expected boolean predicate" in e.message)
+            pass

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -361,3 +361,14 @@ class testQueryValidationFlow(FlowTestsBase):
             # Expecting an error.
             assert("not defined" in e.message)
             pass
+
+    # Invalid filters in cartesian products should raise errors.
+    def test24_cartesian_product_invalid_filter(self):
+        try:
+            query = """MATCH p1=(), (n), ({prop: p1.path_val}) WHERE null RETURN *"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError as e:
+            # Expecting an error.
+            assert("Type mismatch: expected Node but was Path" in e.message)
+            pass

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -350,3 +350,14 @@ class testQueryValidationFlow(FlowTestsBase):
             query = """MATCH (a) WHERE 1 RETURN a"""
             assert("Expected boolean predicate" in e.message)
             pass
+
+    # Referencing a variable before defining it should raise a compile-time error.
+    def test23_reference_before_definition(self):
+        try:
+            query = """MATCH ({prop: reference}) MATCH (reference) RETURN *"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError as e:
+            # Expecting an error.
+            assert("not defined" in e.message)
+            pass

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -348,11 +348,14 @@ class testQueryValidationFlow(FlowTestsBase):
     def test23_invalid_constant_filter(self):
         try:
             query = """MATCH (a) WHERE 1 RETURN a"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError as e:
             assert("Expected boolean predicate" in e.message)
             pass
 
     # Referencing a variable before defining it should raise a compile-time error.
-    def test23_reference_before_definition(self):
+    def test24_reference_before_definition(self):
         try:
             query = """MATCH ({prop: reference}) MATCH (reference) RETURN *"""
             redis_graph.query(query)
@@ -363,7 +366,7 @@ class testQueryValidationFlow(FlowTestsBase):
             pass
 
     # Invalid filters in cartesian products should raise errors.
-    def test24_cartesian_product_invalid_filter(self):
+    def test25_cartesian_product_invalid_filter(self):
         try:
             query = """MATCH p1=(), (n), ({prop: p1.path_val}) WHERE null RETURN *"""
             redis_graph.query(query)

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -93,3 +93,15 @@ class testVariableLengthTraversals(FlowTestsBase):
         query = """MATCH (a)-[:not_knows*0..1]->(b) RETURN a"""
         actual_result = redis_graph.query(query)
         self.env.assertEquals(len(actual_result.result_set), 4)
+
+    # Test traversal with a possibly-null source.
+    def test08_optional_source(self):
+        query = """OPTIONAL MATCH (a:fake) OPTIONAL MATCH (a)-[*]->(b) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        actual_result = redis_graph.query(query)
+        expected_result = [[None, None]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        query = """OPTIONAL MATCH (a:node {name: 'A'}) OPTIONAL MATCH (a)-[*]->(b {name: 'B'}) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        actual_result = redis_graph.query(query)
+        expected_result = [['A', 'B']]
+        self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
This PR resolves a series of crashes identified by `CyphSem`, which can best be inferred by looking at the added tests.

The more significant changes include:
- Changing alias reference validations to be per-query rather than per-scope.
- Fix placement of constant filters (WHERE false) in OPTIONAL contexts.
- Add handling for NULL sources in variable-length traversals.
- Avoid memory errors when trying to clean up after UNWINDing an invalid list.