### PR TITLE
Ensure label data is up-to-date when initializing index scans

### DIFF
--- a/src/execution_plan/ops/op_index_scan.c
+++ b/src/execution_plan/ops/op_index_scan.c
@@ -5,6 +5,7 @@
 */
 
 #include "op_index_scan.h"
+#include "../../query_ctx.h"
 #include "shared/print_functions.h"
 
 /* Forward declarations. */
@@ -39,6 +40,14 @@ OpBase *NewIndexScanOp(const ExecutionPlan *plan, Graph *g, NodeScanCtx n, RSInd
 
 static OpResult IndexScanInit(OpBase *opBase) {
 	if(opBase->childCount > 0) OpBase_UpdateConsume(opBase, IndexScanConsumeFromChild);
+	IndexScan *op = (IndexScan *)opBase;
+	// Resolve label ID now if it is still unknown.
+	if(op->n.label_id == GRAPH_UNKNOWN_LABEL) {
+		GraphContext *gc = QueryCtx_GetGraphCtx();
+		Schema *schema = GraphContext_GetSchema(gc, op->n.label, SCHEMA_NODE);
+		ASSERT(schema != NULL);
+		op->n.label_id = schema->id;
+	}
 	return OP_OK;
 }
 

--- a/tests/flow/test_cache.py
+++ b/tests/flow/test_cache.py
@@ -202,7 +202,29 @@ class testCache(FlowTestsBase):
         self.env.assertEqual(1, len(result.result_set))
         self.env.assertEqual("Label", result.result_set[0][0].label)
 
-    def test11_test_skip_limit(self):
+    def test11_test_index_scan_update(self):
+        # In this scenario a label scan and Update op are made for non-existent label,
+        # then the label is created and an index are subsequently created.
+        # When the cached query is reused, it should rely on valid label data.
+        graph = Graph('Cache_test_index_scan_update', redis_con)
+        params = {'v': 1}
+        query = "MERGE (n:Label {v: 1}) SET n.v = $v"
+        result = graph.query(query, params)
+        self.env.assertEqual(0, len(result.result_set))
+        self.env.assertEqual(1, result.nodes_created)
+        self.env.assertEqual(1, result.labels_added)
+
+        query = "CREATE INDEX ON :Label(v)"
+        result = graph.query(query)
+        self.env.assertEqual(1, result.indices_created)
+
+        params = {'v': 5}
+        query = "MERGE (n:Label {v: 1}) SET n.v = $v"
+        result = graph.query(query, params)
+        self.env.assertEqual(0, result.nodes_created)
+        self.env.assertEqual(1, result.properties_set)
+
+    def test12_test_skip_limit(self):
         # Test using parameters for skip and limit values,
         # ensuring cached executions always use the parameterized values.
         graph = Graph('Cache_Empty_Key', redis_con)


### PR DESCRIPTION
This PR resolves an issue in which reusing a cached execution plan after introducing a label and index can cause an invalid memory access on label schema lookup.