### PR TITLE
Limit threadpool queue size

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,7 +86,7 @@ $ redis-server --loadmodule ./redisgraph.so MAINTAIN_TRANSPOSED_MATRICES no
 
 ## MAX_QUEUED_QUERIES
 
-Setting the maximum number of queued queries allows the server to reject incoming queries with the error message `Max queries exceeded`. This reduces the memory overhead of pending queries on an overloaded server and avoids congestion when the server processes its backlog of queries.
+Setting the maximum number of queued queries allows the server to reject incoming queries with the error message `Max pending queries exceeded`. This reduces the memory overhead of pending queries on an overloaded server and avoids congestion when the server processes its backlog of queries.
 
 This configuration can be set when the module loads or at runtime.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -84,6 +84,26 @@ $ redis-server --loadmodule ./redisgraph.so MAINTAIN_TRANSPOSED_MATRICES no
 
 ---
 
+## MAX_QUEUED_QUERIES
+
+Setting the maximum number of queued queries allows the server to reject incoming queries with the error message `Max queries exceeded`. This reduces the memory overhead of pending queries on an overloaded server and avoids congestion when the server processes its backlog of queries.
+
+This configuration can be set when the module loads or at runtime.
+
+### Default
+
+`MAX_QUEUED_QUERIES` is effectively unlimited by default (config value of `UINT64_MAX`).
+
+### Example
+
+```
+$ redis-server --loadmodule ./redisgraph.so MAX_QUEUED_QUERIES 500
+
+$ redis-cli GRAPH.CONFIG SET MAX_QUEUED_QUERIES 500
+```
+
+---
+
 ## TIMEOUT
 
 Timeout is a flag that specifies the maximum runtime for read queries in milliseconds. This configuration will not be respected by write queries, to avoid leaving the graph in an inconsistent state.

