### PR TITLE
Validate destination level in BFS when seeking known destination

### DIFF
--- a/src/algorithms/LAGraph_bfs_pushpull.c
+++ b/src/algorithms/LAGraph_bfs_pushpull.c
@@ -523,7 +523,8 @@ GrB_Info LAGraph_bfs_pushpull   // push-pull BFS, or push-only if AT = NULL
 
 		if(dest) {
 			GrB_Info res = GrB_Vector_extractElement(&dest_val, v, *dest) ;
-			if(res != GrB_NO_VALUE) break ;
+			// break if the destination node's value equals the current level
+			if(res != GrB_NO_VALUE && dest_val == level) break ;
 		}
 
 		//----------------------------------------------------------------------


### PR DESCRIPTION
While iteratively performing push-pull BFS, it is possible to assign an explicit 0 value to the destination node ID in the output vector. This should not be mistaken for terminating the search; a valid path has only been found once the `level` value is assigned to the destination node.

I was not able to write a simple test to validate this fix, but it can be validated using the data and query provided in #1695.

Resolves #1695