### PR TITLE
Tuple iter race

### DIFF
--- a/deps/GraphBLAS/README.md
+++ b/deps/GraphBLAS/README.md
@@ -4,6 +4,7 @@ SuiteSparse:GraphBLAS, Timothy A. Davis, (c) 2017-2021, All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 
 VERSION 4.0.1, Jan 4, 2021
+FORCE REBUILD
 
 SuiteSparse:GraphBLAS is complete implementation of the GraphBLAS standard,
 which defines a set of sparse matrix operations on an extended algebra of

--- a/deps/GraphBLAS/Source/GxB_Matrix_tuple_iter.c
+++ b/deps/GraphBLAS/Source/GxB_Matrix_tuple_iter.c
@@ -22,9 +22,6 @@ GrB_Info GxB_MatrixTupleIter_new
 	GB_WHERE(A, "GxB_MatrixTupleIter_new (A)") ;
 	GB_RETURN_IF_NULL_OR_FAULTY(A) ;
 
-	// make sure matrix is not bitmap or full
-	GxB_set(A, GxB_SPARSITY_CONTROL, GxB_SPARSE) ;
-
 	GrB_Index nrows;
 	GrB_Matrix_nrows(&nrows, A) ;
 
@@ -50,9 +47,9 @@ GrB_Info GxB_MatrixTupleIter_iterate_row
 	_EmptyIterator(iter) ;
 
 	if(rowIdx < 0 || rowIdx >= iter->nrows) {
-		GB_ERROR (GrB_INVALID_INDEX,
-			"Row index " GBu " out of range; must be < " GBu,
-			rowIdx, iter->nrows) ;
+		GB_ERROR(GrB_INVALID_INDEX,
+				 "Row index " GBu " out of range; must be < " GBu,
+				 rowIdx, iter->nrows) ;
 	}
 
 	iter->nvals = iter->A->p[rowIdx + 1];
@@ -74,9 +71,9 @@ GrB_Info GxB_MatrixTupleIter_jump_to_row
 	_EmptyIterator(iter) ;
 
 	if(rowIdx < 0 || rowIdx >= iter->nrows) {
-		GB_ERROR (GrB_INVALID_INDEX,
-			"Row index " GBu " out of range; must be < " GBu,
-			rowIdx, iter->nrows ) ;
+		GB_ERROR(GrB_INVALID_INDEX,
+				 "Row index " GBu " out of range; must be < " GBu,
+				 rowIdx, iter->nrows) ;
 	}
 
 	GrB_Matrix_nvals(&(iter->nvals), iter->A) ;
@@ -100,14 +97,14 @@ GrB_Info GxB_MatrixTupleIter_iterate_range
 
 	if(startRowIdx < 0 || startRowIdx >= iter->nrows) {
 		GB_ERROR(GrB_INVALID_INDEX,
-			"row index " GBu " out of range; must be < " GBu,
-			startRowIdx, iter->nrows ) ;
+				 "row index " GBu " out of range; must be < " GBu,
+				 startRowIdx, iter->nrows) ;
 	}
 
 	if(startRowIdx > endRowIdx) {
 		GB_ERROR(GrB_INVALID_INDEX,
-			"row index " GBu " must be > " GBu,
-			startRowIdx, endRowIdx ) ;
+				 "row index " GBu " must be > " GBu,
+				 startRowIdx, endRowIdx) ;
 	}
 
 	iter->nnz_idx = iter->A->p[startRowIdx] ;

--- a/deps/GraphBLAS/Source/GxB_Matrix_tuple_iter.c
+++ b/deps/GraphBLAS/Source/GxB_Matrix_tuple_iter.c
@@ -22,16 +22,21 @@ GrB_Info GxB_MatrixTupleIter_new
 	GB_WHERE(A, "GxB_MatrixTupleIter_new (A)") ;
 	GB_RETURN_IF_NULL_OR_FAULTY(A) ;
 
-	GrB_Index nrows;
+	// make sure matrix is not bitmap or full
+	GxB_set(A, GxB_SPARSITY_CONTROL, GxB_SPARSE) ;
+
+	GrB_Index nrows ;
 	GrB_Matrix_nrows(&nrows, A) ;
 
 	*iter = GB_MALLOC(1, GxB_MatrixTupleIter) ;
 	GrB_Matrix_nvals(&((*iter)->nvals), A) ;
