### PR TITLE
ignore bound node when constructing a scan op for it

### DIFF
--- a/src/execution_plan/execution_plan_build/build_match_op_tree.c
+++ b/src/execution_plan/execution_plan_build/build_match_op_tree.c
@@ -35,8 +35,14 @@ static void _ExecutionPlan_ProcessQueryGraph(ExecutionPlan *plan, QueryGraph *qg
 		OpBase *tail = NULL;
 
 		if(edge_count == 0) {
-			/* If there are no edges in the component, we only need a node scan. */
+			// if there are no edges in the component, we only need a node scan
 			QGNode *n = cc->nodes[0];
+
+			if(raxFind(bound_vars, (unsigned char *)n->alias, strlen(n->alias))
+					!= raxNotFound) {
+				continue;
+			}
+
 			if(n->labelID != GRAPH_NO_LABEL) {
 				NodeScanCtx ctx = NODE_CTX_NEW(n->alias, n->label, n->labelID);
 				root = NewNodeByLabelScanOp(plan, ctx);

--- a/src/execution_plan/execution_plan_build/build_merge_op_tree.c
+++ b/src/execution_plan/execution_plan_build/build_merge_op_tree.c
@@ -71,17 +71,16 @@ void buildMergeOp(ExecutionPlan *plan, AST *ast, const cypher_astnode_t *clause,
 	// Convert all AST data required to populate our operations tree.
 	AST_MergeContext merge_ctx = AST_PrepareMergeOp(clause, gc, plan->query_graph, bound_vars);
 
-	// Create a Merge operation. It will store no information at this time except for any graph updates
-	// it should make due to ON MATCH and ON CREATE SET directives in the query.
-	OpBase *merge_op = NewMergeOp(plan, merge_ctx.on_match, merge_ctx.on_create);
-
-	// Set Merge op as new root and add previously-built ops, if any, as Merge's first stream.
-	ExecutionPlan_UpdateRoot(plan, merge_op);
-
 	// Build the Match stream as a Merge child.
 	const cypher_astnode_t *path = cypher_ast_merge_get_pattern_path(clause);
 	OpBase *match_stream = ExecutionPlan_BuildOpsFromPath(plan, arguments, path);
-	ExecutionPlan_AddOp(plan->root, match_stream); // Add Match stream to Merge op.
+
+	// Create a Merge operation. It will store no information at this time except for any graph updates
+	// it should make due to ON MATCH and ON CREATE SET directives in the query.
+	OpBase *merge_op = NewMergeOp(plan, merge_ctx.on_match, merge_ctx.on_create);
+	// Set Merge op as new root and add previously-built ops, if any, as Merge's first stream.
+	ExecutionPlan_UpdateRoot(plan, merge_op);
+	ExecutionPlan_AddOp(merge_op, match_stream); // Add Match stream to Merge op.
 
 	// Build the Create stream as a Merge child.
 	_buildMergeCreateStream(plan, &merge_ctx, arguments);

--- a/tests/flow/test_bound_variables.py
+++ b/tests/flow/test_bound_variables.py
@@ -78,3 +78,16 @@ class testBoundVariables(FlowTestsBase):
         actual_result = redis_graph.query(query)
         expected_result = [['v2']]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    def test04_projected_scanned_entity(self):
+        query = """MATCH (a:L {val: 'v1'}) WITH a MATCH (a), (b {val: 'v2'}) RETURN a.val, b.val"""
+        actual_result = redis_graph.query(query)
+
+        # Verify that this query generates exactly 2 scan ops.
+        execution_plan = redis_graph.execution_plan(query)
+        self.env.assertEquals(2, execution_plan.count('Scan'))
+
+        # Verify results.
+        expected_result = [['v1', 'v2']]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+


### PR DESCRIPTION
Resolves #1688