### PR TITLE
Emit a single error on failed GraphContext retrieval

### DIFF
--- a/src/commands/cmd_bulk_insert.c
+++ b/src/commands/cmd_bulk_insert.c
@@ -21,8 +21,8 @@ typedef struct {
 // batch, make sure graph key doesn't exists, fails if "BEGIN" token is present
 // and graph key 'graphname' already exists
 static int _MGraph_Bulk_Begin(RedisModuleCtx *ctx, RedisModuleString ***argv,
-		int *argc, RedisModuleString *rs_graph_name, const char *graphname,
-		bool *begin) {
+							  int *argc, RedisModuleString *rs_graph_name, const char *graphname,
+							  bool *begin) {
 	ASSERT(argv != NULL);
 	ASSERT(argc != NULL);
 	ASSERT(begin != NULL);
@@ -86,13 +86,17 @@ static void _MGraph_BulkInsert(void *args) {
 
 	bool begin = false;
 	if(_MGraph_Bulk_Begin(ctx, &argv, &argc, rs_graph_name, graphname, &begin)
-			!= BULK_OK) goto cleanup;
+	   != BULK_OK) goto cleanup;
 
 	// create key only if "BEGIN" token present
 	RedisModule_ThreadSafeContextLock(ctx);
 	{
 		gc = GraphContext_Retrieve(ctx, rs_graph_name, false, begin);
-		ASSERT(gc != NULL);
+		if(gc == NULL) {
+			// Failed to retrieve GraphContext; an error has been emitted.
+			RedisModule_ThreadSafeContextUnlock(ctx);
+			goto cleanup;
+		}
 	}
 	RedisModule_ThreadSafeContextUnlock(ctx);
 


### PR DESCRIPTION
This PR fixes a behavior introduced by #1596 in which 2 error messages are emitted instead of 1 (and an assertion fails). The problem occurs when a non-existent graph name is used in a GRAPH.BULK command that does not start with the BEGIN token.