-	(*iter)->A = A ;
-	(*iter)->nnz_idx = 0 ;
-	(*iter)->row_idx = 0 ;
-	(*iter)->nrows = nrows;
-	(*iter)->p = A->p[0] ;
+
+	(*iter)->A        =  A        ;
+	(*iter)->nnz_idx  =  0        ;
+	(*iter)->row_idx  =  0        ;
+	(*iter)->nrows    =  nrows    ;
+	(*iter)->p        =  A->p[0]  ;
+
 	return (GrB_SUCCESS) ;
 }
 
@@ -52,10 +57,10 @@ GrB_Info GxB_MatrixTupleIter_iterate_row
 				 rowIdx, iter->nrows) ;
 	}
 
-	iter->nvals = iter->A->p[rowIdx + 1];
-	iter->nnz_idx = iter->A->p[rowIdx];
-	iter->row_idx = rowIdx;
-	iter->p = 0;
+	iter->p        =  0 ;
+	iter->nvals    =  iter->A->p[rowIdx + 1] ;
+	iter->nnz_idx  =  iter->A->p[rowIdx] ;
+	iter->row_idx  =  rowIdx ;
 	return (GrB_SUCCESS) ;
 }
 
@@ -77,9 +82,11 @@ GrB_Info GxB_MatrixTupleIter_jump_to_row
 	}
 
 	GrB_Matrix_nvals(&(iter->nvals), iter->A) ;
-	iter->nnz_idx = iter->A->p[rowIdx] ;
-	iter->row_idx = rowIdx ;
-	iter->p = 0 ;
+
+	iter->p        =  0                   ;
+	iter->nnz_idx  =  iter->A->p[rowIdx]  ;
+	iter->row_idx  =  rowIdx              ;
+
 	return (GrB_SUCCESS) ;
 }
 
@@ -107,11 +114,12 @@ GrB_Info GxB_MatrixTupleIter_iterate_range
 				 startRowIdx, endRowIdx) ;
 	}
 
-	iter->nnz_idx = iter->A->p[startRowIdx] ;
-	iter->row_idx = startRowIdx ;
+	iter->p        =  0                        ;
+	iter->nnz_idx  =  iter->A->p[startRowIdx]  ;
+	iter->row_idx  =  startRowIdx              ;
 	if(endRowIdx < iter->nrows) iter->nvals = iter->A->p[endRowIdx + 1] ;
 	else GrB_Matrix_nvals(&(iter->nvals), iter->A) ;
-	iter->p = 0 ;
+
 	return (GrB_SUCCESS) ;
 }
 
@@ -140,27 +148,27 @@ GrB_Info GxB_MatrixTupleIter_next
 	//--------------------------------------------------------------------------
 
 	if(col)
-		*col = A->i[nnz_idx];
+		*col = A->i[nnz_idx] ;
 
 	//--------------------------------------------------------------------------
 	// extract the row indices
 	//--------------------------------------------------------------------------
 
-	const int64_t *Ap = A->p;
-	int64_t i = iter->row_idx;
+	const int64_t *Ap = A->p ;
+	int64_t i = iter->row_idx ;
 
 	for(; i < iter->nrows; i++) {
-		int64_t p = iter->p + Ap[i];
+		int64_t p = iter->p + Ap[i] ;
 		if(p < Ap[i + 1]) {
-			iter->p++;
+			iter->p++ ;
 			if(row)
-				*row = i;
-			break;
+				*row = i ;
+			break ;
 		}
-		iter->p = 0;
+		iter->p = 0 ;
 	}
 
-	iter->row_idx = i;
+	iter->row_idx = i ;
 
 	iter->nnz_idx++ ;
 
@@ -175,9 +183,9 @@ GrB_Info GxB_MatrixTupleIter_reset
 ) {
 	GB_WHERE1("GxB_MatrixTupleIter_reset (iter)") ;
 	GB_RETURN_IF_NULL(iter) ;
-	iter->nnz_idx = 0 ;
-	iter->row_idx = 0 ;
-	iter->p = iter->A->p[0] ;
+	iter->nnz_idx  =  0              ;
+	iter->row_idx  =  0              ;
+	iter->p        =  iter->A->p[0]  ;
 	return (GrB_SUCCESS) ;
 }
 
@@ -191,7 +199,10 @@ GrB_Info GxB_MatrixTupleIter_reuse
 	GB_RETURN_IF_NULL(iter) ;
 	GB_RETURN_IF_NULL_OR_FAULTY(A) ;
 
