### PR TITLE
Reused projected variables

### DIFF
--- a/src/execution_plan/execution_plan_build/execution_plan_modify.c
+++ b/src/execution_plan/execution_plan_build/execution_plan_modify.c
@@ -292,6 +292,7 @@ OpBase **ExecutionPlan_LocateTaps(const ExecutionPlan *plan) {
 
 static void _ExecutionPlan_CollectOpsMatchingType(OpBase *root, const OPType *types, int type_count,
 												  OpBase ***ops) {
+	if(root == NULL) return;
 	for(int i = 0; i < type_count; i++) {
 		// Check to see if the op's type matches any of the types we're searching for.
 		if(root->type == types[i]) {

--- a/tests/flow/test_bound_variables.py
+++ b/tests/flow/test_bound_variables.py
@@ -78,3 +78,15 @@ class testBoundVariables(FlowTestsBase):
         actual_result = redis_graph.query(query)
         expected_result = [['v2']]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    def test04_projected_scanned_entity(self):
+        query = """MATCH (a:L {val: 'v1'}) WITH a MATCH (a), (b {val: 'v2'}) RETURN a.val, b.val"""
+        actual_result = redis_graph.query(query)
+
+        # Verify that this query generates exactly 2 scan ops.
+        execution_plan = redis_graph.execution_plan(query)
+        self.env.assertEquals(2, execution_plan.count('Scan'))
+
+        # Verify results.
+        expected_result = [['v1', 'v2']]
+        self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
Fixes a bug in which projected variables could be re-bound with erroneous scan operations.

Resolves #1688