### PR TITLE
Fixes for zero-length traversals

### DIFF
--- a/src/arithmetic/algebraic_expression/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression.c
@@ -57,6 +57,97 @@ static AlgebraicExpression *_AlgebraicExpression_CloneOperand
 	return clone;
 }
 
+// Remove leftmost child node from 'root' if 'src' is set to true
+// rightmost child node otherwise
+static AlgebraicExpression *_AlgebraicExpression_RemoveOperand
+(
+	AlgebraicExpression **root, // Root from which to remove left most child.
+	bool src                    // Remove src operand if set, dest otherwise.
+) {
+	ASSERT(*root);
+	bool transpose                   = false;
+	AlgebraicExpression *ret         = NULL;
+	AlgebraicExpression *parent      = NULL;
+	AlgebraicExpression *current     = *root;
+	AlgebraicExpression *replacement = NULL;
+	AlgebraicExpression **stack      = array_new(AlgebraicExpression*, 0);
+
+	// search for operand
+	while(current->type == AL_OPERATION) {
+		stack = array_append(stack, current);
+		switch(current->operation.op) {
+		case AL_EXP_TRANSPOSE:
+			transpose = !transpose;
+			current = FIRST_CHILD(current); // transpose have only one child
+			break;
+		case AL_EXP_ADD:
+			// Addition order of operands is not effected by transpose
+			if(src) current = FIRST_CHILD(current);
+			else current = LAST_CHILD(current);
+			break;
+		case AL_EXP_MUL:
+			// Multiplication order of operands depends on transpose
+			// | transpose     | src     | get dest |
+			// | transpose     | not src | get src  |
+			// | not transpose | src     | get src  |
+			// | not transpose | not src | get dest |
+			if(transpose && src) current = LAST_CHILD(current);
+			else if(transpose && !src) current = FIRST_CHILD(current);
+			else if(!transpose && src) current = FIRST_CHILD(current);
+			else if(!transpose && !src) current = LAST_CHILD(current);
+
+			break;
+		default:
+			ASSERT("Unknown algebraic expression operation" && false);
+		}
+	}
+
+	ret = current;
+	ASSERT(current->type == AL_OPERAND);
+
+	// expression is just a single operand, set root to NULL
+	if(array_len(stack) == 0) *root = NULL;
+
+	/* propegate operand removal upward
+	 * when removing A from MUL(A,B) root should become B
+	 * when removing A from T(T(A)) root should become NULL
+	 * when removing A from ADD(MUL(T(A),B),C) root should become ADD(B,C) */
+
+	while(array_len(stack) > 0) {
+		parent = array_pop(stack);
+		_AlgebraicExpression_OperationRemoveChild(parent, current);
+
+		// do not free return value
+		if(current != ret) AlgebraicExpression_Free(current);
+
+		AL_EXP_OP op = parent->operation.op;
+		/* binary operation with a single child, replace operaion with child
+		 * removing A from A+B should become B */
+		if(op == AL_EXP_ADD || op == AL_EXP_MUL) {
+			if(AlgebraicExpression_ChildCount(parent) == 1) {
+				// replace operation with only child
+				replacement = _AlgebraicExpression_OperationRemoveDest(parent);
+				_AlgebraicExpression_InplaceRepurpose(parent, replacement);
+			}
+			// stop here, no need to propagate further
+			break;
+		}
+
+		current = parent;
+	}
+
+	// handle last parent situation, e.g. removing A from T(T(T(A)))
+	if(parent && parent->type == AL_OPERATION) {
+		if(AlgebraicExpression_ChildCount(parent) == 0) {
+			AlgebraicExpression_Free(parent);
+			*root = NULL;
+		}
+	}
+
+	array_free(stack);
+	return ret;
+}
+
 //------------------------------------------------------------------------------
 // AlgebraicExpression Node creation functions.
 //------------------------------------------------------------------------------
