### PR TITLE
Added the graph500 (scale 21) 1-3 hop variations benchmarks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,6 +113,7 @@ commands:
           command: python3 -m pip install -r ./tests/benchmarks/requirements.txt
       - run:
           name: Run CI benchmarks on aws
+          no_output_timeout: 30m # given we use very large datasets we need this timeout
           command: |
               cd ./tests/benchmarks
               export AWS_ACCESS_KEY_ID=$PERFORMANCE_EC2_ACCESS_KEY

--- a/tests/benchmarks/graph500_scale21-1hop.yml
+++ b/tests/benchmarks/graph500_scale21-1hop.yml
@@ -1,0 +1,22 @@
+name: "graph500_scale21-1hop"
+description: "graph500 scale 21 dataset contains 2396019 nodes and and 67108864 edges"
+remote:
+  - setup: redisgraph-r5
+  - type: oss-standalone
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisgraph/datasets/graph500_scale21/graph500_scale21_v2.2.16_dump.rdb"
+  - dataset_load_timeout_secs: 1200
+clientconfig:
+  - tool: redisgraph-benchmark-go
+  - parameters:
+    - graph: "graph500_21"
+    - rps: 0
+    - clients: 32
+    - threads: 4
+    - connections: 32
+    - requests: 1000000
+    - queries:
+      - { q: "match (n)-[:IS_CONNECTED*1]->(z) where ID(n) = __rand_int__ return ID(n), count(z)", ratio: 1.0 }
+kpis:
+  - le: { $.OverallClientLatencies.Total.q50: 4.0 }
+  - ge: { $.OverallQueryRates.Total: 18000 }

--- a/tests/benchmarks/graph500_scale21-2hops.yml
+++ b/tests/benchmarks/graph500_scale21-2hops.yml
@@ -1,0 +1,22 @@
+name: "graph500_scale21-2hops"
+description: "graph500 scale 21 dataset contains 2396019 nodes and and 67108864 edges"
+remote:
+  - setup: redisgraph-r5
+  - type: oss-standalone
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisgraph/datasets/graph500_scale21/graph500_scale21_v2.2.16_dump.rdb"
+  - dataset_load_timeout_secs: 1200
+clientconfig:
+  - tool: redisgraph-benchmark-go
+  - parameters:
+    - graph: "graph500_21"
+    - rps: 0
+    - clients: 32
+    - threads: 4
+    - connections: 32
+    - requests: 100000
+    - queries:
+      - { q: "match (n)-[:IS_CONNECTED*2]->(z) where ID(n) = __rand_int__ return ID(n), count(z)", ratio: 1.0 }
+kpis:
+  - le: { $.OverallClientLatencies.Total.q50: 30.0 }
+  - ge: { $.OverallQueryRates.Total: 1500 }

--- a/tests/benchmarks/graph500_scale21-3hops.yml
+++ b/tests/benchmarks/graph500_scale21-3hops.yml
@@ -1,0 +1,22 @@
+name: "graph500_scale21-3hops"
+description: "graph500 scale 21 dataset contains 2396019 nodes and and 67108864 edges"
+remote:
+  - setup: redisgraph-r5
+  - type: oss-standalone
+dbconfig:
+  - dataset: "https://s3.amazonaws.com/benchmarks.redislabs/redisgraph/datasets/graph500_scale21/graph500_scale21_v2.2.16_dump.rdb"
+  - dataset_load_timeout_secs: 1200
+clientconfig:
+  - tool: redisgraph-benchmark-go
+  - parameters:
+    - graph: "graph500_21"
+    - rps: 0
+    - clients: 32
+    - threads: 4
+    - connections: 32
+    - requests: 10000
+    - queries:
+      - { q: "match (n)-[:IS_CONNECTED*3]->(z) where ID(n) = __rand_int__ return ID(n), count(z)", ratio: 1.0 }
+kpis:
+  - le: { $.OverallClientLatencies.Total.q50: 300.0 }
+  - ge: { $.OverallQueryRates.Total: 150 }


### PR DESCRIPTION
The following PR adds the graph500 benchmarks to CI. 
Some notes:
- The rdb load time should be >5min ( we keep track of it )
- The graph contains the following index:
```
127.0.0.1:6379> graph.query graph500_21 "CALL db.indexes()"
1) 1) "type"
   2) "label"
   3) "properties"
2) 1) 1) "exact-match"
      2) "IS_CONNECTED"
      3) "[id]"
   2) 1) "exact-match"
      2) "Node"
      3) "[id]"
3) 1) "Cached execution: 0"
   2) "Query internal execution time: 0.124838 milliseconds"
```  
- The graph size is as follow:
```
127.0.0.1:6379> graph.query graph500_21 "match (n) return count(n)"
1) 1) "count(n)"
2) 1) 1) (integer) 2396019
3) 1) "Cached execution: 0"
   2) "Query internal execution time: 0.157120 milliseconds"
127.0.0.1:6379> graph.query graph500_21 "match ()-[e]->() return count(e)"
1) 1) "count(e)"
2) 1) 1) (integer) 67108864
3) 1) "Cached execution: 0"
   2) "Query internal execution time: 0.221987 milliseconds"
```
