### PR TITLE
Disallow traversal patterns outside of the appropriate clauses

### DIFF
--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -447,29 +447,14 @@ class testQueryValidationFlow(FlowTestsBase):
 
     # Encountering traversals as property values or ORDER BY expressions should raise compile-time errors.
     def test30_unexpected_traversals(self):
-        try:
-            query = """MATCH (a {prop: ()-[]->()}) RETURN a"""
-            redis_graph.query(query)
-            assert(False)
-        except redis.exceptions.ResponseError as e:
-            # Expecting an error.
-            assert("Encountered path traversal" in e.message)
-            pass
-
-        try:
-            query = """MATCH (a) RETURN a ORDER BY (a)-[]->()"""
-            redis_graph.query(query)
-            assert(False)
-        except redis.exceptions.ResponseError as e:
-            # Expecting an error.
-            assert("Encountered path traversal" in e.message)
-            pass
-
-        try:
-            query = """MATCH (a) RETURN (a)-[]->()"""
-            redis_graph.query(query)
-            assert(False)
-        except redis.exceptions.ResponseError as e:
-            # Expecting an error.
-            assert("Encountered path traversal" in e.message)
-            pass
+        queries = ["""MATCH (a {prop: ()-[]->()}) RETURN a""",
+                   """MATCH (a) RETURN a ORDER BY (a)-[]->()""",
+                   """MATCH (a) RETURN (a)-[]->()"""]
+        for query in queries:
+            try:
+                redis_graph.query(query)
+                assert(False)
+            except redis.exceptions.ResponseError as e:
+                # Expecting an error.
+                assert("Encountered path traversal" in e.message)
+                pass


### PR DESCRIPTION
Cypher allows traversal patterns to appear in a number of unexpected places, such as:
```
MATCH (a) RETURN (a)-[]->()
MATCH (a) RETURN a ORDER BY (a)-[]->()
MATCH (a {prop: ()-[]->()}) RETURN a
```
These constructions don't seem useful to me, and they often cause crashes because QueryGraph construction collects all paths in an AST:
https://github.com/RedisGraph/RedisGraph/blob/master/src/graph/query_graph.c#L301

This PR disallows all such constructions by introducing a whitelist of the AST nodes that can validly have traversals as their children.

Resolves #1428