### PR TITLE
Fix orphaned record in OpApply

### DIFF
--- a/src/execution_plan/ops/op_apply.c
+++ b/src/execution_plan/ops/op_apply.c
@@ -73,6 +73,8 @@ static Record ApplyConsume(OpBase *opBase) {
 		// Clone the bound Record and merge the RHS Record into it.
 		Record r = OpBase_CloneRecord(op->r);
 		Record_Merge(r, rhs_record);
+		// Delete the RHS record, as it has been merged into r.
+		OpBase_DeleteRecord(rhs_record);
 
 		return r;
 	}


### PR DESCRIPTION
Fixes an increase in memory consumption over time in OpApply. (Orphaned records are still ultimately freed in execution teardown.)