### PR TITLE
Disallow assigning properties to complex types in MERGE SET

### DIFF
--- a/src/execution_plan/ops/op_merge.c
+++ b/src/execution_plan/ops/op_merge.c
@@ -40,6 +40,7 @@ static int _UpdateProperty(Record r, GraphEntity *ge, EntityUpdateEvalCtx *updat
 
 	// Emit an error and exit if we're trying to add an invalid type.
 	if(!(SI_TYPE(new_value) & SI_VALID_PROPERTY_VALUE)) {
+		res = 0;
 		Error_InvalidPropertyValue();
 		ErrorCtx_RaiseRuntimeException(NULL);
 		goto cleanup;

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -460,7 +460,8 @@ class testQueryValidationFlow(FlowTestsBase):
 
     def test31_set_invalid_property_type(self):
         queries = ["""MATCH (a) CREATE (:L {v: a})""",
-                   """MATCH (a), (b) WHERE b.age IS NOT NULL SET b.age = a"""]
+                   """MATCH (a), (b) WHERE b.age IS NOT NULL SET b.age = a""",
+                   """MERGE (a) ON MATCH SET a.age = a"""]
         for q in queries:
             try:
                 redis_graph.query(q)


### PR DESCRIPTION
Brings the logic of ON MATCH/CREATE SET into parity with SET and CREATE (changed in #1432).

The updated logic disallows the assignment of complex types like nodes to property values.
