### PR TITLE
Add support for raw identifiers in map projections

### DIFF
--- a/src/arithmetic/arithmetic_expression_construct.c
+++ b/src/arithmetic/arithmetic_expression_construct.c
@@ -373,8 +373,7 @@ static AR_ExpNode *_AR_ExpFromMapProjection(const cypher_astnode_t *expr) {
 			prop = cypher_ast_map_projection_property_get_prop_name(selector);
 			prop_name = cypher_ast_prop_name_get_value(prop);
 
-			children[i * 2] =
-				AR_EXP_NewConstOperandNode(SI_ConstStringVal((char *)prop_name));
+			children[i * 2] = AR_EXP_NewConstOperandNode(SI_ConstStringVal((char *)prop_name));
 
 			children[i * 2 + 1] = AR_EXP_NewAttributeAccessNode(entity, prop_name);
 		} else if(t == CYPHER_AST_MAP_PROJECTION_LITERAL) {
@@ -384,10 +383,17 @@ static AR_ExpNode *_AR_ExpFromMapProjection(const cypher_astnode_t *expr) {
 			const cypher_astnode_t *literal_exp =
 				cypher_ast_map_projection_literal_get_expression(selector);
 
-			children[i * 2] =
-				AR_EXP_NewConstOperandNode(SI_ConstStringVal((char *)prop_name));
+			children[i * 2] = AR_EXP_NewConstOperandNode(SI_ConstStringVal((char *)prop_name));
 
 			children[i * 2 + 1] = AR_EXP_FromASTNode(literal_exp);
+		} else if(t == CYPHER_AST_MAP_PROJECTION_IDENTIFIER) {
+			// { v }
+			prop = cypher_ast_map_projection_identifier_get_identifier(selector);
+			prop_name = cypher_ast_identifier_get_name(prop);
+
+			children[i * 2] = AR_EXP_NewConstOperandNode(SI_ConstStringVal((char *)prop_name));
+
+			children[i * 2 + 1] = AR_EXP_FromASTNode(prop);
 		} else {
 			ASSERT("Unexpected AST node type" && false);
 		}

--- a/src/arithmetic/arithmetic_expression_construct.c
+++ b/src/arithmetic/arithmetic_expression_construct.c
@@ -393,7 +393,7 @@ static AR_ExpNode *_AR_ExpFromMapProjection(const cypher_astnode_t *expr) {
 
 			children[i * 2] = AR_EXP_NewConstOperandNode(SI_ConstStringVal((char *)prop_name));
 
-			children[i * 2 + 1] = AR_EXP_FromASTNode(prop);
+			children[i * 2 + 1] = AR_EXP_NewVariableOperandNode(prop_name);
 		} else {
 			ASSERT("Unexpected AST node type" && false);
 		}

--- a/tests/flow/test_map.py
+++ b/tests/flow/test_map.py
@@ -49,6 +49,13 @@ class testMap(FlowTestsBase):
                            [{'val': 3}]]
         self.env.assertEquals(query_result.result_set, expected_result)
 
+        query = """WITH 'lit' AS literal MATCH (a) RETURN a {.val, literal} ORDER BY a.val"""
+        query_result = redis_graph.query(query)
+        expected_result = [[{'val': 1, 'literal': 'lit'}],
+                           [{'val': 2, 'literal': 'lit'}],
+                           [{'val': 3, 'literal': 'lit'}]]
+        self.env.assertEquals(query_result.result_set, expected_result)
+
     # Validate behaviors of nested maps
     def test03_nested_maps(self):
         # Return a map with nesting


### PR DESCRIPTION
Support identifiers in map projections as in the following:
`MATCH (a) WITH a, a.prop AS p RETURN a {p}`