### PR TITLE
Don't attempt to normalize IN filters when utilizing indexes

### DIFF
--- a/src/execution_plan/optimizations/utilize_indices.c
+++ b/src/execution_plan/optimizations/utilize_indices.c
@@ -15,19 +15,6 @@
 // Filter normalization
 //------------------------------------------------------------------------------
 
-void _normalize_in_filter(FT_FilterNode *filter_tree) {
-	// Left child should be variadic, while the right child should be constant
-	AR_ExpNode *left_child = filter_tree->exp.exp->op.children[0];
-	AR_ExpNode *right_child = filter_tree->exp.exp->op.children[1];
-
-	if(left_child->operand.type == AR_EXP_CONSTANT) {
-		// Swap!
-		AR_ExpNode *temp = left_child;
-		filter_tree->exp.exp->op.children[0] = right_child;
-		filter_tree->exp.exp->op.children[1] = temp;
-	}
-}
-
 /* Modifies filter tree such that the left-hand side
  * is of type variadic and the right-hand side is constant. */
 void _normalize_filter(FT_FilterNode **filter) {
@@ -117,10 +104,7 @@ bool _simple_predicates(FT_FilterNode *filter) {
 		res = (t & (SI_NUMERIC | T_STRING | T_BOOL));
 		break;
 	case FT_N_EXP:
-		if(_isInFilter(filter)) {
-			_normalize_in_filter(filter);
-			res = _validateInExpression(filter->exp.exp);
-		}
+		res = (_isInFilter(filter) && _validateInExpression(filter->exp.exp));
 		break;
 	case FT_N_COND:
 		res = (_simple_predicates(filter->cond.left) && _simple_predicates(filter->cond.right));

--- a/tests/flow/test_index_scans.py
+++ b/tests/flow/test_index_scans.py
@@ -283,3 +283,30 @@ class testIndexScanFlow(FlowTestsBase):
         # One index scan should be performed.
         self.env.assertEqual(plan.count("Index Scan"), 1)
 
+    def test13_index_scan_utilize_array(self):
+        # Querying indexed properties using IN a constant array should utilize indexes.
+        query = "MATCH (a:person) WHERE a.age IN [34, 33] RETURN a.name ORDER BY a.name"
+        plan = redis_graph.execution_plan(query)
+        # One index scan should be performed.
+        self.env.assertEqual(plan.count("Index Scan"), 1)
+        query_result = redis_graph.query(query)
+        expected_result = [["Noam Nativ"],
+                           ["Omri Traub"]]
+        self.env.assertEquals(query_result.result_set, expected_result)
+
+        # Querying indexed properties using IN a generated array should utilize indexes.
+        query = "MATCH (a:person) WHERE a.age IN range(33, 34) RETURN a.name ORDER BY a.name"
+        plan = redis_graph.execution_plan(query)
+        # One index scan should be performed.
+        self.env.assertEqual(plan.count("Index Scan"), 1)
+        query_result = redis_graph.query(query)
+        expected_result = [["Noam Nativ"],
+                           ["Omri Traub"]]
+        self.env.assertEquals(query_result.result_set, expected_result)
+
+        # Querying indexed properties using IN a non-constant array should not utilize indexes.
+        query = "MATCH (a:person)-[]->(b) WHERE a.age IN b.arr RETURN a"
+        plan = redis_graph.execution_plan(query)
+        # No index scans should be performed.
+        self.env.assertEqual(plan.count("Label Scan"), 1)
+        self.env.assertEqual(plan.count("Index Scan"), 0)


### PR DESCRIPTION
This PR resolves a regression caused by the fix https://github.com/RedisGraph/RedisGraph/pull/1440#discussion_r526646463 .
Filters of the form `val IN array` do not require normalization.

Resolves #1526
