### PR TITLE
Error on alias references in parameters

### DIFF
--- a/src/arithmetic/arithmetic_expression_construct.c
+++ b/src/arithmetic/arithmetic_expression_construct.c
@@ -116,8 +116,14 @@ static AR_ExpNode *_AR_EXP_FromIdentifierExpression(const cypher_astnode_t *expr
 }
 
 static AR_ExpNode *_AR_EXP_FromIdentifier(const cypher_astnode_t *expr) {
-	// check if the identifier is a named path identifier
 	AST *ast = QueryCtx_GetAST();
+	if(ast == NULL) {
+		// Attempted to access the AST before it has been constructed.
+		ErrorCtx_SetError("Attempted to access variable before it has been defined");
+		return AR_EXP_NewConstOperandNode(SI_NullVal());
+	}
+
+	// check if the identifier is a named path identifier
 	AnnotationCtx *named_paths_ctx =
 		AST_AnnotationCtxCollection_GetNamedPathsCtx(ast->anot_ctx_collection);
 

--- a/src/arithmetic/arithmetic_expression_construct.c
+++ b/src/arithmetic/arithmetic_expression_construct.c
@@ -118,7 +118,9 @@ static AR_ExpNode *_AR_EXP_FromIdentifierExpression(const cypher_astnode_t *expr
 static AR_ExpNode *_AR_EXP_FromIdentifier(const cypher_astnode_t *expr) {
 	AST *ast = QueryCtx_GetAST();
 	if(ast == NULL) {
-		// Attempted to access the AST before it has been constructed.
+		/* Attempted to access the AST before it has been constructed.
+		 * This can occur in scenarios like parameter evaluation:
+		 * CYPHER param=[a] MATCH (a) RETURN a */
 		ErrorCtx_SetError("Attempted to access variable before it has been defined");
 		return AR_EXP_NewConstOperandNode(SI_NullVal());
 	}

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -495,3 +495,13 @@ class testQueryValidationFlow(FlowTestsBase):
                 assert("Unexpected clause following RETURN" in e.message)
                 pass
 
+    # Parameters cannot reference aliases.
+    def test33_alias_reference_in_param(self):
+        try:
+            query = """CYPHER A=[a] RETURN 5"""
+            redis_graph.query(query)
+            assert(False)
+        except redis.exceptions.ResponseError as e:
+            # Expecting an error.
+            assert("Attempted to access variable" in e.message)
+            pass


### PR DESCRIPTION
Causes a compile-time error to be emitted when parameters refer to AST identifier nodes (unquoted strings).

Resolves #1502.