### PR TITLE
Replicate graph config

### DIFF
--- a/ramp.yml
+++ b/ramp.yml
@@ -7,7 +7,7 @@ license: Redis Source Available License Agreement
 command_line_args: ""
 min_redis_version: "6.0"
 min_redis_pack_version: "6.0.8"
-config_command: "GRAPH.CONFIG"
+config_command: "GRAPH.CONFIG SET"
 capabilities:
     - types
     - failover_migrate

--- a/src/commands/cmd_config.c
+++ b/src/commands/cmd_config.c
@@ -88,8 +88,6 @@ void _Config_set(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	const char *val_str = RedisModule_StringPtrLen(value, NULL);
 
 	if(Config_Option_set(config_field, val_str)) {
-		// replicate command and reply to caller
-		RedisModule_ReplicateVerbatim(ctx);
 		RedisModule_ReplyWithSimpleString(ctx, "OK");
 	} else {
 		RedisModule_ReplyWithError(ctx, "Failed to set config value");

--- a/src/commands/cmd_config.c
+++ b/src/commands/cmd_config.c
@@ -88,6 +88,8 @@ void _Config_set(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	const char *val_str = RedisModule_StringPtrLen(value, NULL);
 
 	if(Config_Option_set(config_field, val_str)) {
+		// replicate command and reply to caller
+		RedisModule_ReplicateVerbatim(ctx);
 		RedisModule_ReplyWithSimpleString(ctx, "OK");
 	} else {
 		RedisModule_ReplyWithError(ctx, "Failed to set config value");

--- a/tests/flow/test_replication.py
+++ b/tests/flow/test_replication.py
@@ -111,32 +111,3 @@ class testReplication(FlowTestsBase):
         replica_result = replica.query(q).result_set
         self.env.assertEquals(replica_result, result)
 
-    def test_config_replication(self):
-        env = self.env
-        source_con = env.getConnection()
-        replica_con = env.getSlaveConnection()
-        self.env.assertNotEqual(source_con, replica_con)
-
-        # enable write commands on slave, required as all RedisGraph
-        # commands are registered as write commands
-        replica_con.config_set("slave-read-only", "no")
-
-        # read config from both source and replica
-        src_timeout = source_con.execute_command("GRAPH.CONFIG", "GET", "TIMEOUT")
-        rep_timeout = replica_con.execute_command("GRAPH.CONFIG", "GET", "TIMEOUT")
-
-        # make sure timeout config is the same on both source and replica
-        self.env.assertEquals(src_timeout, rep_timeout)
-
-        # reconfig on source
-        timeout = 40
-        source_con.execute_command("GRAPH.CONFIG", "SET", "TIMEOUT", timeout)
-
-        # read config from both source and replica
-        src_timeout = source_con.execute_command("GRAPH.CONFIG", "GET", "TIMEOUT")[1]
-        rep_timeout = replica_con.execute_command("GRAPH.CONFIG", "GET", "TIMEOUT")[1]
-
-        # make sure timeout config is the same on both source and replica
-        self.env.assertEquals(src_timeout, timeout)
-        self.env.assertEquals(rep_timeout, timeout)
-


### PR DESCRIPTION
After discussing this over with @MeirShpilraien, we've concluded:
1. GRAPH.CONFIG should not be considered as a write command
2. GRAPH.CONFIG should not be replicated