### PR TITLE
Don't assert on failed MERGE updates

### DIFF
--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -66,7 +66,7 @@ static void _UpdateProperties(ResultSetStatistics *stats, EntityUpdateEvalCtx *u
 			// Get the type of the entity to update. If the expected entity was not
 			// found, make no updates but do not error.
 			RecordEntryType t = Record_GetType(r, update_ctx->record_idx);
-			if(t == REC_TYPE_UNKNOWN) {
+			if(t != REC_TYPE_NODE && t != REC_TYPE_EDGE) {
 				failed_updates++;
 				continue;
 			}

--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -53,6 +53,7 @@ static void _UpdateProperties(ResultSetStatistics *stats, EntityUpdateEvalCtx *u
 							  Record *records, uint record_count) {
 	assert(updates && record_count > 0);
 	uint update_count = array_len(updates);
+	uint failed_updates = 0;
 	GraphContext *gc = QueryCtx_GetGraphCtx();
 	// Lock everything.
 	QueryCtx_LockForCommit();
@@ -62,16 +63,21 @@ static void _UpdateProperties(ResultSetStatistics *stats, EntityUpdateEvalCtx *u
 		for(uint j = 0; j < update_count; j ++) { // For each pending update.
 			EntityUpdateEvalCtx *update_ctx = &updates[j];
 
-			// Retrieve the appropriate entry from the Record, make sure it's either a node or an edge.
+			// Get the type of the entity to update. If the expected entity was not
+			// found, make no updates but do not error.
 			RecordEntryType t = Record_GetType(r, update_ctx->record_idx);
-			assert(t == REC_TYPE_NODE || t == REC_TYPE_EDGE);
+			if(t == REC_TYPE_UNKNOWN) {
+				failed_updates++;
+				continue;
+			}
+
 			GraphEntity *ge = Record_GetGraphEntity(r, update_ctx->record_idx);
 
 			_UpdateProperty(r, ge, update_ctx); // Update the entity.
 			if(t == REC_TYPE_NODE) _UpdateIndices(gc, (Node *)ge); // Update indices if necessary.
 		}
 	}
-	if(stats) stats->properties_set += update_count * record_count;
+	if(stats) stats->properties_set += (update_count * record_count) - failed_updates;
 }
 
 //------------------------------------------------------------------------------

--- a/tests/flow/test_graph_merge.py
+++ b/tests/flow/test_graph_merge.py
@@ -534,3 +534,11 @@ class testGraphMergeFlow(FlowTestsBase):
         # Verify that no data was modified and no results were returned.
         self.env.assertEquals(result.nodes_created, 0)
         self.env.assertEquals(result.properties_set, 0)
+
+    def test26_merge_set_invalid_property(self):
+        redis_con = self.env.getConnection()
+        graph = Graph("M", redis_con)
+
+        query = """MATCH p=() MERGE () ON MATCH SET p.prop4 = 5"""
+        result = graph.query(query)
+        self.env.assertEquals(result.properties_set, 0)


### PR DESCRIPTION
This fix makes ON MATCH/CREATE SET behave the same as regular SET in the case of failed updates - https://github.com/RedisGraph/RedisGraph/blob/master/src/execution_plan/ops/op_update.c#L228-L231