--- a/src/commands/cmd_context.c
+++ b/src/commands/cmd_context.c
@@ -73,6 +73,8 @@ void CommandCtx_UntrackCtx(CommandCtx *ctx) {
 	ASSERT(command_ctxs != NULL);
 
 	int tid = ThreadPools_GetThreadID();
+	if(command_ctxs[tid] == NULL) return; // nothing to clean
+
 	ASSERT(command_ctxs[tid] == ctx);
 
 	// set ctx at the current thread entry
@@ -127,10 +129,8 @@ void CommandCtx_ThreadSafeContextUnlock(const CommandCtx *command_ctx) {
 }
 
 void CommandCtx_Free(CommandCtx *command_ctx) {
-	if(command_ctx->bc) {
-		RedisModule_UnblockClient(command_ctx->bc, NULL);
-		RedisModule_FreeThreadSafeContext(command_ctx->ctx);
-	}
+	if(command_ctx->bc) RedisModule_UnblockClient(command_ctx->bc, NULL);
+	if(command_ctx->ctx) RedisModule_FreeThreadSafeContext(command_ctx->ctx);
 
 	CommandCtx_UntrackCtx(command_ctx);
 
@@ -138,3 +138,4 @@ void CommandCtx_Free(CommandCtx *command_ctx) {
 	rm_free(command_ctx->command_name);
 	rm_free(command_ctx);
 }
+

--- a/src/commands/cmd_context.c
+++ b/src/commands/cmd_context.c
@@ -129,8 +129,12 @@ void CommandCtx_ThreadSafeContextUnlock(const CommandCtx *command_ctx) {
 }
 
 void CommandCtx_Free(CommandCtx *command_ctx) {
-	if(command_ctx->bc) RedisModule_UnblockClient(command_ctx->bc, NULL);
-	if(command_ctx->ctx) RedisModule_FreeThreadSafeContext(command_ctx->ctx);
+	if(command_ctx->bc) {
+		RedisModule_UnblockClient(command_ctx->bc, NULL);
+		if(command_ctx->ctx) {
+			RedisModule_FreeThreadSafeContext(command_ctx->ctx);
+		}
+	}
 
 	CommandCtx_UntrackCtx(command_ctx);
 

--- a/src/commands/cmd_dispatcher.c
+++ b/src/commands/cmd_dispatcher.c
@@ -202,7 +202,7 @@ int CommandDispatch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 			// Report an error once our workers thread pool internal queue
 			// is full, this error usually happens when the server is
 			// under heavy load and is unable to catch up
-			RedisModule_ReplyWithError(ctx, "Max queries exceeded");
+			RedisModule_ReplyWithError(ctx, "Max pending queries exceeded");
 			CommandCtx_Free(context);
 		}
 	}

--- a/src/commands/cmd_dispatcher.c
+++ b/src/commands/cmd_dispatcher.c
@@ -94,35 +94,35 @@ static void _rejectOnVersionMismatch(RedisModuleCtx *ctx, uint version) {
 // Return true if the command has a valid number of arguments.
 static inline bool _validate_command_arity(GRAPH_Commands cmd, int arity) {
 	switch(cmd) {
-	case CMD_QUERY:
-	case CMD_RO_QUERY:
-	case CMD_EXPLAIN:
-	case CMD_PROFILE:
-		// Expect a command, graph name, a query, and optional config flags.
-		return arity >= 3 && arity <= 8;
-	case CMD_SLOWLOG:
-		// Expect just a command and graph name.
-		return arity == 2;
-	default:
-		ASSERT("encountered unhandled query type" && false);
-		return false;
+		case CMD_QUERY:
+		case CMD_RO_QUERY:
+		case CMD_EXPLAIN:
+		case CMD_PROFILE:
+			// Expect a command, graph name, a query, and optional config flags.
+			return arity >= 3 && arity <= 8;
+		case CMD_SLOWLOG:
+			// Expect just a command and graph name.
+			return arity == 2;
+		default:
+			ASSERT("encountered unhandled query type" && false);
+			return false;
 	}
 }
 
 // Get command handler.
 static Command_Handler get_command_handler(GRAPH_Commands cmd) {
 	switch(cmd) {
-	case CMD_QUERY:
-	case CMD_RO_QUERY:
-		return Graph_Query;
-	case CMD_EXPLAIN:
-		return Graph_Explain;
-	case CMD_PROFILE:
-		return Graph_Profile;
-	case CMD_SLOWLOG:
-		return Graph_Slowlog;
-	default:
-		ASSERT(false);
+		case CMD_QUERY:
+		case CMD_RO_QUERY:
+			return Graph_Query;
+		case CMD_EXPLAIN:
+			return Graph_Explain;
+		case CMD_PROFILE:
+			return Graph_Profile;
+		case CMD_SLOWLOG:
+			return Graph_Slowlog;
+		default:
+			ASSERT(false);
 	}
 	return NULL;
 }
@@ -171,6 +171,8 @@ int CommandDispatch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	// return incase caller provided a mismatched graph version
 	if(!_verifyGraphVersion(gc, version)) {
 		_rejectOnVersionMismatch(ctx, GraphContext_GetVersion(gc));
+		// Release the GraphContext, as we increased its reference count
+		// when retrieving it.
 		GraphContext_Release(gc);
 		return REDISMODULE_OK;
 	}
@@ -203,6 +205,9 @@ int CommandDispatch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 			// is full, this error usually happens when the server is
 			// under heavy load and is unable to catch up
 			RedisModule_ReplyWithError(ctx, "Max pending queries exceeded");
+			// Release the GraphContext, as we increased its reference count
+			// when retrieving it.
+			GraphContext_Release(gc);
 			CommandCtx_Free(context);
 		}
 	}

--- a/src/config.c
+++ b/src/config.c
@@ -40,11 +40,15 @@
 // whether the module should maintain transposed relationship matrices
 #define MAINTAIN_TRANSPOSED_MATRICES "MAINTAIN_TRANSPOSED_MATRICES"
 
+// config param, max number of queued queries
+#define MAX_QUEUED_QUERIES "MAX_QUEUED_QUERIES"
+
 //------------------------------------------------------------------------------
 // Configuration defaults
 //------------------------------------------------------------------------------
 
