### PR TITLE
Fix replacement of unindexed prop when set before indexed prop

### DIFF
--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -267,15 +267,20 @@ static void _EvalEntityUpdates(EntityUpdateCtx *ctx, GraphContext *gc,
 			break;
 		}
 
+		/* Retrieve the ID of the attribute being updated.
+		 * It is important that this is stored in a variable rather than referring to
+		 * the update_ctx because if we swap an indexed property context to the first position
+		 * in the next condition, the update_ctx reference will be incorrect. */
+		Attribute_ID attr_id = update_ctx->attribute_id;
 		/* Determine whether we must update the index for this set of updates.
 		 * If at least one property being updated is indexed, each node will be reindexed. */
-		Attribute_ID attr_id = update_ctx->attribute_id;
 		if(!update_index && label) {
 			// If the label-index combination has an index, we must reindex this entity.
 			update_index = GraphContext_GetIndex(gc, label, &attr_id, IDX_ANY) != NULL;
 			if(update_index && (i > 0)) {
 				/* Swap the current update expression with the first one
-				 * so that subsequent searches will find the index immediately. */
+				 * so that subsequent searches will find the index immediately.
+				 * Note that this invalidates further references to the update_ctx in this loop! */
 				EntityUpdateEvalCtx first = ctx->exps[0];
 				ctx->exps[0] = ctx->exps[i];
 				ctx->exps[i] = first;

--- a/src/execution_plan/ops/op_update.c
+++ b/src/execution_plan/ops/op_update.c
@@ -233,7 +233,7 @@ static void _EvalEntityUpdates(EntityUpdateCtx *ctx, GraphContext *gc,
 	// Make sure we're updating either a node or an edge.
 	if(t != REC_TYPE_NODE && t != REC_TYPE_EDGE) {
 		ErrorCtx_RaiseRuntimeException("Update error: alias '%s' did not resolve to a graph entity",
-						  ctx->alias);
+									   ctx->alias);
 	}
 
 	GraphEntity *entity = Record_GetGraphEntity(r, ctx->record_idx);
@@ -269,8 +269,8 @@ static void _EvalEntityUpdates(EntityUpdateCtx *ctx, GraphContext *gc,
 
 		/* Determine whether we must update the index for this set of updates.
 		 * If at least one property being updated is indexed, each node will be reindexed. */
+		Attribute_ID attr_id = update_ctx->attribute_id;
 		if(!update_index && label) {
-			Attribute_ID attr_id = update_ctx->attribute_id;
 			// If the label-index combination has an index, we must reindex this entity.
 			update_index = GraphContext_GetIndex(gc, label, &attr_id, IDX_ANY) != NULL;
 			if(update_index && (i > 0)) {
@@ -286,7 +286,7 @@ static void _EvalEntityUpdates(EntityUpdateCtx *ctx, GraphContext *gc,
 			.entity_type = type,
 			.new_value = new_value,
 			.update_index = update_index,
-			.attr_id = update_ctx->attribute_id,
+			.attr_id = attr_id,
 		};
 
 		if(type == GETYPE_EDGE) {


### PR DESCRIPTION
This PR resolves a bug in which, given a query like:
`MATCH (a) SET a.undindexed_prop = 5, b.indexed_prop = 10`
Both properties would be set to the indexed value of `10`.

This was triggered by assigning the unindexed property's ID to both updates when moving the indexed update to the first position.