### PR TITLE
Support updating properties with map referenced by parameter or variable

### DIFF
--- a/src/ast/ast_build_op_contexts.c
+++ b/src/ast/ast_build_op_contexts.c
@@ -69,15 +69,21 @@ static void _ConstructPropertyMap(PropertySetCtx *map, uint map_size,
 }
 
 static void _UpdateCtx_AddPropertyMap(GraphContext *gc, EntityUpdateEvalCtx *ctx,
-									  const cypher_astnode_t *ast_map, MAP_TYPE type,
-									  const char *identifier) {
+									  const cypher_astnode_t *ast_map,
+									  bool have_map_literal) {
 	ASSERT(gc       !=  NULL);
 	ASSERT(ctx      !=  NULL);
 	ASSERT(ast_map  !=  NULL);
 
-	ctx->type = type;
-	if(type != MAP_LITERAL) {
-		ctx->identifier = identifier;
+	if(have_map_literal == false) {
+		// If we are not converting a map literal, enqueue one update that will
+		// be resolved to a map later.
+		if(ctx->properties == NULL) ctx->properties = array_new(PropertySetCtx, 1);
+		PropertySetCtx map_update = {
+			.id = ATTRIBUTE_ALL,
+			.exp = AR_EXP_FromASTNode(ast_map)
+		};
+		ctx->properties = array_append(ctx->properties, map_update);
 		return;
 	}
 
@@ -88,7 +94,6 @@ static void _UpdateCtx_AddPropertyMap(GraphContext *gc, EntityUpdateEvalCtx *ctx
 	_ConstructPropertyMap(map, count, gc, ast_map);
 
 	// merge map into entity update eval context
-	if(ctx->properties == NULL) ctx->properties = array_new(PropertySetCtx, count);
 	for(uint i = 0; i < count; i ++) {
 		ctx->properties = array_append(ctx->properties, map[i]);
 	}
@@ -110,13 +115,16 @@ static void _Update_MergePropertyMap(GraphContext *gc, rax *updates,
 	// Property map
 	const cypher_astnode_t *ast_map = cypher_ast_merge_properties_get_expression(set_item);
 	const cypher_astnode_type_t type = cypher_astnode_type(ast_map);
-	MAP_TYPE map_type = MAP_UNKNOWN;
-	if(type == CYPHER_AST_MAP) map_type = MAP_LITERAL;
-	else if(type == CYPHER_AST_IDENTIFIER) map_type = MAP_ALIAS;
-	else if(type == CYPHER_AST_PARAMETER) map_type = MAP_PARAMETER;
-	if(map_type == MAP_UNKNOWN) {
-		// TODO introduce support for queries like:
-		// MATCH (a {v: 1}), (b {v: 2}) SET a += b
+	// TODO introduce support for queries like:
+	// MATCH (a {v: 1}), (b {v: 2}) SET a = b
+	uint count;
+	bool have_map_literal = false;
+	if(type == CYPHER_AST_MAP) {
+		count = cypher_ast_map_nentries(ast_map);
+		have_map_literal = true;
+	} else if(type == CYPHER_AST_IDENTIFIER || type == CYPHER_AST_PARAMETER) {
+		count = 0;
+	} else {
 		ErrorCtx_SetError("RedisGraph does not currently support assigning graph entities to non-map values.");
 		return;
 	}
@@ -125,20 +133,12 @@ static void _Update_MergePropertyMap(GraphContext *gc, rax *updates,
 	int len = strlen(alias);
 	EntityUpdateEvalCtx *ctx = raxFind(updates, (unsigned char *)alias, len);
 	if(ctx == raxNotFound) {
-		uint count = (map_type != MAP_LITERAL) ? 0 : cypher_ast_map_nentries(ast_map);
 		ctx = UpdateCtx_New(UPDATE_MERGE, count, alias);
 		raxInsert(updates, (unsigned char *)alias, len, ctx, NULL);
 	}
 
-	const char *rhs_identifier = NULL;
-	if(map_type == MAP_ALIAS) {
-		rhs_identifier = cypher_ast_identifier_get_name(ast_map);
-	} else if(map_type == MAP_PARAMETER) {
-		rhs_identifier = cypher_ast_parameter_get_name(ast_map);
-	}
-
 	// add all properties to update context
-	_UpdateCtx_AddPropertyMap(gc, ctx, ast_map, map_type, rhs_identifier);
+	_UpdateCtx_AddPropertyMap(gc, ctx, ast_map, have_map_literal);
 }
 
 // Replace existing properties with the given map
@@ -157,13 +157,16 @@ static void _Update_SetPropertyMap(GraphContext *gc, rax *updates,
 	const cypher_astnode_t *ast_map =
 		cypher_ast_set_all_properties_get_expression(set_item);
 	const cypher_astnode_type_t type = cypher_astnode_type(ast_map);
-	MAP_TYPE map_type = MAP_UNKNOWN;
-	if(type == CYPHER_AST_MAP) map_type = MAP_LITERAL;
-	else if(type == CYPHER_AST_IDENTIFIER) map_type = MAP_ALIAS;
-	else if(type == CYPHER_AST_PARAMETER) map_type = MAP_PARAMETER;
-	if(map_type == MAP_UNKNOWN) {
-		// TODO introduce support for queries like:
-		// MATCH (a {v: 1}), (b {v: 2}) SET a = b
+	// TODO introduce support for queries like:
+	// MATCH (a {v: 1}), (b {v: 2}) SET a = b
+	uint count;
+	bool have_map_literal = false;
+	if(type == CYPHER_AST_MAP) {
+		count = cypher_ast_map_nentries(ast_map);
+		have_map_literal = true;
+	} else if(type == CYPHER_AST_IDENTIFIER || type == CYPHER_AST_PARAMETER) {
+		count = 0;
+	} else {
 		ErrorCtx_SetError("RedisGraph does not currently support assigning graph entities to non-map values.");
 		return;
 	}
@@ -172,7 +175,6 @@ static void _Update_SetPropertyMap(GraphContext *gc, rax *updates,
 	int len = strlen(alias);
 	EntityUpdateEvalCtx *ctx = raxFind(updates, (unsigned char *)alias, len);
 	if(ctx == raxNotFound) {
-		uint count = (map_type != MAP_LITERAL) ? 0 : cypher_ast_map_nentries(ast_map);
 		ctx = UpdateCtx_New(UPDATE_REPLACE, count, alias);
 		raxInsert(updates, (unsigned char *)alias, len, ctx, NULL);
 	} else {
@@ -181,15 +183,8 @@ static void _Update_SetPropertyMap(GraphContext *gc, rax *updates,
 		UpdateCtx_SetMode(ctx, UPDATE_REPLACE);
 	}
 
-	const char *rhs_identifier = NULL;
-	if(map_type == MAP_ALIAS) {
-		rhs_identifier = cypher_ast_identifier_get_name(ast_map);
-	} else if(map_type == MAP_PARAMETER) {
-		rhs_identifier = cypher_ast_parameter_get_name(ast_map);
-	}
-
 	// add all properties to update context
-	_UpdateCtx_AddPropertyMap(gc, ctx, ast_map, map_type, rhs_identifier);
+	_UpdateCtx_AddPropertyMap(gc, ctx, ast_map, have_map_literal);
 }
 
 static void _UpdateCtx_AddProperty(GraphContext *gc, EntityUpdateEvalCtx *ctx,
@@ -206,7 +201,6 @@ static void _UpdateCtx_AddProperty(GraphContext *gc, EntityUpdateEvalCtx *ctx,
 	AR_ExpNode *exp = AR_EXP_FromASTNode(ast_val);
 
 	PropertySetCtx update = { .id  = attribute_id, .exp = exp };
-	if(ctx->properties == NULL) ctx->properties = array_new(PropertySetCtx, 1);
 	ctx->properties = array_append(ctx->properties, update);
 }
 

--- a/src/ast/ast_shared.c
+++ b/src/ast/ast_shared.c
@@ -120,9 +120,8 @@ EntityUpdateEvalCtx *UpdateCtx_New(UPDATE_MODE mode, uint prop_count, const char
 	EntityUpdateEvalCtx *ctx = rm_malloc(sizeof(EntityUpdateEvalCtx));
 	ctx->mode = mode;
 	ctx->alias = alias;
-	ctx->type = MAP_LITERAL;
 	ctx->record_idx = INVALID_INDEX;
-	ctx->properties = (prop_count == 0) ? NULL : array_new(PropertySetCtx, prop_count);
+	ctx->properties = array_new(PropertySetCtx, prop_count);
 
 	return ctx;
 }
@@ -132,19 +131,14 @@ EntityUpdateEvalCtx *UpdateCtx_Clone(const EntityUpdateEvalCtx *orig) {
 	clone->mode = orig->mode;
 	clone->alias = orig->alias;
 	clone->record_idx = orig->record_idx;
-	clone->type = orig->type;
-	if(clone->type == MAP_ALIAS || clone->type == MAP_PARAMETER) {
-		clone->identifier = orig->identifier;
-	} else {
-		uint count = array_len(orig->properties);
-		clone->properties = array_new(PropertySetCtx, count);
-		for(uint i = 0; i < count; i ++) {
-			PropertySetCtx update = {
-				.id = orig->properties[i].id,
-				.exp = AR_EXP_Clone(orig->properties[i].exp),
-			};
-			clone->properties = array_append(clone->properties, update);
-		}
+	uint count = array_len(orig->properties);
+	clone->properties = array_new(PropertySetCtx, count);
+	for(uint i = 0; i < count; i ++) {
+		PropertySetCtx update = {
+			.id = orig->properties[i].id,
+			.exp = AR_EXP_Clone(orig->properties[i].exp),
+		};
+		clone->properties = array_append(clone->properties, update);
 	}
 
 	return clone;
@@ -162,11 +156,9 @@ void UpdateCtx_Clear(EntityUpdateEvalCtx *ctx) {
 }
 
 void UpdateCtx_Free(EntityUpdateEvalCtx *ctx) {
-	if(ctx->type == MAP_LITERAL && ctx->properties) {
-		uint count = array_len(ctx->properties);
-		for(uint i = 0; i < count; i ++) AR_EXP_Free(ctx->properties[i].exp);
-		array_free(ctx->properties);
-	}
+	uint count = array_len(ctx->properties);
+	for(uint i = 0; i < count; i ++) AR_EXP_Free(ctx->properties[i].exp);
+	array_free(ctx->properties);
 	rm_free(ctx);
 }
 

--- a/src/ast/ast_shared.c
+++ b/src/ast/ast_shared.c
@@ -120,8 +120,9 @@ EntityUpdateEvalCtx *UpdateCtx_New(UPDATE_MODE mode, uint prop_count, const char
 	EntityUpdateEvalCtx *ctx = rm_malloc(sizeof(EntityUpdateEvalCtx));
 	ctx->mode = mode;
 	ctx->alias = alias;
+	ctx->type = MAP_LITERAL;
 	ctx->record_idx = INVALID_INDEX;
-	ctx->properties = array_new(PropertySetCtx, prop_count);
+	ctx->properties = (prop_count == 0) ? NULL : array_new(PropertySetCtx, prop_count);
 
 	return ctx;
 }
@@ -131,14 +132,19 @@ EntityUpdateEvalCtx *UpdateCtx_Clone(const EntityUpdateEvalCtx *orig) {
 	clone->mode = orig->mode;
 	clone->alias = orig->alias;
 	clone->record_idx = orig->record_idx;
-	uint count = array_len(orig->properties);
-	clone->properties = array_new(PropertySetCtx, count);
-	for(uint i = 0; i < count; i ++) {
-		PropertySetCtx update = {
-			.id = orig->properties[i].id,
-			.exp = AR_EXP_Clone(orig->properties[i].exp),
-		};
-		clone->properties = array_append(clone->properties, update);
+	clone->type = orig->type;
+	if(clone->type == MAP_ALIAS || clone->type == MAP_PARAMETER) {
+		clone->identifier = orig->identifier;
+	} else {
+		uint count = array_len(orig->properties);
+		clone->properties = array_new(PropertySetCtx, count);
+		for(uint i = 0; i < count; i ++) {
+			PropertySetCtx update = {
+				.id = orig->properties[i].id,
+				.exp = AR_EXP_Clone(orig->properties[i].exp),
+			};
+			clone->properties = array_append(clone->properties, update);
+		}
 	}
 
 	return clone;
@@ -156,9 +162,11 @@ void UpdateCtx_Clear(EntityUpdateEvalCtx *ctx) {
 }
 
 void UpdateCtx_Free(EntityUpdateEvalCtx *ctx) {
-	uint count = array_len(ctx->properties);
-	for(uint i = 0; i < count; i ++) AR_EXP_Free(ctx->properties[i].exp);
-	array_free(ctx->properties);
+	if(ctx->type == MAP_LITERAL && ctx->properties) {
+		uint count = array_len(ctx->properties);
+		for(uint i = 0; i < count; i ++) AR_EXP_Free(ctx->properties[i].exp);
+		array_free(ctx->properties);
+	}
 	rm_free(ctx);
 }
 

--- a/src/ast/ast_shared.h
+++ b/src/ast/ast_shared.h
@@ -56,13 +56,6 @@ typedef enum {
 	UPDATE_REPLACE = 2,    // replace existing property map with new properties
 } UPDATE_MODE;
 
-typedef enum {
-	MAP_UNKNOWN    = 0,    // default, should not be encountered
-	MAP_LITERAL    = 1,    // map literal
-	MAP_ALIAS      = 2,    // alias to a map variable
-	MAP_PARAMETER  = 3,    // name of a map parameter
-} MAP_TYPE;
-
 // Key-value pair of an attribute ID and the value to be associated with it
 // TODO Consider replacing contents of PropertyMap (for ops like Create) with this
 typedef struct {
@@ -72,11 +65,7 @@ typedef struct {
 
 // Context describing an update expression.
 typedef struct {
-	union {
-		PropertySetCtx *properties; // properties to set
-		const char *identifier;
-	};
-	MAP_TYPE type;              // type of the property map
+	PropertySetCtx *properties; // properties to set
 	int record_idx;             // record offset this entity is stored at
 	UPDATE_MODE mode;           // Whether the entity's property map should be updated or replaced
 	const char *alias;          // Access-safe alias of the entity being updated

--- a/src/ast/ast_shared.h
+++ b/src/ast/ast_shared.h
@@ -56,6 +56,13 @@ typedef enum {
 	UPDATE_REPLACE = 2,    // replace existing property map with new properties
 } UPDATE_MODE;
 
+typedef enum {
+	MAP_UNKNOWN    = 0,    // default, should not be encountered
+	MAP_LITERAL    = 1,    // map literal
+	MAP_ALIAS      = 2,    // alias to a map variable
+	MAP_PARAMETER  = 3,    // name of a map parameter
+} MAP_TYPE;
+
 // Key-value pair of an attribute ID and the value to be associated with it
 // TODO Consider replacing contents of PropertyMap (for ops like Create) with this
 typedef struct {
@@ -65,7 +72,11 @@ typedef struct {
 
 // Context describing an update expression.
 typedef struct {
-	PropertySetCtx *properties; // properties to set
+	union {
+		PropertySetCtx *properties; // properties to set
+		const char *identifier;
+	};
+	MAP_TYPE type;              // type of the property map
 	int record_idx;             // record offset this entity is stored at
 	UPDATE_MODE mode;           // Whether the entity's property map should be updated or replaced
 	const char *alias;          // Access-safe alias of the entity being updated
@@ -97,9 +108,6 @@ AST_Operator AST_ConvertOperatorNode(const cypher_operator_t *op);
 
 // Convert a map of properties from the AST into a set of attribute ID keys and AR_ExpNode values.
 PropertyMap *PropertyMap_New(GraphContext *gc, const cypher_astnode_t *props);
-
-// Clone EntityUpdateEvalCtx.
-EntityUpdateEvalCtx EntityUpdateEvalCtx_Clone(EntityUpdateEvalCtx ctx);
 
 // Clone NodeCreateCtx.
 NodeCreateCtx NodeCreateCtx_Clone(NodeCreateCtx ctx);

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -30,19 +30,13 @@ void Graph_Explain(void *args) {
 	/* Retrieve the required execution items and information:
 	 * 1. Execution plan
 	 * 2. Whether these items were cached or not */
-	bool cached = false;
-	ExecutionPlan *plan = NULL;
-	ExecutionCtx *exec_ctx = ExecutionCtx_FromQuery(command_ctx->query);
+	bool           cached     =  false;
+	ExecutionPlan  *plan      =  NULL;
+	ExecutionCtx   *exec_ctx  =  ExecutionCtx_FromQuery(command_ctx->query);
+	if(exec_ctx == NULL) goto cleanup;
 
 	plan = exec_ctx->plan;
 	ExecutionType exec_type = exec_ctx->exec_type;
-
-	// See if there were any query compile time errors
-	if(ErrorCtx_EncounteredError()) {
-		ErrorCtx_EmitException();
-		goto cleanup;
-	}
-	ASSERT(exec_ctx != NULL);
 
 	if(exec_type == EXECUTION_TYPE_INDEX_CREATE) {
 		RedisModule_ReplyWithSimpleString(ctx, "Create Index");
@@ -60,6 +54,7 @@ void Graph_Explain(void *args) {
 	ExecutionPlan_Print(plan, ctx); // Print the execution plan.
 
 cleanup:
+	if(ErrorCtx_EncounteredError()) ErrorCtx_EmitException();
 	if(lock_acquired) Graph_ReleaseLock(gc->g);
 	ExecutionCtx_Free(exec_ctx);
 	GraphContext_Release(gc);

--- a/src/commands/cmd_explain.c
+++ b/src/commands/cmd_explain.c
@@ -42,7 +42,7 @@ void Graph_Explain(void *args) {
 		ErrorCtx_EmitException();
 		goto cleanup;
 	}
-	if(exec_type == EXECUTION_TYPE_INVALID) goto cleanup;
+	ASSERT(exec_ctx != NULL);
 
 	if(exec_type == EXECUTION_TYPE_INDEX_CREATE) {
 		RedisModule_ReplyWithSimpleString(ctx, "Create Index");

--- a/src/commands/cmd_profile.c
+++ b/src/commands/cmd_profile.c
@@ -45,7 +45,7 @@ void Graph_Profile(void *args) {
 		goto cleanup;
 	}
 
-	if(exec_type == EXECUTION_TYPE_INVALID) goto cleanup;
+	ASSERT(exec_ctx != NULL);
 
 	if(exec_type == EXECUTION_TYPE_INDEX_CREATE ||
 	   exec_type == EXECUTION_TYPE_INDEX_DROP) {

--- a/src/commands/cmd_profile.c
+++ b/src/commands/cmd_profile.c
@@ -31,21 +31,14 @@ void Graph_Profile(void *args) {
 	* 2. Execution plan
 	* 3. Whether these items were cached or not */
 	AST *ast               = NULL;
-	ExecutionPlan *plan    = NULL;
 	bool cached            = false;
+	ExecutionPlan *plan    = NULL;
 	ExecutionCtx *exec_ctx = ExecutionCtx_FromQuery(command_ctx->query);
+	if(exec_ctx == NULL) goto cleanup;
 
 	ast = exec_ctx->ast;
 	plan = exec_ctx->plan;
 	ExecutionType exec_type = exec_ctx->exec_type;
-
-	// See if there were any query compile time errors
-	if(ErrorCtx_EncounteredError()) {
-		ErrorCtx_EmitException();
-		goto cleanup;
-	}
-
-	ASSERT(exec_ctx != NULL);
 
 	if(exec_type == EXECUTION_TYPE_INDEX_CREATE ||
 	   exec_type == EXECUTION_TYPE_INDEX_DROP) {
@@ -82,6 +75,8 @@ void Graph_Profile(void *args) {
 	ExecutionPlan_Print(plan, ctx);
 
 cleanup:
+	if(ErrorCtx_EncounteredError()) ErrorCtx_EmitException();
+
 	// Release the read-write lock
 	if(lockAcquired) {
 		if(readonly) Graph_ReleaseLock(gc->g);

--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -245,7 +245,8 @@ void Graph_Query(void *args) {
 		ErrorCtx_EmitException();
 		goto cleanup;
 	}
-	if(exec_ctx->exec_type == EXECUTION_TYPE_INVALID) goto cleanup;
+
+	ASSERT(exec_ctx != NULL);
 
 	bool readonly = AST_ReadOnly(exec_ctx->ast->root);
 
@@ -282,3 +283,4 @@ cleanup:
 	QueryCtx_Free(); // Reset the QueryCtx and free its allocations.
 	ErrorCtx_Clear();
 }
+

--- a/src/commands/execution_ctx.c
+++ b/src/commands/execution_ctx.c
@@ -96,6 +96,11 @@ ExecutionCtx *ExecutionCtx_FromQuery(const char *query) {
 	// In case of valid query, create execution plan, and cache it and the AST.
 	if(exec_type == EXECUTION_TYPE_QUERY) {
 		ExecutionPlan *plan = NewExecutionPlan();
+
+		// TODO: there must be a better way to understand if the execution-plan
+		// was constructed correctly,
+		// maybe free the plan within NewExecutionPlan, if error was encountered
+		// and return NULL ?
 		if(ErrorCtx_EncounteredError()) {
 			// Encountered an error in ExecutionPlan construction,
 			// clean up and return NULL.

--- a/src/commands/execution_ctx.h
+++ b/src/commands/execution_ctx.h
@@ -13,7 +13,6 @@
  * @brief  Execution type derived from a query
  */
 typedef enum {
-	EXECUTION_TYPE_INVALID,         // Execution is not valid due to invalid query.
 	EXECUTION_TYPE_QUERY,           // Normal query execution.
 	EXECUTION_TYPE_INDEX_CREATE,    // Create index execution.
 	EXECUTION_TYPE_INDEX_DROP       // Drop index execution.

--- a/src/datatypes/map.c
+++ b/src/datatypes/map.c
@@ -179,7 +179,7 @@ SIValue *Map_Keys
 	return keys;
 }
 
-bool Map_GetIdx
+void Map_GetIdx
 (
 	const SIValue map,
 	uint idx,
@@ -187,16 +187,14 @@ bool Map_GetIdx
 	SIValue *value
 ) {
 	ASSERT(SI_TYPE(map) & T_MAP);
-
-	uint key_count = Map_KeyCount(map);
-	if(idx >= key_count) return false;
+	ASSERT(idx < Map_KeyCount(map));
+	ASSERT(key != NULL);
+	ASSERT(value != NULL);
 
 	Pair p = map.map[idx];
 
-	if(key) *key = p.key;
-	if(value) *value = p.val;
-
-	return true;
+	*key = p.key;
+	*value = p.val;
 }
 
 #define KEY_ISLT(a,b) (strcmp(a->key.stringval, b->key.stringval) < 0)

--- a/src/datatypes/map.c
+++ b/src/datatypes/map.c
@@ -179,6 +179,26 @@ SIValue *Map_Keys
 	return keys;
 }
 
+bool Map_GetIdx
+(
+	const SIValue map,
+	uint idx,
+	SIValue *key,
+	SIValue *value
+) {
+	ASSERT(SI_TYPE(map) & T_MAP);
+
+	uint key_count = Map_KeyCount(map);
+	if(idx >= key_count) return false;
+
+	Pair p = map.map[idx];
+
+	if(key) *key = p.key;
+	if(value) *value = p.val;
+
+	return true;
+}
+
 #define KEY_ISLT(a,b) (strcmp(a->key.stringval, b->key.stringval) < 0)
 int Map_Compare
 (
@@ -307,3 +327,4 @@ void Map_Free
 
 	array_free(map.map);
 }
+

--- a/src/datatypes/map.h
+++ b/src/datatypes/map.h
@@ -82,6 +82,17 @@ SIValue *Map_Keys
 	SIValue map  // map to extract keys from
 );
 
+// populate the key and value pointers with
+// the map contents at the indicated index,
+// returning true if the index was not out of bounds.
+bool Map_GetIdx
+(
+	const SIValue map,
+	uint idx,
+	SIValue *key,
+	SIValue *value
+);
+
 // compare two maps
 // if map lengths are not equal, the map with the greater length is
 // considered greater
@@ -125,3 +136,4 @@ void Map_Free
 (
 	SIValue map  // map to free
 );
+

--- a/src/datatypes/map.h
+++ b/src/datatypes/map.h
@@ -82,10 +82,9 @@ SIValue *Map_Keys
 	SIValue map  // map to extract keys from
 );
 
-// populate the key and value pointers with
-// the map contents at the indicated index,
-// returning true if the index was not out of bounds.
-bool Map_GetIdx
+// populate 'key' and 'value' pointers with
+// the map contents at the indicated index
+void Map_GetIdx
 (
 	const SIValue map,
 	uint idx,

--- a/tests/flow/test_entity_update.py
+++ b/tests/flow/test_entity_update.py
@@ -82,3 +82,31 @@ class testEntityUpdate(FlowTestsBase):
         result = graph.query("MERGE (n {v: 1}) ON MATCH SET n = {}, n.v = 5 RETURN n")
         expected_result = [[node]]
         self.env.assertEqual(result.result_set, expected_result)
+
+    # Update properties with a map retrieved by alias
+    def test10_property_map_from_identifier(self):
+        # Overwrite existing properties
+        node = Node(properties={"v2": 10})
+        result = graph.query("WITH {v2: 10} as props MATCH (n) SET n = props RETURN n")
+        expected_result = [[node]]
+        self.env.assertEqual(result.result_set, expected_result)
+
+        # Merge property maps
+        node = Node(properties={"v1": True, "v2": 10})
+        result = graph.query("WITH {v1: True} as props MATCH (n) SET n += props RETURN n")
+        expected_result = [[node]]
+        self.env.assertEqual(result.result_set, expected_result)
+
+    # Update properties with a map retrieved from a parameter
+    def test11_property_map_from_parameter(self):
+        # Overwrite existing properties
+        node = Node(properties={"v2": 10})
+        result = graph.query("CYPHER props={v2: 10} MATCH (n) SET n = $props RETURN n")
+        expected_result = [[node]]
+        self.env.assertEqual(result.result_set, expected_result)
+
+        # Merge property maps
+        node = Node(properties={"v1": True, "v2": 10})
+        result = graph.query("CYPHER props={v1: true} MATCH (n) SET n += $props RETURN n")
+        expected_result = [[node]]
+        self.env.assertEqual(result.result_set, expected_result)


### PR DESCRIPTION
This PR adds support for queries of the form:
```
CYPHER props={v2: 10} MATCH (n) SET n = $props
WITH {v1: True} as props MATCH (n) SET n += props
```

It additionally fixes a bug in which some user-level errors encountered during ExecutionPlan construction did not prevent the plan from being cached (and not throwing the error on cached executions).

Resolves #1730