### PR TITLE
persist and retain records in create or update scenarios

### DIFF
--- a/src/execution_plan/ops/op_create.c
+++ b/src/execution_plan/ops/op_create.c
@@ -137,13 +137,15 @@ static Record CreateConsume(OpBase *opBase) {
 		// Pull data until child is depleted.
 		child = op->op.children[0];
 		while((r = OpBase_Consume(child))) {
-			/* Create entities. */
-			_CreateNodes(op, r);
-			_CreateEdges(op, r);
 			/* Persist scalars from previous ops before storing the record,
 			 * as those ops will be freed before the records are handed off. */
 			Record_PersistScalars(r);
-			// Save record for later use.
+
+			// create entities
+			_CreateNodes(op, r);
+			_CreateEdges(op, r);
+
+			// save record for later use
 			op->records = array_append(op->records, r);
 		}
 	}

--- a/tests/flow/test_entity_update.py
+++ b/tests/flow/test_entity_update.py
@@ -46,3 +46,8 @@ class testEntityUpdate(FlowTestsBase):
         result = graph.query("MATCH (n) SET n.x = NULL")
         self.env.assertEqual(result.properties_set, 1)
 
+    def test05_update_from_projection(self):
+        result = graph.query("MATCH (n) UNWIND ['Calgary'] as city_name SET n.name = city_name RETURN n.v, n.name")
+        expected_result = [[1, 'Calgary']]
+        self.env.assertEqual(result.properties_set, 1)
+        self.env.assertEqual(result.result_set, expected_result)

--- a/tests/flow/test_graph_create.py
+++ b/tests/flow/test_graph_create.py
@@ -46,6 +46,13 @@ class testGraphCreationFlow(FlowTestsBase):
         self.env.assertEquals(result.properties_set, 3)
         self.env.assertEquals(result.result_set, expected_result)
 
+        query = """UNWIND ['Vancouver', 'Portland', 'Calgary'] AS city CREATE (p:person {birthplace: city}) RETURN p.birthplace ORDER BY p.birthplace"""
+        result = redis_graph.query(query)
+        expected_result = [['Calgary'], ['Portland'], ['Vancouver']]
+        self.env.assertEquals(result.nodes_created, 3)
+        self.env.assertEquals(result.properties_set, 3)
+        self.env.assertEquals(result.result_set, expected_result)
+
     def test04_create_with_null_properties(self):
         query = """CREATE (a:L {v1: NULL, v2: 'prop'}) RETURN a"""
         result = redis_graph.query(query)


### PR DESCRIPTION
```
UNWIND ['Vancouver','Portland','Calgary'] as city_name CREATE (:City{name: city_name})
MATCH (n) UNWIND ['Calgary'] as city_name SET n.name = city_name
```

In both queries the string was deleted before being set.
Generally speaking I think we should revisit our primitives memory management, as the current solution is a bit wasteful.