-	GrB_Index nrows;
+	// make sure matrix is not bitmap or full
+	GxB_set(A, GxB_SPARSITY_CONTROL, GxB_SPARSE) ;
+
+	GrB_Index nrows ;
 	GrB_Matrix_nrows(&nrows, A) ;
 
 	iter->A = A ;

--- a/src/Makefile
+++ b/src/Makefile
@@ -215,7 +215,7 @@ $(LIBXXHASH):
 # Build GraphBLAS only if library does not already exists.
 $(GRAPHBLAS):
 ifeq (,$(wildcard $(GRAPHBLAS)))
-	@$(MAKE) -C $(ROOT)/deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)'" static_only JOBS=$(shell $(ROOT)/deps/readies/bin/nproc)
+	@$(MAKE) -C $(ROOT)/deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)'" static_only
 endif
 .PHONY: $(GRAPHBLAS)
 

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -67,21 +67,22 @@ void _binary_op_free_edge(void *z, const void *x, const void *y) {
 
 // Creates a new matrix
 static RG_Matrix RG_Matrix_New(const Graph *g, GrB_Type data_type) {
-	RG_Matrix matrix = rm_calloc(1, sizeof(_RG_Matrix));
+	GrB_Info info;
+	UNUSED(info);
 
-	matrix->dirty = true;
-	matrix->allow_multi_edge = true;
+	RG_Matrix matrix = rm_calloc(1, sizeof(_RG_Matrix));
+	matrix->dirty             =  true;
+	matrix->allow_multi_edge  =  true;
 
 	GrB_Index n = Graph_RequiredMatrixDim(g);
-	GrB_Info matrix_res = GrB_Matrix_new(&matrix->grb_matrix, data_type, n, n);
-	ASSERT(matrix_res == GrB_SUCCESS);
+	info = GrB_Matrix_new(&matrix->grb_matrix, data_type, n, n);
+	ASSERT(info == GrB_SUCCESS);
 
-	/* matrix iterator requires matrix format to be sparse
-	 * to avoid future conversion from HYPER-SPARSE, BITMAP, FULL to SPARSE
-	 * we set matrix format at creation time. */
-	GrB_Info set_res = GxB_set(matrix->grb_matrix, GxB_SPARSITY_CONTROL, GxB_SPARSE);
-	UNUSED(set_res);
-	ASSERT(set_res == GrB_SUCCESS);
+	// matrix iterator requires matrix format to be sparse
+	// to avoid future conversion from HYPER-SPARSE, BITMAP, FULL to SPARSE
+	// we set matrix format at creation time
+	info = GxB_set(matrix->grb_matrix, GxB_SPARSITY_CONTROL, GxB_SPARSE);
+	ASSERT(info == GrB_SUCCESS);
 
 	int mutex_res = pthread_mutex_init(&matrix->mutex, NULL);
 	ASSERT(mutex_res == 0);
@@ -1461,9 +1462,6 @@ int Graph_AddRelationType(Graph *g) {
 	ASSERT(g);
 
 	RG_Matrix m = RG_Matrix_New(g, GrB_UINT64);
-	GrB_Info info = GxB_set(m->grb_matrix, GxB_SPARSITY_CONTROL, GxB_SPARSE);
-	UNUSED(info);
-	ASSERT(info == GrB_SUCCESS);
 	array_append(g->relations, m);
 	// Adding a new relationship type, update the stats structures to support it.
 	GraphStatistics_IntroduceRelationship(&g->stats);
@@ -1472,8 +1470,6 @@ int Graph_AddRelationType(Graph *g) {
 
 	if(maintain_transpose) {
 		RG_Matrix tm = RG_Matrix_New(g, GrB_UINT64);
-		info = GxB_set(tm->grb_matrix, GxB_SPARSITY_CONTROL, GxB_SPARSE);
-		ASSERT(info == GrB_SUCCESS);
 		array_append(g->t_relations, tm);
 	}
 


### PR DESCRIPTION
Extensive local testing suggests that this PR resolves #1785.

It appears that `GxB_set` or the particular matrix access it performs is not thread-safe, and can cause crashes when multiple new tuple iterators all attempt to set this field on the same matrix simultaneously.

This crash seemingly can only occur on the earliest set calls to `GxB_set`.
