### PR TITLE
Build: allow specification of parallel jobs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -4,6 +4,8 @@ ROOT:=$(realpath ..)
 # find the OS
 uname_S := $(shell sh -c 'uname -s 2>/dev/null || echo not')
 
+JOBS ?= $(shell MAX_NPROC=8 $(ROOT)/deps/readies/bin/nproc)
+
 ifneq ($(filter cov-upload,$(MAKECMDGOALS)),)
 COV=1
 endif
@@ -215,7 +217,7 @@ $(LIBXXHASH):
 # Build GraphBLAS only if library does not already exists.
 $(GRAPHBLAS):
 ifeq (,$(wildcard $(GRAPHBLAS)))
-	@$(MAKE) -C $(ROOT)/deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)'" static_only
+	@$(MAKE) -C $(ROOT)/deps/GraphBLAS CMAKE_OPTIONS="-DCMAKE_C_COMPILER='$(CC)'" static_only JOBS=$(JOBS)
 endif
 .PHONY: $(GRAPHBLAS)
 


### PR DESCRIPTION
By default, do not exceed 8 jobs, so we don't OOM in CI.
Override (e.g. make JOBS=32) is possible.