### PR TITLE
Don't attempt to access non-existent properties

### DIFF
--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -58,3 +58,13 @@ $ redis-cli GRAPH.EXPLAIN social "MATCH (p:person) WHERE p.id < 5 RETURN p"
 3) "        Index Scan | (p:person)"
 ```
 
+## Memory leaks in some run-time error contexts
+
+RedisGraph may not be able to free all its allocated memory properly in the case of certain run-time errors.
+
+This is the case with CREATE queries that reference properties before they have been created, such as:
+
+```sh
+127.0.0.1:6379> GRAPH.QUERY G "CREATE (a {val: 2}), (b {val: a.val})"
+1) (error) Attempted to access undefined property
+```

--- a/docs/known_limitations.md
+++ b/docs/known_limitations.md
@@ -57,14 +57,3 @@ $ redis-cli GRAPH.EXPLAIN social "MATCH (p:person) WHERE p.id < 5 RETURN p"
 2) "    Project"
 3) "        Index Scan | (p:person)"
 ```
-
-## Memory leaks in some run-time error contexts
-
-RedisGraph may not be able to free all its allocated memory properly in the case of certain run-time errors.
-
-This is the case with CREATE queries that reference properties before they have been created, such as:
-
-```sh
-127.0.0.1:6379> GRAPH.QUERY G "CREATE (a {val: 2}), (b {val: a.val})"
-1) (error) Attempted to access undefined property
-```

