### PR TITLE
Use file streaming endpoint to parse queries

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -161,7 +161,7 @@ ifeq (,$(wildcard $(LIBCYPHER-PARSER)))
 	cd ../deps/libcypher-parser; \
 	sh ./autogen.sh; \
 	./configure --disable-shared;
-	$(MAKE) CFLAGS="-O3 -fPIC -DYY_BUFFER_SIZE=1048576" clean check -C ../deps/libcypher-parser
+	$(MAKE) CFLAGS="-O3 -fPIC" clean check -C ../deps/libcypher-parser
 endif
 .PHONY: $(LIBCYPHER-PARSER)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -161,7 +161,7 @@ ifeq (,$(wildcard $(LIBCYPHER-PARSER)))
 	cd ../deps/libcypher-parser; \
 	sh ./autogen.sh; \
 	./configure --disable-shared;
-	$(MAKE) CFLAGS="-O3 -fPIC" clean check -C ../deps/libcypher-parser
+	$(MAKE) CFLAGS="-O3 -fPIC -DYY_BUFFER_SIZE=1048576" clean check -C ../deps/libcypher-parser
 endif
 .PHONY: $(LIBCYPHER-PARSER)
 

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -35,12 +35,12 @@ static void _consume_function_call_expression(const cypher_astnode_t *node,
 
 		// Retrieve the function name and add to rax.
 		const cypher_astnode_t *func = (!apply_all) ?
-			cypher_ast_apply_operator_get_func_name(node) :
-			cypher_ast_apply_all_operator_get_func_name(node);
+									   cypher_ast_apply_operator_get_func_name(node) :
+									   cypher_ast_apply_all_operator_get_func_name(node);
 
 		const char *func_name = cypher_ast_function_name_get_value(func);
 		raxInsert(referred_funcs, (unsigned char *)func_name, strlen(func_name),
-				NULL, NULL);
+				  NULL, NULL);
 
 		if(apply_all) return;  // Apply All operators have no arguments.
 	}
@@ -161,7 +161,7 @@ void AST_ReferredFunctions(const cypher_astnode_t *root, rax *referred_funcs) {
 
 // Retrieve the first instance of the specified clause in the AST segment, if any.
 const cypher_astnode_t *AST_GetClause(const AST *ast,
-		cypher_astnode_type_t clause_type, uint *clause_idx) {
+									  cypher_astnode_type_t clause_type, uint *clause_idx) {
 	uint clause_count = cypher_ast_query_nclauses(ast->root);
 	for(uint i = 0; i < clause_count; i ++) {
 		const cypher_astnode_t *child = cypher_ast_query_get_clause(ast->root, i);
@@ -528,7 +528,9 @@ void AST_Free(AST *ast) {
 }
 
 cypher_parse_result_t *parse_query(const char *query) {
-	cypher_parse_result_t *result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
+	FILE *f = fmemopen((char *)query, strlen(query), "r");
+	cypher_parse_result_t *result = cypher_fparse(f, NULL, NULL, CYPHER_PARSE_ONLY_STATEMENTS);
+	fclose(f);
 	if(!result) return NULL;
 	if(AST_Validate_Query(result) != AST_VALID) {
 		parse_result_free(result);
@@ -539,7 +541,9 @@ cypher_parse_result_t *parse_query(const char *query) {
 
 
 cypher_parse_result_t *parse_params(const char *query, const char **query_body) {
-	cypher_parse_result_t *result = cypher_parse(query, NULL, NULL, CYPHER_PARSE_ONLY_PARAMETERS);
+	FILE *f = fmemopen((char *)query, strlen(query), "r");
+	cypher_parse_result_t *result = cypher_fparse(f, NULL, NULL, CYPHER_PARSE_ONLY_PARAMETERS);
+	fclose(f);
 	if(!result) return NULL;
 	if(AST_Validate_QueryParams(result) != AST_VALID) {
 		parse_result_free(result);

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -529,6 +529,6 @@ class testQueryValidationFlow(FlowTestsBase):
     # Test a query that allocates a large buffer.
     def test35_large_query(self):
         retval = "abcdef" * 1_000
-        query = """RETURN """ + "'" + retval + "'"
+        query = "RETURN " + "\"" + retval + "\""
         actual_result = redis_graph.query(query)
         self.env.assertEquals(actual_result.result_set[0][0], retval)

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -525,3 +525,10 @@ class testQueryValidationFlow(FlowTestsBase):
         actual_result = redis_graph.query(query)
         expected_result = [[34]]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    # Test a query that allocates a large buffer.
+    def test35_large_query(self):
+        retval = "abcdef" * 1_000
+        query = """RETURN """ + "'" + retval + "'"
+        actual_result = redis_graph.query(query)
+        self.env.assertEquals(actual_result.result_set[0][0], retval)


### PR DESCRIPTION
Resolves erroneous query rejections due to buffer overflows.
#760 #1486