### PR TITLE
Fix regression in GRAPH.CONFIG GET *

### DIFF
--- a/src/configuration/config.c
+++ b/src/configuration/config.c
@@ -310,6 +310,10 @@ const char *Config_Field_name(Config_Option_Field field) {
 			name = ASYNC_DELETE;
 			break;
 
+		case Config_MAX_QUEUED_QUERIES:
+			name = MAX_QUEUED_QUERIES;
+			break;
+
 		case Config_QUERY_MEM_CAPACITY:
 			name = QUERY_MEM_CAPACITY;
 			break;

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -28,8 +28,14 @@ class testConfig(FlowTestsBase):
         # Try reading 'QUERY_MEM_CAPACITY' from config
         config_name = "QUERY_MEM_CAPACITY"
         response = redis_con.execute_command("GRAPH.CONFIG GET " + config_name)
-        expected_response = [config_name, 0] # capacity=QUERY_MEM_CAPACITY_UNLIMITED  
+        expected_response = [config_name, 0] # capacity=QUERY_MEM_CAPACITY_UNLIMITED
         self.env.assertEqual(response, expected_response)
+
+        # Try reading all configurations
+        config_name = "*"
+        response = redis_con.execute_command("GRAPH.CONFIG GET " + config_name)
+        # At least 10 configurations should be reported
+        self.env.assertGreaterEqual(len(response), 10)
 
     def test02_config_get_invalid_name(self):
         global redis_graph


### PR DESCRIPTION
This PR fixes a regression in which the `GRAPH.CONFIG GET *` command hangs indefinitely rather than correctly reporting results.

Resolves #1707 