### PR TITLE
Fuzzy test crashes 2

### DIFF
--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -145,7 +145,7 @@ AR_ExpNode *AR_EXP_NewVariableOperandNode(const char *alias) {
 }
 
 AR_ExpNode *AR_EXP_NewAttributeAccessNode(AR_ExpNode *entity,
-		const char *attr) {
+										  const char *attr) {
 
 	ASSERT(attr != NULL);
 	ASSERT(entity != NULL);
@@ -156,7 +156,7 @@ AR_ExpNode *AR_EXP_NewAttributeAccessNode(AR_ExpNode *entity,
 
 	GraphContext *gc = QueryCtx_GetGraphCtx();
 	SIValue prop_idx = SI_LongVal(ATTRIBUTE_NOTFOUND);
-	SIValue prop_name = SI_ConstStringVal((char*)attr);
+	SIValue prop_name = SI_ConstStringVal((char *)attr);
 	Attribute_ID idx = GraphContext_GetAttributeID(gc, attr);
 
 	if(idx != ATTRIBUTE_NOTFOUND) prop_idx = SI_LongVal(idx);
@@ -576,6 +576,17 @@ bool AR_EXP_IsAttribute(const AR_ExpNode *exp, char **attr) {
 	}
 
 	return true;
+}
+
+bool AR_EXP_ReturnsBoolean(const AR_ExpNode *exp) {
+	ASSERT(exp != NULL && exp->type != AR_EXP_UNKNOWN);
+
+	// If the node does not represent a constant, assume it returns a boolean.
+	// TODO We can add greater introspection in the future if required.
+	if(exp->type == AR_EXP_OP) return true;
+
+	// Operand node, return true if it is a boolean or NULL constant.
+	return (exp->operand.type == AR_EXP_CONSTANT && SI_TYPE(exp->operand.constant) & (T_BOOL | T_NULL));
 }
 
 void _AR_EXP_ToString(const AR_ExpNode *root, char **str, size_t *str_size,

--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -586,7 +586,12 @@ bool AR_EXP_ReturnsBoolean(const AR_ExpNode *exp) {
 	if(exp->type == AR_EXP_OP) return true;
 
 	// Operand node, return true if it is a boolean or NULL constant.
-	return (exp->operand.type == AR_EXP_CONSTANT && SI_TYPE(exp->operand.constant) & (T_BOOL | T_NULL));
+	if(exp->operand.type == AR_EXP_CONSTANT) {
+		return (SI_TYPE(exp->operand.constant) & (T_BOOL | T_NULL));
+	}
+
+	// Node is a variable or parameter, whether it evaluates to boolean cannot be determined now.
+	return true;
 }
 
 void _AR_EXP_ToString(const AR_ExpNode *root, char **str, size_t *str_size,

--- a/src/arithmetic/arithmetic_expression.h
+++ b/src/arithmetic/arithmetic_expression.h
@@ -155,6 +155,10 @@ bool AR_EXP_IsParameter(const AR_ExpNode *exp);
  * sets 'attr' to attribute name if provided. */
 bool AR_EXP_IsAttribute(const AR_ExpNode *exp, char **attr);
 
+/* Returns true if the arithmetic expression returns
+ * a boolean value and false otherwise. */
+bool AR_EXP_ReturnsBoolean(const AR_ExpNode *exp);
+
 /* Generate a heap-allocated name for an arithmetic expression.
  * This routine is only used to name ORDER BY expressions. */
 char *AR_EXP_BuildResolvedName(AR_ExpNode *root);

--- a/src/ast/ast_build_filter_tree.c
+++ b/src/ast/ast_build_filter_tree.c
@@ -86,7 +86,6 @@ static FT_FilterNode *_convertBinaryOperator(const cypher_astnode_t *op_node) {
 	switch(op) {
 	case OP_OR:
 	case OP_AND:
-	case OP_NOT:
 	case OP_EQUAL:
 	case OP_NEQUAL:
 	case OP_LT:
@@ -97,6 +96,9 @@ static FT_FilterNode *_convertBinaryOperator(const cypher_astnode_t *op_node) {
 		lhs = cypher_ast_binary_operator_get_argument1(op_node);
 		rhs = cypher_ast_binary_operator_get_argument2(op_node);
 		return _CreateFilterSubtree(op, lhs, rhs);
+	case OP_NOT:
+		QueryCtx_SetError("Invalid usage of 'NOT' filter with expressions on left and right sides.");
+		return NULL;
 	default:
 		return FilterTree_CreateExpressionFilter(AR_EXP_FromASTNode(op_node));
 	}
@@ -116,21 +118,7 @@ static FT_FilterNode *_convertUnaryOperator(const cypher_astnode_t *op_node) {
 	}
 }
 
-static FT_FilterNode *_convertApplyOperator(const cypher_astnode_t *op_node) {
-	return FilterTree_CreateExpressionFilter(AR_EXP_FromASTNode(op_node));
-}
-
-static FT_FilterNode *_convertTrueOperator() {
-	AR_ExpNode *exp = AR_EXP_NewConstOperandNode(SI_BoolVal(true));
-	return FilterTree_CreateExpressionFilter(exp);
-}
-
-static FT_FilterNode *_convertFalseOperator() {
-	AR_ExpNode *exp = AR_EXP_NewConstOperandNode(SI_BoolVal(false));
-	return FilterTree_CreateExpressionFilter(exp);
-}
-
-static FT_FilterNode *_convertIntegerOperator(const cypher_astnode_t *expr) {
+static FT_FilterNode *_convertOperator(const cypher_astnode_t *expr) {
 	AR_ExpNode *exp = AR_EXP_FromASTNode(expr);
 	return FilterTree_CreateExpressionFilter(exp);
 }
@@ -238,23 +226,10 @@ FT_FilterNode *_FilterNode_FromAST(const cypher_astnode_t *expr) {
 		return _convertBinaryOperator(expr);
 	} else if(type == CYPHER_AST_UNARY_OPERATOR) {
 		return _convertUnaryOperator(expr);
-	} else if(type == CYPHER_AST_APPLY_OPERATOR) {
-		return _convertApplyOperator(expr);
-	} else if(type == CYPHER_AST_TRUE) {
-		return _convertTrueOperator();
-	} else if(type == CYPHER_AST_FALSE) {
-		return _convertFalseOperator();
-	} else if(type == CYPHER_AST_INTEGER) {
-		return _convertIntegerOperator(expr);
 	} else if(type == CYPHER_AST_PATTERN_PATH) {
 		return _convertPatternPath(expr);
 	} else {
-		/* Probably an invalid query
-		 * e.g. MATCH (u) where u.v NOT NULL RETURN u
-		 * this will cause the constructed tree to form an illegal structure
-		 * which will be caught later on by `FilterTree_Valid`
-		 * and set a compile-time error. */
-		return NULL;
+		return _convertOperator(expr);
 	}
 }
 
@@ -298,24 +273,8 @@ void AST_ConvertFilters(FT_FilterNode **root, const cypher_astnode_t *entity) {
 		node = _convertBinaryOperator(entity);
 	} else if(type == CYPHER_AST_UNARY_OPERATOR) {
 		node = _convertUnaryOperator(entity);
-	} else if(type == CYPHER_AST_APPLY_OPERATOR ||
-			  type == CYPHER_AST_ANY            ||
-			  type == CYPHER_AST_ALL            ||
-			  type == CYPHER_AST_LIST_COMPREHENSION) {
-		node = _convertApplyOperator(entity);
-	} else if(type == CYPHER_AST_TRUE) {
-		node = _convertTrueOperator();
-	} else if(type == CYPHER_AST_FALSE) {
-		node = _convertFalseOperator();
-	} else if(type == CYPHER_AST_INTEGER) {
-		node = _convertIntegerOperator(entity);
 	} else {
-		uint child_count = cypher_astnode_nchildren(entity);
-		for(uint i = 0; i < child_count; i++) {
-			const cypher_astnode_t *child = cypher_astnode_get_child(entity, i);
-			// Recursively continue searching
-			AST_ConvertFilters(root, child);
-		}
+		node = _convertOperator(entity);
 	}
 	if(node) _FT_Append(root, node);
 }
@@ -357,8 +316,7 @@ FT_FilterNode *AST_BuildFilterTree(AST *ast) {
 	}
 
 	if(!FilterTree_Valid(filter_tree)) {
-		// Invalid filter tree structure, set a compile-time error.
-		QueryCtx_SetError("Invalid filter statement.");
+		// Invalid filter tree structure, a compile-time error has been set.
 		FilterTree_Free(filter_tree);
 		return NULL;
 	}
@@ -370,7 +328,7 @@ FT_FilterNode *AST_BuildFilterTree(AST *ast) {
 }
 
 FT_FilterNode *AST_BuildFilterTreeFromClauses(const AST *ast,
-		const cypher_astnode_t **clauses, uint count) {
+											  const cypher_astnode_t **clauses, uint count) {
 	cypher_astnode_type_t type;
 	FT_FilterNode *filter_tree = NULL;
 	const cypher_astnode_t *predicate = NULL;
@@ -390,6 +348,12 @@ FT_FilterNode *AST_BuildFilterTreeFromClauses(const AST *ast,
 		}
 
 		if(predicate) AST_ConvertFilters(&filter_tree, predicate);
+	}
+
+	if(!FilterTree_Valid(filter_tree)) {
+		// Invalid filter tree structure, a compile-time error has been set.
+		FilterTree_Free(filter_tree);
+		return NULL;
 	}
 
 	// Apply De Morgan's laws

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1410,6 +1410,11 @@ static AST_Validation _ValidateUnion_Clauses(const AST *ast) {
 	// Require all RETURN clauses to perform the exact same projection.
 	uint *return_indices = AST_GetClauseIndices(ast, CYPHER_AST_RETURN);
 	uint return_clause_count = array_len(return_indices);
+	// We should have one more RETURN clause than we have UNION clauses.
+	if(return_clause_count != union_clause_count + 1) {
+			QueryCtx_SetError("Found %d UNION clauses but only %d RETURN clauses.", union_clause_count, return_clause_count);
+			return AST_INVALID;
+	}
 
 	const cypher_astnode_t *return_clause = cypher_ast_query_get_clause(ast->root, return_indices[0]);
 	uint proj_count = cypher_ast_return_nprojections(return_clause);

--- a/src/execution_plan/optimizations/compact_filters.c
+++ b/src/execution_plan/optimizations/compact_filters.c
@@ -6,6 +6,7 @@
 
 #include "compact_filters.h"
 #include "../../RG.h"
+#include "../../errors.h"
 #include "../../query_ctx.h"
 #include "../ops/op_filter.h"
 #include "../../filter_tree/filter_tree.h"
@@ -27,9 +28,9 @@ static void _removeTrueFilter(ExecutionPlan *plan, OpBase *op) {
 	ASSERT(root->t == FT_N_EXP);
 	// Evaluate the expression, and check if it is a 'true' value.
 	SIValue bool_val = AR_EXP_Evaluate(root->exp.exp, NULL);
-	SIType type = SI_TYPE(bool_val);
-	if(type != T_BOOL) {
-		QueryCtx_SetError("Expected boolean predicate but received %s", SIType_ToString(type));
+	if(SI_TYPE(bool_val) != T_BOOL) {
+		// Value did not resolve to boolean, emit an error.
+		Error_SITypeMismatch(bool_val, T_BOOL);
 		SIValue_Free(bool_val);
 		return;
 	}

--- a/src/execution_plan/optimizations/optimize_cartesian_product.c
+++ b/src/execution_plan/optimizations/optimize_cartesian_product.c
@@ -81,13 +81,13 @@ static void _optimize_cartesian_product(ExecutionPlan *plan, OpBase *cp) {
 		// Try to create a cartesian product, followed by the current filter.
 		OpFilter *filter_op = filter_ctx_arr[i].filter;
 		OpBase **solving_branches = _find_entities_solving_branches(filter_ctx_arr[i].entities, cp);
-		uint solving_branch_count = array_len(solving_branches);
-		if(solving_branches == NULL || solving_branch_count == 0) {
+		if(solving_branches == NULL) {
 			// Filter placement failed, return early.
 			array_free(filter_ctx_arr);
 			return;
 		}
 
+		uint solving_branch_count = array_len(solving_branches);
 		// In case this filter is solved by the entire cartesian product, it does not need to be repositioned.
 		if(solving_branch_count == cp->childCount) {
 			array_free(solving_branches);

--- a/src/execution_plan/optimizations/optimize_cartesian_product.c
+++ b/src/execution_plan/optimizations/optimize_cartesian_product.c
@@ -81,13 +81,13 @@ static void _optimize_cartesian_product(ExecutionPlan *plan, OpBase *cp) {
 		// Try to create a cartesian product, followed by the current filter.
 		OpFilter *filter_op = filter_ctx_arr[i].filter;
 		OpBase **solving_branches = _find_entities_solving_branches(filter_ctx_arr[i].entities, cp);
-		if(solving_branches == NULL) {
+		uint solving_branch_count = array_len(solving_branches);
+		if(solving_branches == NULL || solving_branch_count == 0) {
 			// Filter placement failed, return early.
 			array_free(filter_ctx_arr);
 			return;
 		}
 
-		uint solving_branch_count = array_len(solving_branches);
 		// In case this filter is solved by the entire cartesian product, it does not need to be repositioned.
 		if(solving_branch_count == cp->childCount) {
 			array_free(solving_branches);

--- a/tests/unit/test_filter_tree.cpp
+++ b/tests/unit/test_filter_tree.cpp
@@ -336,16 +336,6 @@ TEST_F(FilterTreeTest, NOTReduction) {
 	}
 }
 
-TEST_F(FilterTreeTest, InvalidTree) {
-	/* MATCH (u) where u.v NOT NULL RETURN u
-	 * is an invalid query,
-	 * should have been:
-	 * MATCH (u) where u.v IS NOT NULL RETURN u */
-	const char *query = "MATCH (u) where u.v NOT NULL RETURN u";
-	FT_FilterNode *tree = build_tree_from_query(query);
-	ASSERT_TRUE(tree == NULL);
-}
-
 TEST_F(FilterTreeTest, ContainsFunc) {
 	bool found = false;
 	FT_FilterNode *node = NULL;


### PR DESCRIPTION
Refactor FilterTree conversion/validation logic, introducing compile-time errors for #1410 and other offending queries like:
```
MATCH (a) WHERE NOT NOT "" RETURN *
MATCH (u) where u.v NOT NULL RETURN u
```

Adds validation to ensure that the number of UNION clauses match the number of RETURN clauses, solving crashes in cases like:
```
CREATE (:L {v: 1}) UNION MERGE (:M {v: 2})
```