### PR TITLE
early returns migrated to one place

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,17 +2,20 @@ version: 2.1
 
 commands:
 
-  early_returns:
+  # If this build is from a fork, stop executing the current job and return success.
+  # This is useful to avoid steps that will fail due to missing credentials.
+  early_return_for_forked_pull_requests:
     steps:
       - run:
-          # If this build is from a fork, stop executing the current job and return success.
-          # This is useful to avoid steps that will fail due to missing credentials.
           name: Early return if this build is from a forked PR
           command: |
             if [ -n "$CIRCLE_PR_NUMBER" ]; then
               echo "Nothing to do for forked PRs, so marking this step successful."
               circleci step halt
             fi
+
+  early_returns:
+    steps:
       - run:
           name: Early return if this is a docs build
           command: |
@@ -133,6 +136,7 @@ commands:
       platform:
         type: string
     steps:
+      - early_returns
       - setup-executor
       - checkout
       - run:
@@ -145,7 +149,7 @@ commands:
           command: |
             cd build/docker
             make build OSNICK=<<parameters.platform>> ARTIFACTS=1 TEST=1 SHOW=1
-      - early_returns
+      - early_return_for_forked_pull_requests
       - run:
           name: Build for platform (publish)
           command: |
@@ -169,6 +173,7 @@ jobs:
           LANGUAGE: en_US.UTF-8
           LC_ALL: en_US.UTF-8
     steps:
+      - early_returns
       - checkout
       - setup-prerequisits
       - load-cached-deps
@@ -181,7 +186,7 @@ jobs:
       - run:
           name: Test
           command: make test
-
+      - early_return_for_forked_pull_requests
       - run:
           name: Persist Artifact for CI benchmarks
           command: |
@@ -202,6 +207,7 @@ jobs:
             LANGUAGE: en_US.UTF-8
             LC_ALL: en_US.UTF-8
     steps:
+      - early_returns
       - checkout
       - setup-prerequisits
       - load-cached-deps
@@ -225,6 +231,7 @@ jobs:
       LANGUAGE: en_US.UTF-8
       LC_ALL: en_US.UTF-8
     steps:
+      - early_returns
       - checkout
       - setup-prerequisits
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,30 @@
 version: 2.1
 
 commands:
-  early_return_for_forked_pull_requests:
-    description: >-
-      If this build is from a fork, stop executing the current job and return success.
-      This is useful to avoid steps that will fail due to missing credentials.
+
+  early_returns:
     steps:
       - run:
+          # If this build is from a fork, stop executing the current job and return success.
+          # This is useful to avoid steps that will fail due to missing credentials.
           name: Early return if this build is from a forked PR
           command: |
             if [ -n "$CIRCLE_PR_NUMBER" ]; then
-              echo "Nothing to do for forked PRs, so marking this step successful"
+              echo "Nothing to do for forked PRs, so marking this step successful."
+              circleci step halt
+            fi
+      - run:
+          name: Early return if this is a docs build
+          command: |
+            if [[ $CIRCLE_BRANCH == *docs ]]; then
+              echo "Identifies as documents PR, no testing required."
+              circleci step halt
+            fi
+      - run:
+          name: Early return if this branch should ignore CI
+          command: |
+            if [[ $CIRCLE_BRANCH == *noci ]]; then
+              echo "Identifies as actively ignoring CI, no testing required."
               circleci step halt
             fi
 
@@ -32,7 +46,7 @@ commands:
           command: |
             git submodule update --init deps/readies
             ./deps/readies/bin/getpy3
-  
+
   load-cached-deps:
     steps:
       # Load GraphBLAS from cache if possible.
@@ -44,7 +58,7 @@ commands:
       - restore_cache:
           keys:
           - libcypher-parser-{{checksum "./deps/libcypher-parser/README.md"}}
-  
+
   save-deps-cache:
     steps:
       # Save GraphBLAS to cache.
@@ -131,7 +145,7 @@ commands:
           command: |
             cd build/docker
             make build OSNICK=<<parameters.platform>> ARTIFACTS=1 TEST=1 SHOW=1
-      - early_return_for_forked_pull_requests
+      - early_returns
       - run:
           name: Build for platform (publish)
           command: |
@@ -184,7 +198,7 @@ jobs:
     docker:
       - image: redisfab/rmbuilder:6.0.9-x64-bionic
         environment:
-            LANG: en_US.UTF-8  
+            LANG: en_US.UTF-8
             LANGUAGE: en_US.UTF-8
             LC_ALL: en_US.UTF-8
     steps:
@@ -291,7 +305,7 @@ jobs:
     docker:
       - image: 'redisfab/rmbuilder:6.0.9-x64-bionic'
     steps:
-      - early_return_for_forked_pull_requests
+      - early_returns
       - checkout
       - attach_workspace:
           at: /workspace
@@ -301,7 +315,7 @@ jobs:
     docker:
       - image: redisfab/rmbuilder:6.0.9-x64-bionic
     steps:
-      - early_return_for_forked_pull_requests
+      - early_returns
       - checkout
       - attach_workspace:
           at: /workspace
@@ -315,7 +329,7 @@ jobs:
     docker:
       - image: redisfab/rmbuilder:6.0.9-x64-bionic
     steps:
-      - early_return_for_forked_pull_requests
+      - early_returns
       - checkout
       - setup-prerequisits
       - attach_workspace:


### PR DESCRIPTION
This ensures that branches with certain names do not run CI step, given an explicit need to test. This brings this module in line with the others.