### PR TITLE
Fix label retrieval on cached unknown value

### DIFF
--- a/src/graph/entities/node.h
+++ b/src/graph/entities/node.h
@@ -43,7 +43,8 @@ typedef struct {
  * If the Node is unlabeled, the return value will be GRAPH_NO_LABEL. */
 #define NODE_GET_LABEL_ID(n, g)                                                                   \
 ({                                                                                                \
-    if ((n)->labelID == GRAPH_NO_LABEL) (n)->labelID = Graph_GetNodeLabel((g), ENTITY_GET_ID(n)); \
+    if ((n)->labelID == GRAPH_NO_LABEL || (n)->labelID == GRAPH_UNKNOWN_LABEL)                    \
+         (n)->labelID = Graph_GetNodeLabel((g), ENTITY_GET_ID(n));                                \
     (n)->labelID;                                                                                 \
 })
 


### PR DESCRIPTION
QueryGraph nodes can be cached with a label of `GRAPH_UNKNOWN_LABEL`, indicating that the relevant schema does not exist. When this schema is later created, the cache is not updated, resulting in the label ID being emitted as `-2`. This can be seen in the sequence:
```
$ redis-cli GRAPH.QUERY  G "MATCH (a:L)-[:E]->(b:L2) RETURN b" --compact
1) 1) 1) (integer) 1
      2) "b"
2) (empty array)
3) 1) "Cached execution: 0"
   2) "Query internal execution time: 0.601046 milliseconds"

$ redis-cli GRAPH.QUERY  G "CREATE (:L)-[:E]->(:L2)"
1) 1) "Labels added: 2"
   2) "Nodes created: 2"
   3) "Relationships created: 1"
   4) "Cached execution: 0"
   5) "Query internal execution time: 1.474727 milliseconds"

$ redis-cli GRAPH.QUERY  G "MATCH (a:L)-[:E]->(b:L2) RETURN b" --compact
1) 1) 1) (integer) 1
      2) "b"
2) 1) 1) 1) (integer) 8
         2) 1) (integer) 1
            2) 1) (integer) -2
            3) (empty array)
3) 1) "Cached execution: 1"
   2) "Query internal execution time: 1.413175 milliseconds"
```
This problem is also resolved by #1561.

This PR resolves the issue reported in #1643.