### PR TITLE
disallow aggregations in maps

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -235,17 +235,16 @@ static AST_Validation _ValidateReferredFunctions(rax *referred_functions, bool i
 // validate that a map doesn't contains a nested aggregation function
 // e.g. {key: count(v)}
 static AST_Validation _ValidateMapExp(const cypher_astnode_t *node) {
-	cypher_astnode_type_t type = cypher_astnode_type(node);
-	ASSERT(type == CYPHER_AST_MAP);
-	AST_Validation res = AST_VALID;
+	ASSERT(cypher_astnode_type(node) == CYPHER_AST_MAP);
 
 	if(AST_ClauseContainsAggregation(node)) {
-		// TODO: provide a more instructive instruction to user
-		ErrorCtx_SetError("map can not contain calls to aggregation functions");
-		res = AST_INVALID;
+		ErrorCtx_SetError("RedisGraph does not allow aggregate function calls \
+to be nested within maps. Aggregate functions should instead be called in a \
+preceding WITH clause and have their aliased values referenced in the map.");
+		return AST_INVALID;
 	}
 
-	return res;
+	return AST_VALID;
 }
 
 // Recursively collect function names and perform validations on functions with STAR arguments.

--- a/src/execution_plan/execution_plan_build/build_projection_ops.c
+++ b/src/execution_plan/execution_plan_build/build_projection_ops.c
@@ -159,15 +159,15 @@ static void _combine_projection_arrays(AR_ExpNode ***exps_ptr, AR_ExpNode **orde
 static inline void _buildProjectionOps(ExecutionPlan *plan,
 									   const cypher_astnode_t *clause) {
 
-	OpBase *op;
-	bool distinct = false;
-	bool aggregate = false;
-	int *sort_directions = NULL;
-	AR_ExpNode **order_exps = NULL;
-	AR_ExpNode **projections = NULL;
-	const cypher_astnode_t *skip_clause = NULL;
-	const cypher_astnode_t *limit_clause = NULL;
-	const cypher_astnode_t *order_clause = NULL;
+	OpBase                  *op               =  NULL  ;
+	bool                    distinct          =  false ;
+	bool                    aggregate         =  false ;
+	int                     *sort_directions  =  NULL  ;
+	AR_ExpNode              **order_exps      =  NULL  ;
+	AR_ExpNode              **projections     =  NULL  ;
+	const cypher_astnode_t  *skip_clause      =  NULL  ;
+	const cypher_astnode_t  *limit_clause     =  NULL  ;
+	const cypher_astnode_t  *order_clause     =  NULL  ;
 
 	cypher_astnode_type_t t = cypher_astnode_type(clause);
 	ASSERT(t == CYPHER_AST_WITH || t == CYPHER_AST_RETURN);
@@ -176,15 +176,15 @@ static inline void _buildProjectionOps(ExecutionPlan *plan,
 	projections = _BuildProjectionExpressions(clause);
 
 	if(t == CYPHER_AST_WITH) {
-		distinct = cypher_ast_with_is_distinct(clause);
-		skip_clause = cypher_ast_with_get_skip(clause);
-		limit_clause = cypher_ast_with_get_limit(clause);
-		order_clause = cypher_ast_with_get_order_by(clause);
+		distinct      =  cypher_ast_with_is_distinct(clause);
+		skip_clause   =  cypher_ast_with_get_skip(clause);
+		limit_clause  =  cypher_ast_with_get_limit(clause);
+		order_clause  =  cypher_ast_with_get_order_by(clause);
 	} else {
-		distinct = cypher_ast_return_is_distinct(clause);
-		skip_clause = cypher_ast_return_get_skip(clause);
-		limit_clause = cypher_ast_return_get_limit(clause);
-		order_clause = cypher_ast_return_get_order_by(clause);
+		distinct      =  cypher_ast_return_is_distinct(clause);
+		skip_clause   =  cypher_ast_return_get_skip(clause);
+		limit_clause  =  cypher_ast_return_get_limit(clause);
+		order_clause  =  cypher_ast_return_get_order_by(clause);
 	}
 
 	if(order_clause) {

--- a/tests/tck/features/clauses/return/Return4.feature
+++ b/tests/tck/features/clauses/return/Return4.feature
@@ -162,6 +162,7 @@ Feature: Return4 - Column renaming
       | 11         |
     And no side effects
 
+  @skip
   Scenario: [9] Handle subexpression in aggregation also occurring as standalone expression with nested aggregation in a literal map
     Given an empty graph
     And having executed:

--- a/tests/tck/features/clauses/return/Return6.feature
+++ b/tests/tck/features/clauses/return/Return6.feature
@@ -114,6 +114,7 @@ Feature: Return6 - Implicit grouping with aggregates
       | 11               |
     And no side effects
 
+  @skip
   Scenario: [6] Handle aggregates inside non-aggregate expressions
     Given an empty graph
     When executing query:


### PR DESCRIPTION
Force user to specify aggregations within a separated WITH clause, this way determining which expressions take part in group key is clear to both user and RedisGraph.

`RETURN a, {b:x, c:count(n)}, d`

Will emit an error, instructing user to rewrite as:

`WITH key0, ..., count(n) AS c RETURN key0,... {b:x, c:c}`