### PR TITLE
[fix] Added missing common context to nightly perf automation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -471,4 +471,5 @@ workflows:
               only: master
     jobs:
       - nightly_automation
-      - nightly_performance_automation
+      - nightly_performance_automation:
+          <<: *context


### PR DESCRIPTION
This PR should fix https://circleci.com/gh/RedisGraph/RedisGraph/11714?utm_campaign=chatroom-integration&utm_medium=referral&utm_source=slack