### PR TITLE
Updated benchmark UPDATE-BASELINE to be less restrictive in the latency KPI

### DIFF
--- a/tests/benchmarks/updates_baseline.yml
+++ b/tests/benchmarks/updates_baseline.yml
@@ -14,5 +14,5 @@ clientconfig:
 queries:
   - { q: "MATCH (n) WHERE ID(n) = 0 SET n.v = n.v + 1", ratio: 1 }
 kpis:
-  - le: { $.OverallClientLatencies.Total.q50: 1.5 }
+  - le: { $.OverallClientLatencies.Total.q50: 2.0 }
   - ge: { $.OverallQueryRates.Total: 20000 }


### PR DESCRIPTION
…

Given we're still experimenting with the benchmarks CI KPI validation, this PR increases the `OverallClientLatencies.Total.q50` to be lower than 2.0 ( before was 1.5 ) so that we can collect further data and adjust afterwards...