@@ -356,77 +447,8 @@ AlgebraicExpression *AlgebraicExpression_RemoveSource
 (
 	AlgebraicExpression **root  // Root from which to remove left most child.
 ) {
-	ASSERT(*root);
-	bool transpose = false;
-	AlgebraicExpression *parent = *root;
-	AlgebraicExpression *current = *root;
-	AlgebraicExpression *grandparent = NULL;
-
-	while(current->type == AL_OPERATION) {
-		grandparent = parent;
-		parent = current;
-		switch(current->operation.op) {
-		case AL_EXP_TRANSPOSE:
-			transpose = !transpose;
-			current = FIRST_CHILD(current); // transpose have only one child
-			break;
-		case AL_EXP_ADD:
-			// Addition order of operands is not effected by transpose
-			current = FIRST_CHILD(current);
-			break;
-		case AL_EXP_MUL:
-			// Multiplication order of operands depends on transpose
-			if(transpose) current = LAST_CHILD(current);
-			else current = FIRST_CHILD(current);
-			break;
-		default:
-			ASSERT("Unknown algebraic expression operation" && false);
-		}
-	}
-	ASSERT(current->type == AL_OPERAND);
-
-	if(parent == current) {
-		/* Expression is just a single operand
-		 * return operand and update root to NULL. */
-		*root = NULL;
-		return current;
-	}
-
-	switch(parent->operation.op) {
-	case AL_EXP_TRANSPOSE:
-		/* A subtree that consists of a transpose operation with an operand child
-		 * should be entirely removed, and the transpose's parent should be updated accordingly. */
-		parent = grandparent;
-		current = _AlgebraicExpression_OperationRemoveSource(parent);
-		break;
-	case AL_EXP_ADD:
-		// Addition is not modified by transposition, so always remove the source.
-		current = _AlgebraicExpression_OperationRemoveSource(parent);
-		break;
-	case AL_EXP_MUL:
-		/* Remove the destination if we're in a transposed context,
-		 * otherwise remove the source. */
-		if(transpose) current = _AlgebraicExpression_OperationRemoveDest(parent);
-		else current = _AlgebraicExpression_OperationRemoveSource(parent);
-		break;
-	default:
-		ASSERT("Unknown algebraic expression operation" && false);
-	}
-
-	uint child_count = AlgebraicExpression_ChildCount(parent);
-	if(child_count == 1) {
-		/* If we just previous operation only has one remaining child,
-		 * it can be replaced by that child:
-		 * MUL(A,B) after removing A will become just B
-		 * Currently, this point is unreachable for transpose ops,
-		 * as when we encounter a structure like:
-		 * MUL(T(A),B)
-		 * The entire T(A) subtree has already been freed. */
-		AlgebraicExpression *replacement = _AlgebraicExpression_OperationRemoveDest(parent);
-		_AlgebraicExpression_InplaceRepurpose(parent, replacement);
-	}
-
-	return current;
+	bool src = true;
+	return _AlgebraicExpression_RemoveOperand(root, src);
 }
 
 // Remove right most child node from root.
