### PR TITLE
Enabled O3 compiler optimization on libcypher-parser ( we were overleading the default libcypher with O0 )

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -160,7 +160,7 @@ ifeq (,$(wildcard $(LIBCYPHER-PARSER)))
 	cd ../deps/libcypher-parser; \
 	sh ./autogen.sh; \
 	./configure --disable-shared;
-	$(MAKE) CFLAGS="-fPIC -DYY_BUFFER_SIZE=1048576" clean check -C ../deps/libcypher-parser
+	$(MAKE) CFLAGS="-O3 -fPIC -DYY_BUFFER_SIZE=1048576" clean check -C ../deps/libcypher-parser
 endif
 .PHONY: $(LIBCYPHER-PARSER)
 


### PR DESCRIPTION
Given we're passing `libcypher-parser` our `CFLAGS`, the default libcypher automake added optimization flag `-O2` is being overloaded with `-O0` ( given we don't pass one ). 

To validate this is the case, I've built current master with/without specifying an libcypher compiler optimization level -O3.

To test it I've ran memtier with a mixed reads/writes query pattern ( the queries we've been discussing this week ) and we've moved from 13.2K ops/sec with an p50 latency of 4.12ms ( including RTT ) to 14.3K ops/sec with an p50 latency of 3.83ms ( including RTT )

**without optimization ( O0 )**
```
1         Threads
50        Connections per thread
180       Seconds


ALL STATS
==========================================================================================================
Type                 Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------
Graph.ro_querys      1896.74         0.92285         0.90300         1.34300         1.54300      1650.39 
Graph.querys        11379.91         4.23873         4.31900        13.43900        19.83900      8024.06 
Totals              13276.64         3.76501         4.12700        12.86300        19.32700      9674.44 


```

**with O3**
```
1         Threads
50        Connections per thread
180       Seconds


ALL STATS
==========================================================================================================
Type                 Ops/sec    Avg. Latency     p50 Latency     p99 Latency   p99.9 Latency       KB/sec 
----------------------------------------------------------------------------------------------------------
Graph.ro_querys      2047.45         0.85183         0.83100         1.23100         1.48700      1781.52 
Graph.querys        12283.90         3.92728         3.99900        14.52700        22.39900      8661.53 
Totals              14331.35         3.48790         3.83900        14.20700        21.88700     10443.05 
```

--------

To confirm that is this setting that is really affecting positively the numbers I've collected the hotspots by CPU for both variations. Bellow are the CPU Time differences:
![image](https://user-images.githubusercontent.com/5832149/105598580-2efbf180-5d8c-11eb-9cbb-e7d8c4bc09a0.png)
![image](https://user-images.githubusercontent.com/5832149/105598651-33c0a580-5d8c-11eb-9305-52733be6e8b4.png)
