### PR TITLE
Fix CI benchmarks on version tag

### DIFF
--- a/tests/benchmarks/requirements.txt
+++ b/tests/benchmarks/requirements.txt
@@ -1,1 +1,1 @@
-redisbench_admin==0.1.54
+redisbench_admin>=0.1.62


### PR DESCRIPTION
This PR fixes errors like the following (https://app.circleci.com/pipelines/github/RedisGraph/RedisGraph/2756/workflows/20ece276-b3f7-4018-947e-cda94d274ebc/jobs/10184) :
```
redisbench-admin: error: argument --github_branch: expected one argument
```

Given that depending on the CI trigger ( branch, version, nightly ) we have different CI env variables with/without github actor/ branch/ etc... The tool is now agnostic and handles those types of failures since v0.1.61:
https://github.com/RedisLabsModules/redisbench-admin/releases/tag/v0.1.61