@@ -434,80 +456,8 @@ AlgebraicExpression *AlgebraicExpression_RemoveDest
 (
 	AlgebraicExpression **root  // Root from which to remove left most child.
 ) {
-	ASSERT(*root);
-	bool transpose = false;
-	AlgebraicExpression *parent = *root;
-	AlgebraicExpression *current = *root;
-	AlgebraicExpression *grandparent = NULL;
-
-	while(current->type == AL_OPERATION) {
-		grandparent = parent;
-		parent = current;
-		switch(current->operation.op) {
-		case AL_EXP_TRANSPOSE:
-			transpose = !transpose;
-			current = LAST_CHILD(current); // transpose have only one child
-			break;
-		case AL_EXP_ADD:
-			// Addition order of operands is not effected by transpose
-			current = LAST_CHILD(current);
-			break;
-		case AL_EXP_MUL:
-			// Multiplication order of operands depends on transpose
-			if(transpose) current = FIRST_CHILD(current);
-			else current = LAST_CHILD(current);
-			break;
-		default:
-			ASSERT("Unknown algebraic expression operation" && false);
-		}
-	}
-	ASSERT(current->type == AL_OPERAND);
-
-	if(parent == current) {
-		/* Expression is just a single operand
-		 * return operand and update root to NULL. */
-		*root = NULL;
-		return current;
-	}
-
-	switch(parent->operation.op) {
-	case AL_EXP_TRANSPOSE:
-		/* A subtree that consists of a transpose operation with an operand child
-		 * should be entirely removed, and the transpose's parent should be updated accordingly. */
-		parent = grandparent;
-		current = _AlgebraicExpression_OperationRemoveSource(parent);
-		break;
-	case AL_EXP_ADD:
-		// Addition is not modified by transposition, so always remove the destination.
-		current = _AlgebraicExpression_OperationRemoveDest(parent);
-		break;
-	case AL_EXP_MUL:
-		// Remove the source if we're in a transposed context,
-		// otherwise remove the destination.
-		if(transpose) {
-			current = _AlgebraicExpression_OperationRemoveSource(parent);
-		} else {
-			current = _AlgebraicExpression_OperationRemoveDest(parent);
-		}
-		break;
-	default:
-		ASSERT("Unknown algebraic expression operation" && false);
-	}
-
-	uint child_count = AlgebraicExpression_ChildCount(parent);
-	if(child_count == 1) {
-		/* If we just previous operation only has one remaining child,
-		 * it can be replaced by that child:
-		 * MUL(A,B) after removing A will become just B
-		 * Currently, this point is unreachable for transpose ops,
-		 * as when we encounter a structure like:
-		 * MUL(T(A),B)
-		 * The entire T(A) subtree has already been freed. */
-		AlgebraicExpression *replacement = _AlgebraicExpression_OperationRemoveDest(parent);
-		_AlgebraicExpression_InplaceRepurpose(parent, replacement);
-	}
-
-	return current;
+	bool src = false;
+	return _AlgebraicExpression_RemoveOperand(root, src);
 }
 
 /* Multiply root to the left with op.
@@ -591,7 +541,7 @@ void AlgebraicExpression_Free
 (
 	AlgebraicExpression *root  // Root node.
 ) {
-	ASSERT(root);
+	ASSERT(root != NULL);
 	switch(root->type) {
 	case AL_OPERATION:
 		_AlgebraicExpression_FreeOperation(root);

--- a/src/arithmetic/algebraic_expression/algebraic_expression.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression.c
@@ -361,7 +361,10 @@ AlgebraicExpression *AlgebraicExpression_RemoveSource
 	AlgebraicExpression *prev = *root;
 	AlgebraicExpression *current = *root;
 
-	while(current->type == AL_OPERATION) {
+	/* This loop iterates until it reaches an operand node or a transpose node
+	 * with an operand child. */
+	while(current->type == AL_OPERATION &&
+		  !(current->operation.op == AL_EXP_TRANSPOSE && FIRST_CHILD(current)->type == AL_OPERAND)) {
 		prev = current;
 		switch(current->operation.op) {
 		case AL_EXP_TRANSPOSE:
@@ -413,9 +416,9 @@ AlgebraicExpression *AlgebraicExpression_RemoveSource
 		 * it can be replaced by that child:
 		 * MUL(A,B) after removing A will become just B
 		 * Currently, this point is unreachable for transpose ops,
-		 * as at this point their child is always an operation.
-		 * If that changes, logic should be added such that:
-		 * TRANSPOSE(A) after removing A should become NULL. */
+		 * as when we encounter a structure like:
+		 * MUL(T(A),B)
+		 * The entire T(A) subtree has already been freed. */
 		AlgebraicExpression *replacement = _AlgebraicExpression_OperationRemoveDest(prev);
 		_AlgebraicExpression_InplaceRepurpose(prev, replacement);
 	}

--- a/src/arithmetic/algebraic_expression/utils.c
+++ b/src/arithmetic/algebraic_expression/utils.c
@@ -36,6 +36,34 @@ void _AlgebraicExpression_InplaceRepurpose
 	rm_free(replacement);
 }
 
