### PR TITLE
Decode IDX_ANY as an exact-match index

### DIFF
--- a/src/schema/schema.c
+++ b/src/schema/schema.c
@@ -72,10 +72,8 @@ int Schema_AddIndex(Index **idx, Schema *s, const char *field, IndexType type) {
 		GraphContext *gc = QueryCtx_GetGraphCtx();
 		Attribute_ID fieldID = GraphContext_FindOrAddAttribute(gc, field);
 		if(Index_ContainsAttribute(_idx, fieldID)) return INDEX_FAIL;
-	}
-
-	// Index doesn't exists, create it.
-	if(!_idx) {
+	} else {
+		// Index doesn't exist, create it.
 		_idx = Index_New(s->name, type);
 		if(type == IDX_FULLTEXT) s->fulltextIdx = _idx;
 		else s->index = _idx;

--- a/src/serializers/decoders/prev/v7/decode_graph_schema.c
+++ b/src/serializers/decoders/prev/v7/decode_graph_schema.c
@@ -41,14 +41,8 @@ static Schema *_RdbLoadSchema(RedisModuleIO *rdb, SchemaType type) {
 		fields[i] = field;
 	}
 
-	if(adjust_for_idx_any) {
-		// Invalid IDX_ANY value found, increment all type values by 1.
-		for(uint i = 0; i < index_count; i++) {
-			types[i] += 1;
-		}
-	}
-
 	for(uint i = 0; i < index_count; i++) {
+		if(adjust_for_idx_any) types[i] += 1; // Adjust for invalid IDX_ANY value.
 		Schema_AddIndex(&idx, s, fields[i], types[i]);
 		RedisModule_Free(fields[i]);
 	}

--- a/src/serializers/decoders/prev/v7/decode_graph_schema.c
+++ b/src/serializers/decoders/prev/v7/decode_graph_schema.c
@@ -22,6 +22,7 @@ static Schema *_RdbLoadSchema(RedisModuleIO *rdb, SchemaType type) {
 	uint index_count = RedisModule_LoadUnsigned(rdb);
 	for(uint i = 0; i < index_count; i++) {
 		IndexType type = RedisModule_LoadUnsigned(rdb);
+		if(type == IDX_ANY) type = IDX_EXACT_MATCH;
 		char *field = RedisModule_LoadStringBuffer(rdb, NULL);
 
 		Schema_AddIndex(&idx, s, field, type);


### PR DESCRIPTION
In v2.0.19, the `IndexType` enum was extended with [IDX_ANY](https://github.com/RedisGraph/RedisGraph/blob/b16e1acfa88a41a936dcdcfee35feab28ffd23ac/src/index/index.h#L17). This should have been accompanied by an RDB version increase, as this enum is serialized and used to differentiate between exact and full-text indexes.

Since this did not happen, v7 RDBs may encode their types as `[IDX_EXACT_MATCH, IDX_FULLTEXT]` or `[IDX_ANY, IDX_EXACT_MATCH]`, depending on when they were created. This PR makes a partial fix to this problem by interpreting `IDX_ANY` in v7 as `IDX_EXACT_MATCH` - a perfect fix is impossible.

Since we have since incremented to v8 RDBs, this is not a problem newer RDB files can trigger.

Resolves #1472