### PR TITLE
drain thread pools before shutting down

### DIFF
--- a/src/module_event_handlers.c
+++ b/src/module_event_handlers.c
@@ -204,21 +204,22 @@ static void _PersistenceEventHandler(RedisModuleCtx *ctx, RedisModuleEvent eid, 
 // Perform clean-up upon server shutdown.
 static void _ShutdownEventHandler(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t subevent,
 		void *data) {
-	// Wait for all wokrer threads to exit.
-	// `thpool_destroy` will block for one second (at most)
-	// giving all worker threads a chance to exit.
-	// after which it will simply call `thread_destroy` and continue.
-	ThreadPools_Destroy();
-
 	// Server is shutting down, finalize GraphBLAS.
 	GrB_finalize();
 }
 
 static void _RegisterServerEvents(RedisModuleCtx *ctx) {
-	RedisModule_SubscribeToKeyspaceEvents(ctx, REDISMODULE_NOTIFY_GENERIC, _RenameGraphHandler);
-	RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_FlushDB, _FlushDBHandler);
-	RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_Persistence, _PersistenceEventHandler);
-	RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_Shutdown, _ShutdownEventHandler);
+	RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_FlushDB,
+			_FlushDBHandler);
+
+	RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_Shutdown,
+			_ShutdownEventHandler);
+
+	RedisModule_SubscribeToKeyspaceEvents(ctx, REDISMODULE_NOTIFY_GENERIC,
+			_RenameGraphHandler);
+
+	RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_Persistence,
+			_PersistenceEventHandler);
 }
 
 static void RG_AfterForkChild() {

--- a/src/util/thpool/pools.c
+++ b/src/util/thpool/pools.c
@@ -145,32 +145,3 @@ int ThreadPools_AddWorkBulkLoader
 	return thpool_add_work(_bulk_thpool, function_p, arg_p);
 }
 
-// destroy all thread pools
-void ThreadPools_Destroy
-(
-	void
-) {
-	ASSERT(_bulk_thpool != NULL);
-	ASSERT(_readers_thpool != NULL);
-	ASSERT(_writers_thpool != NULL);
-
-	// assuming redis-server is shutting down
-	// we're currently executing on redis main thread
-	// therefor writers will be deadlocked waiting for the GIL
-	// readers can complete, but what's the use?
-	// simply pause all threads
-	thpool_pause(_bulk_thpool);
-	thpool_pause(_readers_thpool);
-	thpool_pause(_writers_thpool);
-
-	// destroy pools with paused threads
-	// memory can leak but once again the process is killed
-	thpool_destroy(_bulk_thpool);
-	thpool_destroy(_readers_thpool);
-	thpool_destroy(_writers_thpool);
-
-	_bulk_thpool = NULL;
-	_readers_thpool = NULL;
-	_writers_thpool = NULL;
-}
-

--- a/src/util/thpool/pools.h
+++ b/src/util/thpool/pools.h
@@ -63,9 +63,3 @@ int ThreadPools_AddWorkBulkLoader
 	void *arg_p
 );
 
-// destroy all thread pools
-void ThreadPools_Destroy
-(
-	void
-);
-

--- a/src/util/thpool/thpool.c
+++ b/src/util/thpool/thpool.c
@@ -202,8 +202,8 @@ void thpool_destroy(thpool_* thpool_p) {
 	/* End each thread 's infinite loop */
 	threads_keepalive = 0;
 
-	/* Give one second to kill idle threads */
-	double TIMEOUT = 1.0;
+	/* Give 0.1 second to kill idle threads */
+	double TIMEOUT = 0.1;
 	time_t start, end;
 	double tpassed = 0.0;
 	time(&start);
@@ -214,10 +214,11 @@ void thpool_destroy(thpool_* thpool_p) {
 	}
 
 	/* Poll remaining threads */
-	while(thpool_p->num_threads_alive) {
-		bsem_post_all(thpool_p->jobqueue.has_jobs);
-		sleep(1);
-	}
+	// do not wait forever for threads to complete their work
+	//while(thpool_p->num_threads_alive) {
+	//	bsem_post_all(thpool_p->jobqueue.has_jobs);
+	//	sleep(1);
+	//}
 
 	/* Job queue cleanup */
 	jobqueue_destroy(&thpool_p->jobqueue);

--- a/src/util/thpool/thpool.c
+++ b/src/util/thpool/thpool.c
@@ -214,10 +214,10 @@ void thpool_destroy(thpool_* thpool_p) {
 	}
 
 	/* Poll remaining threads */
-	//while(thpool_p->num_threads_alive) {
-	//	bsem_post_all(thpool_p->jobqueue.has_jobs);
-	//	sleep(1);
-	//}
+	while(thpool_p->num_threads_alive) {
+		bsem_post_all(thpool_p->jobqueue.has_jobs);
+		sleep(1);
+	}
 
 	/* Job queue cleanup */
 	jobqueue_destroy(&thpool_p->jobqueue);

--- a/tests/unit/test_thread_pools.cpp
+++ b/tests/unit/test_thread_pools.cpp
@@ -30,22 +30,16 @@ class ThreadPoolsTest: public ::testing::Test {
 		ThreadPools_CreatePools(READER_COUNT, WRITER_COUNT, BULK_COUNT);
 	}
 
-	static void TearDownTestCase() {
-		ThreadPools_Destroy();
-	}
-
 	static void get_thread_friendly_id(void *arg) {
 		int *threadID = (int*)arg;
 		*threadID = ThreadPools_GetThreadID();	
 	}
 };
 
-TEST_F(ThreadPoolsTest, ThreadPools_ThreadCount) {
+TEST_F(ThreadPoolsTest, ThreadPools_ThreadID) {
 	// verify thread count equals to the number of reader and writer threads
 	ASSERT_EQ (READER_COUNT + WRITER_COUNT, ThreadPools_ThreadCount());
-}
 
-TEST_F(ThreadPoolsTest, ThreadPools_ThreadID) {
 	int thread_ids[READER_COUNT + WRITER_COUNT + 1] = {-1, -1, -1, -1, -1, -1};
 
 	// get main thread friendly id


### PR DESCRIPTION
Test:

As redis-benchmark keeps the server busy. e.g.
```
redis-benchmark -e GRAPH.QUERY g "UNWIND range (0, 1000000) AS x WITH x WHERE (x / 2) = 50  RETURN x"
```

issue a shutdown:
```
redis-cli shutdown
```

Due to the thread pools being destroyed one after another the `ThreadPools_GetThreadID` returns a wrong `thread id` as this relies on pool thread count, which leads to crash when performing `CommandCtx_UntrackCtx`