### PR TITLE
fixing peg to install man pages into local tree

### DIFF
--- a/sbin/system-setup.py
+++ b/sbin/system-setup.py
@@ -65,7 +65,7 @@ class RedisGraphSetup(paella.Setup):
             tar xzf peg-0.1.18.tar.gz
             cd peg-0.1.18
             make
-            make install
+            make install MANDIR=.
             cd /tmp
             rm -rf $build_dir
             """)


### PR DESCRIPTION
Given that we don't use the man pages, but the make install target requires it, this ensures it won't break, and doesn't pollute the filesystem.  This is to fix the mac build, which cannot write to /usr/local/man.