### PR TITLE
Fix edge_count.yml benchmark name.

### DIFF
--- a/tests/benchmarks/entity_count.yml
+++ b/tests/benchmarks/entity_count.yml
@@ -1,10 +1,10 @@
-name: "ENTITY COUNT"
+name: "ENTITY_COUNT"
 remote:
   - setup: redisgraph-r5
   - type: oss-standalone
 dbconfig:
   - init_commands:
-    - "GRAPH.QUERY g UNWIND range(0, 5000000) AS x CREATE (:N)-[:R]->(:N)"
+    - '"GRAPH.QUERY" "g" "UNWIND range(0, 5000000) AS x CREATE (:N)-[:R]->(:N)"'
 clientconfig:
   - tool: redisgraph-benchmark-go
   - parameters:


### PR DESCRIPTION
The space in the test name is making the grafana redis datasource not behaving as expected ( making us unable to chart this use-case ). The solution is simple - rename the test so that it does not contain spaces.