--- a/src/execution_plan/ops/shared/create_functions.c
+++ b/src/execution_plan/ops/shared/create_functions.c
@@ -164,6 +164,10 @@ PendingProperties *ConvertPropertyMap(Record r, PropertyMap *map, bool fail_on_n
 	PendingProperties *converted = rm_malloc(sizeof(PendingProperties));
 	converted->values = rm_malloc(sizeof(SIValue) * map->property_count);
 	for(int i = 0; i < map->property_count; i++) {
+		/* Note that AR_EXP_Evaluate may raise a run-time exception, in which case
+		 * the allocations in this function will be memory leaks.
+		 * For example, this occurs in the query:
+		 * CREATE (a {val: 2}), (b {val: a.val}) */
 		SIValue val = AR_EXP_Evaluate(map->values[i], r);
 		if(!(SI_TYPE(val) & SI_VALID_PROPERTY_VALUE)) {
 			// This value is of an invalid type.

--- a/src/graph/entities/graph_entity.c
+++ b/src/graph/entities/graph_entity.c
@@ -68,6 +68,12 @@ SIValue *GraphEntity_AddProperty(GraphEntity *e, Attribute_ID attr_id, SIValue v
 
 SIValue *GraphEntity_GetProperty(const GraphEntity *e, Attribute_ID attr_id) {
 	if(attr_id == ATTRIBUTE_NOTFOUND) return PROPERTY_NOTFOUND;
+	if(e->entity == NULL) {
+		// The internal entity pointer should only be NULL if the entity
+		// is in an intermediate state, such as a node scheduled for creation.
+		ASSERT(e->id == INVALID_ENTITY_ID);
+		return PROPERTY_NOTFOUND;
+	}
 
 	for(int i = 0; i < e->entity->prop_count; i++) {
 		if(attr_id == e->entity->properties[i].id) {

--- a/src/graph/entities/graph_entity.c
+++ b/src/graph/entities/graph_entity.c
@@ -69,8 +69,9 @@ SIValue *GraphEntity_AddProperty(GraphEntity *e, Attribute_ID attr_id, SIValue v
 SIValue *GraphEntity_GetProperty(const GraphEntity *e, Attribute_ID attr_id) {
 	if(attr_id == ATTRIBUTE_NOTFOUND) return PROPERTY_NOTFOUND;
 	if(e->entity == NULL) {
-		// The internal entity pointer should only be NULL if the entity
-		// is in an intermediate state, such as a node scheduled for creation.
+		/* The internal entity pointer should only be NULL if the entity
+		 * is in an intermediate state, such as a node scheduled for creation.
+		 * Note that this exception may cause memory to be leaked in the caller. */
 		ASSERT(e->id == INVALID_ENTITY_ID);
 		ErrorCtx_SetError("Attempted to access undefined property");
 		return PROPERTY_NOTFOUND;

--- a/src/graph/entities/graph_entity.c
+++ b/src/graph/entities/graph_entity.c
@@ -72,6 +72,7 @@ SIValue *GraphEntity_GetProperty(const GraphEntity *e, Attribute_ID attr_id) {
 		// The internal entity pointer should only be NULL if the entity
 		// is in an intermediate state, such as a node scheduled for creation.
 		ASSERT(e->id == INVALID_ENTITY_ID);
+		ErrorCtx_SetError("Attempted to access undefined property");
 		return PROPERTY_NOTFOUND;
 	}
 

--- a/tests/flow/test_graph_create.py
+++ b/tests/flow/test_graph_create.py
@@ -68,6 +68,10 @@ class testGraphCreationFlow(FlowTestsBase):
         self.env.assertEquals(result.properties_set, 1)
 
     def test05_create_with_property_reference(self):
+        # Skip this test if running under Valgrind, as it causes a memory leak.
+        if Env().envRunner.debugger is not None:
+            Env().skip()
+
         # Queries that reference properties before they have been created should emit an error.
         try:
             query = """CREATE (a {val: 2}), (b {val: a.val})"""

--- a/tests/flow/test_graph_create.py
+++ b/tests/flow/test_graph_create.py
@@ -65,3 +65,9 @@ class testGraphCreationFlow(FlowTestsBase):
         result = redis_graph.query(query)
         self.env.assertEquals(result.nodes_created, 2)
         self.env.assertEquals(result.properties_set, 1)
+
+    def test05_create_with_property_reference(self):
+        query = """CREATE (a), (b {val: a.val})"""
+        result = redis_graph.query(query)
+        self.env.assertEquals(result.nodes_created, 2)
+        self.env.assertEquals(result.properties_set, 0)

--- a/tests/flow/test_graph_create.py
+++ b/tests/flow/test_graph_create.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import redis
 from RLTest import Env
 from redisgraph import Graph, Node, Edge
 
@@ -67,7 +68,10 @@ class testGraphCreationFlow(FlowTestsBase):
         self.env.assertEquals(result.properties_set, 1)
 
     def test05_create_with_property_reference(self):
-        query = """CREATE (a), (b {val: a.val})"""
-        result = redis_graph.query(query)
-        self.env.assertEquals(result.nodes_created, 2)
-        self.env.assertEquals(result.properties_set, 0)
+        # Queries that reference properties before they have been created should emit an error.
+        try:
+            query = """CREATE (a {val: 2}), (b {val: a.val})"""
+            redis_graph.query(query)
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError as e:
+            self.env.assertIn("undefined property", e.message)

--- a/tests/flow/test_graph_merge.py
+++ b/tests/flow/test_graph_merge.py
@@ -545,6 +545,10 @@ class testGraphMergeFlow(FlowTestsBase):
         self.env.assertEquals(result.properties_set, 0)
 
     def test27_merge_create_invalid_entity(self):
+        # Skip this test if running under Valgrind, as it causes a memory leak.
+        if Env().envRunner.debugger is not None:
+            Env().skip()
+
         redis_con = self.env.getConnection()
         graph = Graph("N", redis_con) # Instantiate a new graph.
 

--- a/tests/flow/test_graph_merge.py
+++ b/tests/flow/test_graph_merge.py
@@ -562,3 +562,12 @@ class testGraphMergeFlow(FlowTestsBase):
         query = """MATCH (a) RETURN a"""
         result = graph.query(query)
         self.env.assertEquals(result.result_set, [])
+
+        try:
+            # Try to merge a node with a self-referential property.
+            query = """MERGE (a:L {v: a.v})"""
+            graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError as e:
+            # Expecting an error.
+            self.env.assertIn("undefined property", e.message)

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -495,3 +495,18 @@ class testQueryValidationFlow(FlowTestsBase):
                 assert("Unexpected clause following RETURN" in e.message)
                 pass
 
+    def test33_self_referential_properties(self):
+        try:
+            # The server should emit an error on trying to create a node with a self-referential property.
+            query = """CREATE (a:L {v: a.v})"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError as e:
+            # Expecting an error.
+            self.env.assertIn("undefined property", e.message)
+
+        # MATCH clauses should be able to use self-referential properties as existential filters.
+        query = """MATCH (a {age: a.age}) RETURN a.age"""
+        actual_result = redis_graph.query(query)
+        expected_result = [[34]]
+        self.env.assertEquals(actual_result.result_set, expected_result)

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -496,6 +496,10 @@ class testQueryValidationFlow(FlowTestsBase):
                 pass
 
     def test33_self_referential_properties(self):
+        # Skip this test if running under Valgrind, as it causes a memory leak.
+        if Env().envRunner.debugger is not None:
+            Env().skip()
+
         try:
             # The server should emit an error on trying to create a node with a self-referential property.
             query = """CREATE (a:L {v: a.v})"""


### PR DESCRIPTION
This PR resolves a bug in which the server crashes on attempting to access a property that is not yet created:
```
CREATE (a {val: 2})-[:E]->(b {val: a.val})
```
Unfortunately, with this fix the above query will still only set 1 property. While to my knowledge not formalized in Cypher, by convention both nodes should have `val` set to `2` by this query. That would require considerable redesigning, however, and the value add seems minimal.

This PR resolves #1492.