+void _AlgebraicExpression_OperationRemoveChild
+(
+	AlgebraicExpression *parent,
+	const AlgebraicExpression *child
+) {
+	ASSERT(parent != NULL);
+	ASSERT(child != NULL);
+
+	if(parent->type != AL_OPERATION) return;
+
+	uint child_count = AlgebraicExpression_ChildCount(parent);
+	// no child nodes to remove
+	if(child_count == 0) return;
+
+	// search for child in parent
+	for(uint i = 0; i < child_count; i++) {
+		if(parent->operation.children[i] != child) continue;
+
+		// child found, remove it
+		// shift-left following children
+		for(uint j = i; j < child_count - 1; j++) {
+			parent->operation.children[j] = parent->operation.children[j+1];
+		}
+		array_pop(parent->operation.children);
+		break;
+	}
+}
+
 // Removes the rightmost direct child node of root.
 AlgebraicExpression *_AlgebraicExpression_OperationRemoveDest
 (

--- a/src/arithmetic/algebraic_expression/utils.h
+++ b/src/arithmetic/algebraic_expression/utils.h
@@ -28,6 +28,13 @@ void _AlgebraicExpression_InplaceRepurpose
 	AlgebraicExpression *replacement    // Replacement expression taking over `exp`.
 );
 
+// Remove 'child' from 'parent'
+void _AlgebraicExpression_OperationRemoveChild
+(
+	AlgebraicExpression *parent,      // parent to remove child from
+	const AlgebraicExpression *child  // child to remove
+);
+
 // Removes the rightmost direct child node of root.
 AlgebraicExpression *_AlgebraicExpression_OperationRemoveDest
 (

--- a/src/ast/ast_build_reference_map.c
+++ b/src/ast/ast_build_reference_map.c
@@ -60,6 +60,8 @@ static void _AST_MapOrderByReferences(AST *ast, const cypher_astnode_t *order_by
 static void _AST_MapReferencedNode(AST *ast, const cypher_astnode_t *node, bool force_mapping) {
 
 	const cypher_astnode_t *properties = cypher_ast_node_pattern_get_properties(node);
+	// Disregard empty property maps.
+	if(properties && cypher_astnode_nchildren(properties) == 0) properties = NULL;
 	// A node with inlined filters is always referenced for the FilterTree.
 	// (In the case of a CREATE path, these are properties being set)
 	if(properties || force_mapping) {
@@ -76,6 +78,8 @@ static void _AST_MapReferencedNode(AST *ast, const cypher_astnode_t *node, bool 
 static void _AST_MapReferencedEdge(AST *ast, const cypher_astnode_t *edge, bool force_mapping) {
 
 	const cypher_astnode_t *properties = cypher_ast_rel_pattern_get_properties(edge);
+	// Disregard empty property maps.
+	if(properties && cypher_astnode_nchildren(properties) == 0) properties = NULL;
 	// An edge with inlined filters is always referenced for the FilterTree.
 	// (In the case of a CREATE path, these are properties being set)
 	if(properties || force_mapping) {


### PR DESCRIPTION
This PR fixes 2 misbehaviors:
The query:
```
MATCH (a)-[]-(:L{})<-[*0]-(b:L) RETURN a
```
Caused the server to crash.

The above query produced a different execution plan than the logically equivalent variant:
```
MATCH (a)-[]-(:L)<-[*0]-(b:L) RETURN a
```

(The second query does not have the empty property map.)

However, there are still problems evaluating 0-hop traversals. If the intermediate node does have filters, as in:
```
CREATE (:L {v:1})-[:E]->(:L {v: 2})<-[:E]-(:L {v: 3})
MATCH (a)-[]-(:L{v: 2})<-[*0]-(b:L) RETURN a
```
No results will be returned.

The difference can be seen in the execution plans:

```
redis-cli GRAPH.EXPLAIN G "MATCH (a)-[]-(:L)<-[*0]-(b:L) RETURN a"
1) "Results"
2) "    Project"
3) "        Conditional Traverse | (b:L)->(a)"
4) "            Node By Label Scan | (b:L)"
```
```
redis-cli GRAPH.EXPLAIN G "MATCH (a)-[]-(:L{v: 2})<-[*0]-(b:L) RETURN a"
1) "Results"
2) "    Project"
3) "        Conditional Traverse | (anon_1:L)->(a)"
4) "            Conditional Traverse | (b:L)->(b:L)"
5) "                Filter"
6) "                    Node By Label Scan | (anon_1:L)"
```
