### PR TITLE
Report 0 indices created on duplicate index creation

### DIFF
--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -377,10 +377,8 @@ int GraphContext_AddIndex(Index **idx, GraphContext *gc, const char *label,
 	if(s == NULL) s = GraphContext_AddSchema(gc, label, SCHEMA_NODE);
 
 	int res = Schema_AddIndex(idx, s, field, type);
-	if(res == INDEX_OK) {
-		ResultSet *result_set = QueryCtx_GetResultSet();
-		ResultSet_IndexCreated(result_set, res);
-	}
+	ResultSet *result_set = QueryCtx_GetResultSet();
+	ResultSet_IndexCreated(result_set, res);
 
 	return res;
 }


### PR DESCRIPTION
This PR solves a regression in which the attempted creation of pre-existing indexes currently does not mention indexes in execution statistics. This fix causes 0 indexes created to again be reported instead:
```
127.0.0.1:6379> GRAPH.QUERY G "CREATE INDEX ON :L(v)"
1) 1) "Indices created: 1"
   2) "Cached execution: 0"
   3) "Query internal execution time: 0.277525 milliseconds"
127.0.0.1:6379> GRAPH.QUERY G "CREATE INDEX ON :L(v)"
1) 1) "Indices created: 0"
   2) "Cached execution: 0"
   3) "Query internal execution time: 0.173453 milliseconds"
```