-#define CACHE_SIZE_DEFAULT 25
+#define CACHE_SIZE_DEFAULT            25
+#define QUEUED_QUERIES_UNLIMITED      UINT64_MAX
 #define VKEY_MAX_ENTITY_COUNT_DEFAULT 100000
 
 extern RG_Config config; // global module configuration
@@ -91,6 +95,18 @@ static inline bool _Config_ParseYesNo(RedisModuleString *rm_str, bool *value) {
 //==============================================================================
 // Config access functions
 //==============================================================================
+
+//------------------------------------------------------------------------------
+// max queued queries
+//------------------------------------------------------------------------------
+
+void Config_max_queued_queries_set(uint64_t max_queued_queries) {
+	config.max_queued_queries = max_queued_queries;
+}
+
+uint Config_max_queued_queries_get(void) {
+	return config.max_queued_queries;
+}
 
 //------------------------------------------------------------------------------
 // timeout
@@ -208,6 +224,8 @@ bool Config_Contains_field(const char *field_str, Config_Option_Field *field) {
 		f = Config_CACHE_SIZE;
 	} else if(!(strcasecmp(field_str, RESULTSET_SIZE))) {
 		f = Config_RESULTSET_MAX_SIZE;
+	} else if (!(strcasecmp(field_str, MAX_QUEUED_QUERIES))) {
+		f = Config_MAX_QUEUED_QUERIES;
 	} else {
 		return false;
 	}
@@ -297,6 +315,9 @@ void _Config_SetToDefaults(RedisModuleCtx *ctx) {
 
 	// no query timeout by default
 	config.timeout = CONFIG_TIMEOUT_NO_TIMEOUT;
+
+	// no limit on number of queued queries by default
+	config.max_queued_queries = QUEUED_QUERIES_UNLIMITED;
 }
 
 int Config_Init(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
@@ -347,6 +368,20 @@ bool Config_Option_set(Config_Option_Field field, RedisModuleString *val) {
 
 	switch (field)
 	{
+		//----------------------------------------------------------------------
+		// max queued queries
+		//----------------------------------------------------------------------
+
+		case Config_MAX_QUEUED_QUERIES:
+			{
+				long long max_queued_queries;
+				if(!_Config_ParsePositiveInteger(val, &max_queued_queries)) {
+					return false;
+				}
+				Config_max_queued_queries_set(max_queued_queries);
+			}
+			break;
+
 		//----------------------------------------------------------------------
 		// timeout
 		//----------------------------------------------------------------------
@@ -470,6 +505,17 @@ bool Config_Option_get(Config_Option_Field field, ...) {
 
 	switch (field)
 	{
+		case Config_MAX_QUEUED_QUERIES:
+			{
+
+				va_start(ap, field);
+				uint64_t *max_queued_queries = va_arg(ap, uint64_t*);
+				va_end(ap);
+
+				ASSERT(max_queued_queries != NULL);
+				(*max_queued_queries) = Config_max_queued_queries_get();
+			}
+			break;
 		//----------------------------------------------------------------------
 		// timeout
 		//----------------------------------------------------------------------

--- a/src/config.c
+++ b/src/config.c
@@ -15,7 +15,6 @@
 //-----------------------------------------------------------------------------
 // Configuration parameters
 //-----------------------------------------------------------------------------
-
 // config param, the timeout for each query in milliseconds
 #define TIMEOUT "TIMEOUT"
 

--- a/src/config.c
+++ b/src/config.c
@@ -282,7 +282,7 @@ const char *Config_Field_name(Config_Option_Field field) {
 }
 
 // initialize every module-level configuration to its default value
-void _Config_SetToDefaults() {
+void _Config_SetToDefaults(void) {
 	// the thread pool's default size is equal to the system's number of cores
 	int CPUCount = sysconf(_SC_NPROCESSORS_ONLN);
 	config.thread_pool_size = (CPUCount != -1) ? CPUCount : 1;

--- a/src/config.c
+++ b/src/config.c
@@ -283,7 +283,7 @@ const char *Config_Field_name(Config_Option_Field field) {
 }
 
 // initialize every module-level configuration to its default value
-void _Config_SetToDefaults(RedisModuleCtx *ctx) {
+void _Config_SetToDefaults() {
 	// the thread pool's default size is equal to the system's number of cores
 	int CPUCount = sysconf(_SC_NPROCESSORS_ONLN);
 	config.thread_pool_size = (CPUCount != -1) ? CPUCount : 1;
@@ -298,11 +298,9 @@ void _Config_SetToDefaults(RedisModuleCtx *ctx) {
 	#ifdef MEMCHECK
 		// disable async delete during memcheck
 		config.async_delete = false;
-		RedisModule_Log(ctx, "notice", "Graph deletion will be done synchronously.");
 	#else
 		// always perform async delete when no checking for memory issues
 		config.async_delete = true;
-		RedisModule_Log(ctx, "notice", "Graph deletion will be done asynchronously.");
 	#endif
 
 	config.cache_size = CACHE_SIZE_DEFAULT;
@@ -322,7 +320,7 @@ void _Config_SetToDefaults(RedisModuleCtx *ctx) {
 
 int Config_Init(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	// Initialize the configuration to its default values.
-	_Config_SetToDefaults(ctx);
+	_Config_SetToDefaults();
 
 	if(argc % 2) {
 		// emit an error if we received an odd number of arguments,

--- a/src/config.h
+++ b/src/config.h
@@ -22,7 +22,8 @@ typedef enum {
 	Config_RESULTSET_MAX_SIZE       = 5,  // max number of records in result-set
 	Config_MAINTAIN_TRANSPOSE       = 6,  // maintain transpose matrices
 	Config_VKEY_MAX_ENTITY_COUNT    = 7,  // max number of elements in vkey
-	Config_END_MARKER               = 8
+	Config_MAX_QUEUED_QUERIES       = 8,  // max number of queued queries
+	Config_END_MARKER               = 9
 } Config_Option_Field;
 
 // configuration object
@@ -35,11 +36,17 @@ typedef struct {
 	uint64_t resultset_size;           // resultset maximum size, (-1) unlimited
 	uint64_t vkey_entity_count;        // The limit of number of entities encoded at once for each RDB key.
 	bool maintain_transposed_matrices; // If true, maintain a transposed version of each relationship matrix.
+	uint64_t max_queued_queries;       // max number of queued queries
 } RG_Config;
 
 // Run-time configurable fields
-#define RUNTIME_CONFIG_COUNT 2
-static const Config_Option_Field RUNTIME_CONFIGS[] = { Config_RESULTSET_MAX_SIZE, Config_TIMEOUT };
+#define RUNTIME_CONFIG_COUNT 3
+static const Config_Option_Field RUNTIME_CONFIGS[] =
+{
+	Config_RESULTSET_MAX_SIZE,
+	Config_TIMEOUT,
+	Config_MAX_QUEUED_QUERIES
+};
 
 // Set module-level configurations to defaults or to user arguments where provided.
 // returns REDISMODULE_OK on success, emits an error and returns REDISMODULE_ERR on failure.

--- a/src/errors.h
+++ b/src/errors.h
@@ -48,6 +48,10 @@ void ErrorCtx_EmitException(void);
 
 bool ErrorCtx_EncounteredError(void);
 
+//------------------------------------------------------------------------------
+// common errors
+//------------------------------------------------------------------------------
+
 // Report an error in filter placement with the first unresolved entity.
 void Error_InvalidFilterPlacement(rax *entitiesRax);
 
@@ -62,3 +66,4 @@ void Error_UnsupportedASTOperator(const cypher_operator_t *op);
 
 // Report an error on trying to assign a complex type to a property.
 void Error_InvalidPropertyValue(void);
+

--- a/src/util/thpool/pools.c
+++ b/src/util/thpool/pools.c
@@ -48,7 +48,7 @@ uint ThreadPools_ThreadCount
 	ASSERT(_readers_thpool != NULL);
 	ASSERT(_writers_thpool != NULL);
 
-	uint count = 0;
+	uint count = 1; // Account for main thread
 	count += thpool_num_threads(_readers_thpool);
 	count += thpool_num_threads(_writers_thpool);
 

--- a/src/util/thpool/pools.c
+++ b/src/util/thpool/pools.c
@@ -48,7 +48,7 @@ uint ThreadPools_ThreadCount
 	ASSERT(_readers_thpool != NULL);
 	ASSERT(_writers_thpool != NULL);
 
-	uint count = 1; // Account for main thread
+	uint count = 0;
 	count += thpool_num_threads(_readers_thpool);
 	count += thpool_num_threads(_writers_thpool);
 

--- a/src/util/thpool/pools.c
+++ b/src/util/thpool/pools.c
@@ -6,6 +6,7 @@
 
 #include "RG.h"
 #include "pools.h"
+#include "../../config.h"
 #include <pthread.h>
 
 //------------------------------------------------------------------------------
@@ -112,6 +113,22 @@ void ThreadPools_Resume
 	thpool_resume(_writers_thpool);
 }
 
+// return true if thread pool internal queue is full with pending work
+static bool _queue_full(threadpool thpool) {
+	ASSERT(thpool != NULL);
+
+	bool      res                 =  false;
+	uint64_t  max_queued_queries  =  0;
+
+	if(Config_Option_get(Config_MAX_QUEUED_QUERIES, &max_queued_queries)) {
+		// test if there's enough room in thread pool queue
+		uint queued_queries = thpool_queue_size(thpool);
+		res = (queued_queries >= max_queued_queries);
+	}
+
+	return res;
+}
+
 // add task for reader thread
 int ThreadPools_AddWorkReader
 (
@@ -119,6 +136,9 @@ int ThreadPools_AddWorkReader
 	void *arg_p
 ) {
 	ASSERT(_readers_thpool != NULL);
+
+	// make sure there's enough room in thread pool queue
+	if(_queue_full(_readers_thpool)) return THPOOL_QUEUE_FULL;
 
 	return thpool_add_work(_readers_thpool, function_p, arg_p);
 }
@@ -130,6 +150,9 @@ int ThreadPools_AddWorkWriter
 	void *arg_p
 ) {
 	ASSERT(_writers_thpool != NULL);
+
+	// make sure there's enough room in thread pool queue
+	if(_queue_full(_writers_thpool)) return THPOOL_QUEUE_FULL;
 
 	return thpool_add_work(_writers_thpool, function_p, arg_p);
 }

--- a/src/util/thpool/pools.h
+++ b/src/util/thpool/pools.h
@@ -5,8 +5,10 @@
 */
 
 #pragma once
+
 #include "thpool.h"
 
+#define THPOOL_QUEUE_FULL -2
 // create both readers and writers thread pools
 int ThreadPools_CreatePools
 (

--- a/src/util/thpool/thpool.h
+++ b/src/util/thpool/thpool.h
@@ -11,6 +11,9 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
+#include <sys/types.h>
+
 /* =================================== API ======================================= */
 
 
@@ -63,7 +66,7 @@ threadpool thpool_init(int num_threads, const char *name);
  * @param  threadpool    threadpool to which the work will be added
  * @param  function_p    pointer to function to add as work
  * @param  arg_p         pointer to an argument
- * @return 0 on successs, -1 otherwise.
+ * @return 0 on successs -1 otherwise
  */
 int thpool_add_work(threadpool, void (*function_p)(void*), void* arg_p);
 
@@ -200,6 +203,14 @@ int thpool_num_threads(threadpool);
  * @return integer      friendly thread id
  */
 int thpool_get_thread_id(threadpool, pthread_t);
+
+/**
+ * @brief Returns number of pending jobs in queue
+ *
+ * @param threadpool    the threadpool of interest
+ * @return integer      number of pending jobs in jobqueue
+ */
+uint thpool_queue_size(threadpool);
 
 #ifdef __cplusplus
 }

--- a/tests/flow/test_pending_queries_limit.py
+++ b/tests/flow/test_pending_queries_limit.py
@@ -44,7 +44,8 @@ class testPendingQueryLimit():
     def stress_server(self):
         threads = []
         connections = []
-        thread_count = 60
+        threadpool_size = self.conn.execute_command("GRAPH.CONFIG", "GET", "THREAD_COUNT")[1]
+        thread_count = threadpool_size * 5
 
         # init connections
         for i in range(thread_count):

--- a/tests/flow/test_pending_queries_limit.py
+++ b/tests/flow/test_pending_queries_limit.py
@@ -1,0 +1,102 @@
+import threading
+from RLTest import Env
+from redisgraph import Graph
+
+# 1.test getting and setting config
+# 2. test overflowing the server when there's a limit
+#    expect to get error!
+# 3. test overflowing the server when there's no limit
+#    expect not to get any exceptions
+
+g = None
+error_encountered = False
+
+GRAPH_NAME = "max_pending_queries"
+FAST_QUERY = "RETURN 1"
+SLOW_QUERY = "UNWIND range (0, 100000) AS x WITH x WHERE (x / 2) = 50  RETURN x"
+
+def issue_query(conn, q):
+    global error_encountered
+
+    try:
+        res = conn.execute_command("GRAPH.QUERY", GRAPH_NAME, q)
+    except:
+        error_encountered = True
+
+class testPendingQueryLimit():
+    def __init__(self):
+        global g
+        
+        self.env = Env(decodeResponses=True)
+        self.conn = self.env.getConnection()
+        g = Graph(GRAPH_NAME, self.conn)
+    
+    def test_01_query_limit_config(self):
+        # read max queued queries config
+        result = self.conn.execute_command("GRAPH.CONFIG", "GET", "MAX_QUEUED_QUERIES")
+        max_queued_queries = result[1]
+        self.env.assertEquals(max_queued_queries, 4294967295)
+
+        # update configuration, set max queued queries
+        self.conn.execute_command("GRAPH.CONFIG", "SET", "MAX_QUEUED_QUERIES", 10)
+
+        # re-read configuration
+        result = self.conn.execute_command("GRAPH.CONFIG", "GET", "MAX_QUEUED_QUERIES")
+        max_queued_queries = result[1]
+        self.env.assertEquals(max_queued_queries, 10)
+
+    def stress_server(self):
+        threads = []
+        connections = []
+        thread_count = 60
+        slow_query_count = 40
+        fast_query_count = 20
+
+        # init connections
+        for i in range(thread_count):
+            connections.append(self.env.getConnection())
+
+        # invoke slow queries
+        for i in range(slow_query_count):
+            con = connections.pop()
+            t = threading.Thread(target=issue_query, args=(con, SLOW_QUERY))
+            t.setDaemon(True)
+            threads.append(t)
+            t.start()
+
+        for i in range(fast_query_count):
+            con = connections.pop()
+            t = threading.Thread(target=issue_query, args=(con, FAST_QUERY))
+            t.setDaemon(True)
+            threads.append(t)
+            t.start()
+
+        # wait for threads to return
+        for i in range(thread_count):
+            t = threads[i]
+            t.join()
+
+    def test_02_overflow_no_limit(self):
+        global error_encountered 
+        error_encountered = False
+
+        # no limit on number of pending queries
+        limit = 4294967295
+        self.conn.execute_command("GRAPH.CONFIG", "SET", "MAX_QUEUED_QUERIES", limit)
+
+        self.stress_server()
+
+        self.env.assertFalse(error_encountered)
+
+    def test_03_overflow_with_limit(self):
+        global error_encountered 
+        error_encountered = False
+
+        # limit number of pending queries
+        limit = 10
+        self.conn.execute_command("GRAPH.CONFIG", "SET", "MAX_QUEUED_QUERIES", limit)
+
+        self.stress_server()
+
+        self.env.assertTrue(error_encountered)
+

--- a/tests/flow/test_pending_queries_limit.py
+++ b/tests/flow/test_pending_queries_limit.py
@@ -8,29 +8,25 @@ from redisgraph import Graph
 # 3. test overflowing the server when there's no limit
 #    expect not to get any exceptions
 
-g = None
 error_encountered = False
 
 GRAPH_NAME = "max_pending_queries"
-FAST_QUERY = "RETURN 1"
 SLOW_QUERY = "UNWIND range (0, 100000) AS x WITH x WHERE (x / 2) = 50  RETURN x"
 
 def issue_query(conn, q):
     global error_encountered
 
     try:
-        res = conn.execute_command("GRAPH.QUERY", GRAPH_NAME, q)
-    except:
+        conn.execute_command("GRAPH.QUERY", GRAPH_NAME, q)
+    except Exception as e:
+        assert "Max pending queries exceeded" in str(e)
         error_encountered = True
 
 class testPendingQueryLimit():
     def __init__(self):
-        global g
-        
         self.env = Env(decodeResponses=True)
         self.conn = self.env.getConnection()
-        g = Graph(GRAPH_NAME, self.conn)
-    
+
     def test_01_query_limit_config(self):
         # read max queued queries config
         result = self.conn.execute_command("GRAPH.CONFIG", "GET", "MAX_QUEUED_QUERIES")
@@ -49,24 +45,15 @@ class testPendingQueryLimit():
         threads = []
         connections = []
         thread_count = 60
-        slow_query_count = 40
-        fast_query_count = 20
 
         # init connections
         for i in range(thread_count):
             connections.append(self.env.getConnection())
 
-        # invoke slow queries
-        for i in range(slow_query_count):
+        # invoke queries
+        for i in range(thread_count):
             con = connections.pop()
             t = threading.Thread(target=issue_query, args=(con, SLOW_QUERY))
-            t.setDaemon(True)
-            threads.append(t)
-            t.start()
-
-        for i in range(fast_query_count):
-            con = connections.pop()
-            t = threading.Thread(target=issue_query, args=(con, FAST_QUERY))
             t.setDaemon(True)
             threads.append(t)
             t.start()
@@ -77,7 +64,7 @@ class testPendingQueryLimit():
             t.join()
 
     def test_02_overflow_no_limit(self):
-        global error_encountered 
+        global error_encountered
         error_encountered = False
 
         # no limit on number of pending queries
@@ -89,14 +76,13 @@ class testPendingQueryLimit():
         self.env.assertFalse(error_encountered)
 
     def test_03_overflow_with_limit(self):
-        global error_encountered 
+        global error_encountered
         error_encountered = False
 
         # limit number of pending queries
-        limit = 10
+        limit = 1
         self.conn.execute_command("GRAPH.CONFIG", "SET", "MAX_QUEUED_QUERIES", limit)
 
         self.stress_server()
 
         self.env.assertTrue(error_encountered)
-

--- a/tests/unit/test_thread_pools.cpp
+++ b/tests/unit/test_thread_pools.cpp
@@ -11,6 +11,7 @@ extern "C" {
 #endif
 
 #include "assert.h"
+#include "../../src/config.h"
 #include "../../src/util/rmalloc.h"
 #include "../../src/util/thpool/pools.h"
 
@@ -27,6 +28,7 @@ class ThreadPoolsTest: public ::testing::Test {
 	// Use the malloc family for allocations
 	static void SetUpTestCase() {
 		Alloc_Reset();
+		Config_Init(NULL, NULL, 0);
 		ThreadPools_CreatePools(READER_COUNT, WRITER_COUNT, BULK_COUNT);
 	}
 


### PR DESCRIPTION
limit the number of pending queries in the thread-pool, in case thread-pool internal queue size has reached the current configured limit and additional queries are received, these will get rejected with an error ("Max queries exceeded")

This is a load/runtime configuration,
to limit internal queue to 10 elements issue:`GRAPH.CONFIG set MAX_QUEUED_QUERIES 10`