### PR TITLE
support value extraction from tuple iterator

### DIFF
--- a/deps/GraphBLAS/Config/GraphBLAS.h.in
+++ b/deps/GraphBLAS/Config/GraphBLAS.h.in
@@ -7848,6 +7848,7 @@ typedef struct
 	int64_t p ;             // Number of none zero values in current column
 	int64_t row_idx ;       // Index of current row
 	GrB_Index nrows ;       // Total number of rows in matrix
+	size_t size ;           // Size of an entry in A
 } GxB_MatrixTupleIter ;
 
 // Create a new matrix iterator
@@ -7885,6 +7886,7 @@ GrB_Info GxB_MatrixTupleIter_next
 	GxB_MatrixTupleIter *iter,      // iterator to consume
 	GrB_Index *row,                 // optional row index of current NNZ
 	GrB_Index *col,                 // optional column index of current NNZ
+	void *val,                      // optional value at A[row, col]
 	bool *depleted                  // indicate if iterator depleted
 ) ;
 

--- a/deps/GraphBLAS/Include/GraphBLAS.h
+++ b/deps/GraphBLAS/Include/GraphBLAS.h
@@ -7848,6 +7848,7 @@ typedef struct
 	int64_t p ;             // Number of none zero values in current column
 	int64_t row_idx ;       // Index of current row
 	GrB_Index nrows ;       // Total number of rows in matrix
+	size_t size ;           // Size of an entry in A
 } GxB_MatrixTupleIter ;
 
 // Create a new matrix iterator
@@ -7885,6 +7886,7 @@ GrB_Info GxB_MatrixTupleIter_next
 	GxB_MatrixTupleIter *iter,      // iterator to consume
 	GrB_Index *row,                 // optional row index of current NNZ
 	GrB_Index *col,                 // optional column index of current NNZ
+	void *val,                      // optional value at A[row, col]
 	bool *depleted                  // indicate if iterator depleted
 ) ;
 

--- a/deps/GraphBLAS/README.md
+++ b/deps/GraphBLAS/README.md
@@ -3,8 +3,8 @@
 SuiteSparse:GraphBLAS, Timothy A. Davis, (c) 2017-2021, All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 
+CACHE-BREAK-0
 VERSION 4.0.1, Jan 4, 2021
-FORCE REBUILD
 
 SuiteSparse:GraphBLAS is complete implementation of the GraphBLAS standard,
 which defines a set of sparse matrix operations on an extended algebra of

--- a/src/algorithms/all_neighbors.c
+++ b/src/algorithms/all_neighbors.c
@@ -124,7 +124,7 @@ EntityID AllNeighborsCtx_NextNeighbor
 
 		bool depleted;
 		GrB_Index dest_id;
-		GxB_MatrixTupleIter_next(it, NULL, &dest_id, &depleted);
+		GxB_MatrixTupleIter_next(it, NULL, &dest_id, NULL, &depleted);
 
 		if(depleted) {
 			// backtrack

--- a/src/execution_plan/ops/op_cond_var_len_traverse.c
+++ b/src/execution_plan/ops/op_cond_var_len_traverse.c
@@ -148,11 +148,13 @@ static OpResult CondVarLenTraverseInit(OpBase *opBase) {
 			AlgebraicExpression_Edge(op->ae));
 	uint reltype_count = QGEdge_RelationCount(e);
 
-	bool multi_edge = true;
+	bool  multi_edge  =  true;
+	bool  transpose   =  op->traverseDir != GRAPH_EDGE_DIR_OUTGOING;
 	if(reltype_count == 1) {
 		int rel_id = QGEdge_RelationID(e, 0);
 		if(rel_id != GRAPH_NO_RELATION && rel_id != GRAPH_UNKNOWN_RELATION) {
-			multi_edge = Graph_RelationshipContainsMultiEdge(op->g, rel_id);
+			multi_edge = Graph_RelationshipContainsMultiEdge(op->g, rel_id,
+					transpose);
 		}
 	}
 

--- a/src/execution_plan/ops/op_conditional_traverse.c
+++ b/src/execution_plan/ops/op_conditional_traverse.c
@@ -140,7 +140,8 @@ static Record CondTraverseConsume(OpBase *opBase) {
 	NodeID dest_id = INVALID_ENTITY_ID;
 
 	while(true) {
-		if(op->iter) GxB_MatrixTupleIter_next(op->iter, &src_id, &dest_id, &depleted);
+		if(op->iter) GxB_MatrixTupleIter_next(op->iter, &src_id, &dest_id,
+				NULL, &depleted);
 
 		// Managed to get a tuple, break.
 		if(!depleted) break;

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -111,7 +111,7 @@ static Record NodeByLabelScanConsumeFromChild(OpBase *opBase) {
 	// Try to get new nodeID.
 	GrB_Index nodeId;
 	bool depleted = true;
-	GxB_MatrixTupleIter_next(op->iter, NULL, &nodeId, &depleted);
+	GxB_MatrixTupleIter_next(op->iter, NULL, &nodeId, NULL, &depleted);
 	/* depleted will be true in the following cases:
 	 * 1. No iterator: GxB_MatrixTupleIter_next will fail and depleted will stay true. This scenario means
 	 * that there was no consumption of a record from a child, otherwise there was an iterator.
@@ -138,7 +138,7 @@ static Record NodeByLabelScanConsumeFromChild(OpBase *opBase) {
 			_ResetIterator(op);
 		}
 		// Try to get new NodeID.
-		GxB_MatrixTupleIter_next(op->iter, NULL, &nodeId, &depleted);
+		GxB_MatrixTupleIter_next(op->iter, NULL, &nodeId, NULL, &depleted);
 	}
 
 	// We've got a record and NodeID.
@@ -154,7 +154,7 @@ static Record NodeByLabelScanConsume(OpBase *opBase) {
 
 	GrB_Index nodeId;
 	bool depleted = false;
-	GxB_MatrixTupleIter_next(op->iter, NULL, &nodeId, &depleted);
+	GxB_MatrixTupleIter_next(op->iter, NULL, &nodeId, NULL, &depleted);
 	if(depleted) return NULL;
 
 	Record r = OpBase_CreateRecord((OpBase *)op);

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -191,7 +191,7 @@ static void _CollectEdgesFromEntry
 	EdgeID edgeId,
 	Edge **edges
 ) {
-	Edge e;
+	Edge e = {0};
 
 	e.relationID  =  r;
 	e.srcNodeID   =  src;

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -165,7 +165,7 @@ void Graph_WriterLeave(Graph *g) {
 }
 
 /* Force execution of all pending operations on a matrix. */
-static void _Graph_ApplyPending(GrB_Matrix m) {
+static inline void _Graph_ApplyPending(GrB_Matrix m) {
 	GrB_Info res = GrB_wait(&m);
 	ASSERT(res == GrB_SUCCESS);
 }

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -165,7 +165,7 @@ void Graph_WriterLeave(Graph *g) {
 }
 
 /* Force execution of all pending operations on a matrix. */
-static inline void _Graph_ApplyPending(GrB_Matrix m) {
+static void _Graph_ApplyPending(GrB_Matrix m) {
 	GrB_Info res = GrB_wait(&m);
 	ASSERT(res == GrB_SUCCESS);
 }
@@ -182,34 +182,31 @@ static inline size_t _Graph_EdgeCap(const Graph *g) {
 	return g->edges->itemCap;
 }
 
-// Locates edges connecting src to destination.
-void _Graph_GetEdgesConnectingNodes(const Graph *g, NodeID src, NodeID dest, int r, Edge **edges) {
-	ASSERT(g && src < Graph_RequiredMatrixDim(g) && dest < Graph_RequiredMatrixDim(g) &&
-		   r < Graph_RelationTypeCount(g));
-
+static void _CollectEdgesFromEntry
+(
+	const Graph *g,
+	NodeID src,
+	NodeID dest,
+	int r,
+	EdgeID edgeId,
+	Edge **edges
+) {
 	Edge e;
-	EdgeID edgeId;
-	e.relationID = r;
-	e.srcNodeID = src;
-	e.destNodeID = dest;
 
-	// relation map, maps (src, dest, r) to edge IDs.
-	GrB_Matrix relation = Graph_GetRelationMatrix(g, r);
-	GrB_Info res = GrB_Matrix_extractElement_UINT64(&edgeId, relation, src, dest);
-
-	// No entry at [dest, src], src is not connected to dest with relation R.
-	if(res == GrB_NO_VALUE) return;
+	e.relationID  =  r;
+	e.srcNodeID   =  src;
+	e.destNodeID  =  dest;
 
 	if(SINGLE_EDGE(edgeId)) {
-		// Discard most significate bit.
-		edgeId = SINGLE_EDGE_ID(edgeId);
-		e.entity = DataBlock_GetItem(g->edges, edgeId);
-		e.id = edgeId;
+		// discard most significate bit
+		edgeId    =  SINGLE_EDGE_ID(edgeId);
+		e.id      =  edgeId;
+		e.entity  =  DataBlock_GetItem(g->edges,  edgeId);
 		ASSERT(e.entity);
 		array_append(*edges, e);
 	} else {
-		/* Multiple edges connecting src to dest,
-		 * entry is a pointer to an array of edge IDs. */
+		// multiple edges connecting src to dest,
+		// entry is a pointer to an array of edge IDs
 		EdgeID *edgeIds = (EdgeID *)edgeId;
 		int edgeCount = array_len(edgeIds);
 
@@ -221,6 +218,32 @@ void _Graph_GetEdgesConnectingNodes(const Graph *g, NodeID src, NodeID dest, int
 			array_append(*edges, e);
 		}
 	}
+}
+
+// Locates edges connecting src to destination.
+void _Graph_GetEdgesConnectingNodes
+(
+	const Graph *g,
+	NodeID src,
+	NodeID dest,
+	int r,
+	Edge **edges
+) {
+	ASSERT(g);
+	ASSERT(r    != GRAPH_NO_RELATION);
+	ASSERT(r    < Graph_RelationTypeCount(g));
+	ASSERT(src  < Graph_RequiredMatrixDim(g));
+	ASSERT(dest < Graph_RequiredMatrixDim(g));
+
+	// relation map, maps (src, dest, r) to edge IDs.
+	EdgeID      id    =  INVALID_ENTITY_ID;
+	GrB_Matrix  M     =  Graph_GetRelationMatrix(g, r);
+	GrB_Info    res   =  GrB_Matrix_extractElement_UINT64(&id, M, src, dest);
+
+	// no entry at [dest, src], src is not connected to dest with relation R
+	if(res == GrB_NO_VALUE) return;
+
+	_CollectEdgesFromEntry(g, src, dest, r, id, edges);
 }
 
 static inline Entity *_Graph_GetEntity(const DataBlock *entities, EntityID id) {
@@ -562,23 +585,34 @@ int Graph_GetEdgeRelation(const Graph *g, Edge *e) {
 	return GRAPH_NO_RELATION;
 }
 
-void Graph_GetEdgesConnectingNodes(const Graph *g, NodeID srcID, NodeID destID,
-								   int r, Edge **edges) {
-	ASSERT(g && r < Graph_RelationTypeCount(g) && edges);
+void Graph_GetEdgesConnectingNodes
+(
+	const Graph *g,
+	NodeID srcID,
+	NodeID destID,
+	int r,
+	Edge **edges)
+{
+	ASSERT(g);
+	ASSERT(edges);
+	ASSERT(r < Graph_RelationTypeCount(g)); 
 
-	// Invalid relation type specified; this can occur on multi-type traversals like:
+	// invalid relation type specified;
+	// this can occur on multi-type traversals like:
 	// MATCH ()-[:real_type|fake_type]->()
 	if(r == GRAPH_UNKNOWN_RELATION) return;
 
-	Node srcNode = GE_NEW_NODE();
-	Node destNode = GE_NEW_NODE();
+#if RG_DEBUG
+	Node  srcNode   =  GE_NEW_NODE();
+	Node  destNode  =  GE_NEW_NODE();
 	ASSERT(Graph_GetNode(g, srcID, &srcNode));
 	ASSERT(Graph_GetNode(g, destID, &destNode));
+#endif
 
 	if(r != GRAPH_NO_RELATION) {
 		_Graph_GetEdgesConnectingNodes(g, srcID, destID, r, edges);
 	} else {
-		// Relation type missing, scan through each edge type.
+		// relation type missing, scan through each edge type
 		int relationCount = Graph_RelationTypeCount(g);
 		for(int i = 0; i < relationCount; i++) {
 			_Graph_GetEdgesConnectingNodes(g, srcID, destID, i, edges);
@@ -712,8 +746,8 @@ int Graph_ConnectNodes(Graph *g, NodeID src, NodeID dest, int r, Edge *e) {
 	return 1;
 }
 
-/* Retrieves all either incoming or outgoing edges
- * to/from given node N, depending on given direction. */
+// retrieves all either incoming or outgoing edges
+// to/from given node N, depending on given direction
 void Graph_GetNodeEdges
 (
 	const Graph *g,      // graph to collect edges from
@@ -728,10 +762,11 @@ void Graph_GetNodeEdges
 
 	if(r == GRAPH_UNKNOWN_RELATION) return;
 
-	GrB_Matrix           M           =  NULL;
-	NodeID               srcID       =  ENTITY_GET_ID(n);
-	NodeID               destID      =  INVALID_ENTITY_ID;
-	GxB_MatrixTupleIter  *tupleIter  =  NULL;
+	GrB_Matrix           M       =  NULL;
+	GxB_MatrixTupleIter  *it     =  NULL;
+	NodeID               srcID   =  ENTITY_GET_ID(n);
+	NodeID               destID  =  INVALID_ENTITY_ID;
+	EdgeID               edgeID  =  INVALID_ENTITY_ID;
 
 	// outgoing
 	if(dir == GRAPH_EDGE_DIR_OUTGOING || dir == GRAPH_EDGE_DIR_BOTH) {
@@ -742,16 +777,21 @@ void Graph_GetNodeEdges
 
 		// construct an iterator to traverse over the source node row,
 		// containing all outgoing edges
-		GxB_MatrixTupleIter_new(&tupleIter, M);
-		GxB_MatrixTupleIter_iterate_row(tupleIter, srcID);
+		GxB_MatrixTupleIter_new(&it, M);
+		GxB_MatrixTupleIter_iterate_row(it, srcID);
 		while(true) {
 			bool depleted = false;
-			GxB_MatrixTupleIter_next(tupleIter, NULL, &destID, &depleted);
+			GxB_MatrixTupleIter_next(it, NULL, &destID, &edgeID, &depleted);
 			if(depleted) break;
+
 			// collect all edges (src)->(dest)
-			Graph_GetEdgesConnectingNodes(g, srcID, destID, r, edges);
+			if(r != GRAPH_NO_RELATION) {
+				_CollectEdgesFromEntry(g, srcID, destID, r, edgeID, edges);
+			} else {
+				Graph_GetEdgesConnectingNodes(g, srcID, destID, r, edges);
+			}
 		}
-		GxB_MatrixTupleIter_free(tupleIter);
+		GxB_MatrixTupleIter_free(it);
 	}
 
 	// incoming
@@ -763,19 +803,23 @@ void Graph_GetNodeEdges
 
 		// construct an iterator to traverse over the source node row,
 		// containing all incoming edges
-		GxB_MatrixTupleIter_new(&tupleIter, M);
-		GxB_MatrixTupleIter_iterate_row(tupleIter, srcID);
+		GxB_MatrixTupleIter_new(&it, M);
+		GxB_MatrixTupleIter_iterate_row(it, srcID);
 
 		while(true) {
 			bool depleted = false;
-			GxB_MatrixTupleIter_next(tupleIter, NULL, &destID, &depleted);
+			GxB_MatrixTupleIter_next(it, NULL, &destID, &edgeID, &depleted);
 			if(depleted) break;
 			// collect all edges connecting destId to srcId
-			Graph_GetEdgesConnectingNodes(g, destID, srcID, r, edges);
+			if(r != GRAPH_NO_RELATION) {
+				_CollectEdgesFromEntry(g, destID, srcID, r, edgeID, edges);
+			} else {
+				Graph_GetEdgesConnectingNodes(g, destID, srcID, r, edges);
+			}
 		}
 
 		// Clean up
-		GxB_MatrixTupleIter_free(tupleIter);
+		GxB_MatrixTupleIter_free(it);
 	}
 }
 
@@ -1123,7 +1167,7 @@ static void _BulkDeleteNodes(Graph *g, Node *nodes, uint node_count,
 		// outgoing edges
 		GxB_MatrixTupleIter_iterate_row(adj_iter, ID);
 		while(true) {
-			GxB_MatrixTupleIter_next(adj_iter, NULL, &dest, &depleted);
+			GxB_MatrixTupleIter_next(adj_iter, NULL, &dest, NULL, &depleted);
 			if(depleted) break;
 			GrB_Matrix_setElement_BOOL(Mask, true, ID, dest);
 		}
@@ -1133,7 +1177,7 @@ static void _BulkDeleteNodes(Graph *g, Node *nodes, uint node_count,
 		// incoming edges
 		GxB_MatrixTupleIter_iterate_row(tadj_iter, ID);
 		while(true) {
-			GxB_MatrixTupleIter_next(tadj_iter, NULL, &src, &depleted);
+			GxB_MatrixTupleIter_next(tadj_iter, NULL, &src, NULL, &depleted);
 			if(depleted) break;
 			GrB_Matrix_setElement_BOOL(Mask, true, src, ID);
 		}
@@ -1518,11 +1562,21 @@ GrB_Matrix Graph_GetRelationMatrix(const Graph *g, int relation_idx) {
 }
 
 // Returns true if relationship matrix 'r' contains multi-edge entries, false otherwise
-bool Graph_RelationshipContainsMultiEdge(const Graph *g, int r) {
+bool Graph_RelationshipContainsMultiEdge
+(
+	const Graph *g,
+	int r,
+	bool transpose
+) {
 	ASSERT(Graph_RelationTypeCount(g) > r);
-	GrB_Index nvals;
-	// A relationship matrix contains multi-edge if nvals < number of edges with type r.
-	GrB_Matrix R = Graph_GetRelationMatrix(g, r);
+
+	GrB_Matrix  R;
+	GrB_Index   nvals;
+	// a relationship matrix contains multi-edge
+	// if nvals < number of edges with type r
+	if(transpose) R = Graph_GetTransposedRelationMatrix(g, r);
+	else R = Graph_GetRelationMatrix(g, r);
+
 	GrB_Matrix_nvals(&nvals, R);
 
 	return (Graph_RelationEdgeCount(g, r) > nvals);

--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -321,8 +321,13 @@ GrB_Matrix Graph_GetRelationMatrix(
 	int relation        // Relation described by matrix.
 );
 
-// Returns true if relationship matrix 'r' contains multi-edge entries, false otherwise.
-bool Graph_RelationshipContainsMultiEdge(const Graph *g, int r);
+// returns true if relationship matrix 'r' contains multi-edge entries
+// false otherwise
+bool Graph_RelationshipContainsMultiEdge(
+	const Graph *g, // Graph containing matrix to inspect
+	int r,          // Relationship ID
+	bool transpose  // false for R, true for transpose R
+);
 
 // Retrieves a transposed typed adjacency matrix.
 // Matrix is resized if its size doesn't match graph's node count.

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -61,7 +61,7 @@ static void _populateIndex(Index *idx) {
 	// Iterate over each labeled node.
 	while(true) {
 		bool depleted = false;
-		GxB_MatrixTupleIter_next(it, NULL, &node_id, &depleted);
+		GxB_MatrixTupleIter_next(it, NULL, &node_id, NULL, &depleted);
 		if(depleted) break;
 
 		Graph_GetNode(g, node_id, &node);

--- a/src/index/index.c
+++ b/src/index/index.c
@@ -50,11 +50,13 @@ static void _populateIndex(Index *idx) {
 	// Label doesn't exists.
 	if(s == NULL) return;
 
-	Node node = GE_NEW_NODE();
-	NodeID node_id;
-	Graph *g = gc->g;
-	int label_id = s->id;
+	NodeID  node_id;
 	GxB_MatrixTupleIter *it;
+
+	Node   node      =  GE_NEW_NODE();
+	Graph  *g        =  gc->g;
+	int    label_id  =  s->id;
+
 	const GrB_Matrix label_matrix = Graph_GetLabelMatrix(g, label_id);
 	GxB_MatrixTupleIter_new(&it, label_matrix);
 

--- a/src/procedures/proc_bfs.c
+++ b/src/procedures/proc_bfs.c
@@ -178,7 +178,7 @@ static SIValue *Proc_BFS_Step(ProcedureCtx *ctx) {
 	UNUSED(res);
 	res = GxB_MatrixTupleIter_new(&iter, (GrB_Matrix)bfs_ctx->nodes);
 	ASSERT(res == GrB_SUCCESS);
-	res = GxB_MatrixTupleIter_next(iter, NULL, &id, &depleted);
+	res = GxB_MatrixTupleIter_next(iter, NULL, &id, NULL, &depleted);
 	ASSERT(res == GrB_SUCCESS);
 
 	while(!depleted) {
@@ -203,7 +203,7 @@ static SIValue *Proc_BFS_Step(ProcedureCtx *ctx) {
 			SIArray_Append(&edges, SI_Edge(edge));
 		}
 
-		res = GxB_MatrixTupleIter_next(iter, NULL, &id, &depleted);
+		res = GxB_MatrixTupleIter_next(iter, NULL, &id, NULL, &depleted);
 		ASSERT(res == GrB_SUCCESS);
 	}
 

--- a/src/serializers/encoder/v9/encode_graph_entities.c
+++ b/src/serializers/encoder/v9/encode_graph_entities.c
@@ -274,7 +274,7 @@ void RdbSaveEdges_v9(RedisModuleIO *rdb, GraphContext *gc, uint64_t edges_to_enc
 		EdgeID edgeID;
 		bool depleted = false;
 		// Try to get next tuple.
-		GxB_MatrixTupleIter_next(iter, &src, &dest, &depleted);
+		GxB_MatrixTupleIter_next(iter, &src, &dest, &edgeID, &depleted);
 		// If iterator is depleted, get new tuple from different matrix or finish encode.
 		while(depleted && r < relation_count) {
 			// Free iterator
@@ -288,12 +288,11 @@ void RdbSaveEdges_v9(RedisModuleIO *rdb, GraphContext *gc, uint64_t edges_to_enc
 			// Get matrix and set iterator.
 			M = Graph_GetRelationMatrix(gc->g, r);
 			GxB_MatrixTupleIter_new(&iter, M);
-			GxB_MatrixTupleIter_next(iter, &src, &dest, &depleted);
+			GxB_MatrixTupleIter_next(iter, &src, &dest, &edgeID, &depleted);
 		}
 
 		e.srcNodeID = src;
 		e.destNodeID = dest;
-		GrB_Matrix_extractElement_UINT64(&edgeID, M, e.srcNodeID, e.destNodeID);
 		if(SINGLE_EDGE(edgeID)) {
 			edgeID = SINGLE_EDGE_ID(edgeID);
 			Graph_GetEdge(gc->g, edgeID, &e);

--- a/tests/unit/test_graph.cpp
+++ b/tests/unit/test_graph.cpp
@@ -944,36 +944,37 @@ TEST_F(GraphTest, GraphStatistics) {
 	* 9. Verify r0 multi edge (True) */
 
 	// 1. Verify r0 multi edge (False)
-	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r0));
+	bool transpose = false;
+	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r0, transpose));
 	// (0)-[r0]->(1)
 	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[0]), ENTITY_GET_ID(&n[1]), r0, &e[0]);
 	ASSERT_EQ(g->stats.edge_count[r0], 1);
 	// 2. Verify r0 multi edge (False)
-	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r0));
+	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r0, transpose));
 	// (0)-[r0]->(1)
 	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[0]), ENTITY_GET_ID(&n[1]), r0, &e[1]);
 	// 3. Verify r0 multi edge (True)
-	ASSERT_TRUE(Graph_RelationshipContainsMultiEdge(g, r0));
+	ASSERT_TRUE(Graph_RelationshipContainsMultiEdge(g, r0, transpose));
 	// 4. Verify r1 no multi edge
-	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r1));
+	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r1, transpose));
 	// (0)-[r1]->(1)
 	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[0]), ENTITY_GET_ID(&n[1]), r1, &e[2]);
 	// 5. Verify r1 multi edge (False)
-	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r1));
+	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r1, transpose));
 	// (1)-[r1]->(0)
 	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[1]), ENTITY_GET_ID(&n[0]), r1, &e[3]);
 	// 6. Verify r1 multi edge (False)
-	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r1));
+	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r1, transpose));
 	// (2)-[r1]->(1)
 	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[2]), ENTITY_GET_ID(&n[1]), r1, &e[4]);
 	// 7. Verify r1 multi edge (False)
-	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r1));
+	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r1, transpose));
 	// (2)-[r1]->(1)
 	Graph_ConnectNodes(g, ENTITY_GET_ID(&n[2]), ENTITY_GET_ID(&n[1]), r1, &e[5]);
 	// 8. Verify r1 multi edge (True)
-	ASSERT_TRUE(Graph_RelationshipContainsMultiEdge(g, r1));
+	ASSERT_TRUE(Graph_RelationshipContainsMultiEdge(g, r1, transpose));
 	// 9. Verify r0 multi edge (True)
-	ASSERT_TRUE(Graph_RelationshipContainsMultiEdge(g, r0));
+	ASSERT_TRUE(Graph_RelationshipContainsMultiEdge(g, r0, transpose));
 
 	Graph_ReleaseLock(g);
 	/* Delete edges:
@@ -990,8 +991,8 @@ TEST_F(GraphTest, GraphStatistics) {
 	Graph_BulkDelete(g, &n[2], 1, &e[0], 1, &node_deleted, &edge_deleted);
 	Graph_ReleaseLock(g);
 
-	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r0));
-	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r1));
+	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r0, transpose));
+	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r1, transpose));
 	ASSERT_EQ(Graph_RelationEdgeCount(g, r0), 1);
 	ASSERT_EQ(Graph_RelationEdgeCount(g, r1), 2);
 	ASSERT_EQ(node_deleted, 1);

--- a/tests/unit/test_tuples_iter.cpp
+++ b/tests/unit/test_tuples_iter.cpp
@@ -98,11 +98,11 @@ TEST_F(TuplesTest, RandomVectorTest) {
 	//--------------------------------------------------------------------------
 	bool depleted = false;
 	for(int i = 0; i < nvals; i++) {
-		GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+		GxB_MatrixTupleIter_next(iter, NULL, &col, NULL, &depleted);
 		ASSERT_FALSE(depleted);
 		ASSERT_EQ(col, I_expected[i]);
 	}
-	GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+	GxB_MatrixTupleIter_next(iter, NULL, &col, NULL, &depleted);
 	ASSERT_TRUE(depleted);
 
 	//--------------------------------------------------------------------------
@@ -143,11 +143,11 @@ TEST_F(TuplesTest, VectorIteratorTest) {
 	//--------------------------------------------------------------------------
 	bool depleted = false;
 	for(int i = 0; i < nvals; i++) {
-		GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+		GxB_MatrixTupleIter_next(iter, NULL, &col, NULL, &depleted);
 		ASSERT_FALSE(depleted);
 		ASSERT_EQ(col, I_expected[i]);
 	}
-	GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+	GxB_MatrixTupleIter_next(iter, NULL, &col, NULL, &depleted);
 	ASSERT_TRUE(depleted);
 
 	//--------------------------------------------------------------------------
@@ -156,11 +156,11 @@ TEST_F(TuplesTest, VectorIteratorTest) {
 
 	GxB_MatrixTupleIter_reset(iter);
 	for(int i = 0; i < nvals; i++) {
-		GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+		GxB_MatrixTupleIter_next(iter, NULL, &col, NULL, &depleted);
 		ASSERT_FALSE(depleted);
 		ASSERT_EQ(col, I_expected[i]);
 	}
-	GxB_MatrixTupleIter_next(iter, NULL, &col, &depleted);
+	GxB_MatrixTupleIter_next(iter, NULL, &col, NULL, &depleted);
 	ASSERT_TRUE(depleted);
 
 	//--------------------------------------------------------------------------
@@ -216,12 +216,12 @@ TEST_F(TuplesTest, RandomMatrixTest) {
 	//--------------------------------------------------------------------------
 	bool depleted = false;
 	for(int i = 0; i < nvals; i++) {
-		GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 		ASSERT_FALSE(depleted);
 		ASSERT_EQ(row, I_expected[i]);
 		ASSERT_EQ(col, J_expected[i]);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 	ASSERT_TRUE(depleted);
 
 	//--------------------------------------------------------------------------
@@ -261,12 +261,12 @@ TEST_F(TuplesTest, MatrixIteratorTest) {
 	//--------------------------------------------------------------------------
 	bool depleted = false;
 	for(int i = 0; i < nvals; i++) {
-		GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 		ASSERT_FALSE(depleted);
 		ASSERT_EQ(row, I_expected[i]);
 		ASSERT_EQ(col, J_expected[i]);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 	ASSERT_TRUE(depleted);
 
 	//--------------------------------------------------------------------------
@@ -275,12 +275,12 @@ TEST_F(TuplesTest, MatrixIteratorTest) {
 
 	GxB_MatrixTupleIter_reset(iter);
 	for(int i = 0; i < nvals; i++) {
-		GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 		ASSERT_FALSE(depleted);
 		ASSERT_EQ(row, I_expected[i]);
 		ASSERT_EQ(col, J_expected[i]);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 	ASSERT_TRUE(depleted);
 
 	//--------------------------------------------------------------------------
@@ -328,12 +328,12 @@ TEST_F(TuplesTest, ColumnIteratorTest) {
 			//--------------------------------------------------------------------------
 			bool depleted = false;
 			for(int i = 0; i < nvals; i++) {
-				GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+				GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 				ASSERT_FALSE(depleted);
 				ASSERT_EQ(row, I_expected[i]);
 				ASSERT_EQ(col, j);
 			}
-			GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+			GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 			ASSERT_TRUE(depleted);
 		}
 
@@ -367,7 +367,7 @@ TEST_F(TuplesTest, ColumnIteratorEmptyMatrixTest) {
 		// Verify iterator returned values.
 		//--------------------------------------------------------------------------
 		bool depleted = false;
-		GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 		ASSERT_TRUE(depleted);
 	}
 
@@ -416,13 +416,13 @@ TEST_F(TuplesTest, IteratorJumpToRowTest) {
 
 	// Check that the right indices are retrived.
 	for(int i = 1; i < 5; i++) {
-		info = GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		info = GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 		ASSERT_EQ(GrB_SUCCESS, info);
 		ASSERT_EQ(indices[i][0], row);
 		ASSERT_EQ(indices[i][1], col);
 		ASSERT_FALSE(depleted);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 	ASSERT_TRUE(depleted);
 
 	// Jump to start, check that iterator is depleted only when it is done iterating the matrix.
@@ -430,13 +430,13 @@ TEST_F(TuplesTest, IteratorJumpToRowTest) {
 	ASSERT_EQ(GrB_SUCCESS, info);
 
 	for(int i = 0; i < 5; i ++) {
-		info = GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		info = GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 		ASSERT_EQ(GrB_SUCCESS, info);
 		ASSERT_EQ(indices[i][0], row);
 		ASSERT_EQ(indices[i][1], col);
 		ASSERT_FALSE(depleted);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 	ASSERT_TRUE(depleted);
 }
 
@@ -486,13 +486,13 @@ TEST_F(TuplesTest, IteratorRange) {
 
 	// Check that the right indices are retrived.
 	for(int i = 1; i <= 2; i++) {
-		info = GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		info = GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 		ASSERT_EQ(GrB_SUCCESS, info);
 		ASSERT_EQ(indices[i][0], row);
 		ASSERT_EQ(indices[i][1], col);
 		ASSERT_FALSE(depleted);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 	ASSERT_TRUE(depleted);
 
 	// Check for legal range setting.
@@ -501,13 +501,13 @@ TEST_F(TuplesTest, IteratorRange) {
 
 	// Check that the right indices are retrived.
 	for(int i = 1; i <= 4; i++) {
-		info = GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		info = GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 		ASSERT_EQ(GrB_SUCCESS, info);
 		ASSERT_EQ(indices[i][0], row);
 		ASSERT_EQ(indices[i][1], col);
 		ASSERT_FALSE(depleted);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 	ASSERT_TRUE(depleted);
 
 
@@ -516,13 +516,13 @@ TEST_F(TuplesTest, IteratorRange) {
 	ASSERT_EQ(GrB_SUCCESS, info);
 
 	for(int i = 0; i < 6; i ++) {
-		info = GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+		info = GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 		ASSERT_EQ(GrB_SUCCESS, info);
 		ASSERT_EQ(indices[i][0], row);
 		ASSERT_EQ(indices[i][1], col);
 		ASSERT_FALSE(depleted);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
 	ASSERT_TRUE(depleted);
 }
 

--- a/tests/unit/test_tuples_iter.cpp
+++ b/tests/unit/test_tuples_iter.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */
@@ -35,25 +35,29 @@ class TuplesTest: public ::testing::Test {
 	GrB_Matrix CreateSquareNByNDiagonalMatrix(GrB_Index n) {
 		GrB_Matrix A = CreateSquareNByNEmptyMatrix(n);
 
-		GrB_Index I[n];
-		GrB_Index J[n];
-		bool X[n];
+		uint64_t  *X = (uint64_t*)  malloc(sizeof(uint64_t)  * n);
+		GrB_Index *I = (GrB_Index*) malloc(sizeof(GrB_Index) * n);
+		GrB_Index *J = (GrB_Index*) malloc(sizeof(GrB_Index) * n);
 
-		// Initialize.
+		// initialize
 		for(int i = 0; i < n; i++) {
 			I[i] = i;
 			J[i] = i;
-			X[i] = i;
+			X[i] = 1;
 		}
 
-		GrB_Matrix_build_BOOL(A, I, J, X, n, GrB_FIRST_BOOL);
+		GrB_Matrix_build_UINT64(A, I, J, X, n, GrB_FIRST_UINT64);
+
+		free(X);
+		free(I);
+		free(J);
 
 		return A;
 	}
 
 	GrB_Matrix CreateSquareNByNEmptyMatrix(GrB_Index n) {
 		GrB_Matrix A;
-		GrB_Matrix_new(&A, GrB_BOOL, n, n);
+		GrB_Matrix_new(&A, GrB_UINT64, n, n);
 		return A;
 	}
 };
@@ -123,31 +127,35 @@ TEST_F(TuplesTest, VectorIteratorTest) {
 	GrB_Vector_new(&A, GrB_BOOL, 4);
 
 	GrB_Index nvals = 2;
-	GrB_Index I[2] = {1, 3};
-	bool X[2] = {true, true};
+	GrB_Index I[2]  = {1, 3};
+	bool      X[2]  = {true, true};
+
+	bool      X_expected[nvals];
 	GrB_Index I_expected[nvals];
 
 	GrB_Vector_build_BOOL(A, I, X, nvals, GrB_FIRST_BOOL);
-	GrB_Vector_extractTuples_BOOL(I_expected, NULL, &nvals, A);
+	GrB_Vector_extractTuples_BOOL(I_expected, X_expected, &nvals, A);
 
 	//--------------------------------------------------------------------------
 	// Get an iterator over all vector nonzero elements.
 	//--------------------------------------------------------------------------
 
-	GxB_MatrixTupleIter *iter;
+	bool                 val;
+	GrB_Index            col;
+	GxB_MatrixTupleIter  *iter;
 	GxB_MatrixTupleIter_new(&iter, (GrB_Matrix)A);
-	GrB_Index col;
 
 	//--------------------------------------------------------------------------
 	// Verify iterator returned values.
 	//--------------------------------------------------------------------------
 	bool depleted = false;
 	for(int i = 0; i < nvals; i++) {
-		GxB_MatrixTupleIter_next(iter, NULL, &col, NULL, &depleted);
+		GxB_MatrixTupleIter_next(iter, NULL, &col, &val, &depleted);
 		ASSERT_FALSE(depleted);
 		ASSERT_EQ(col, I_expected[i]);
+		ASSERT_EQ(val, X_expected[i]);
 	}
-	GxB_MatrixTupleIter_next(iter, NULL, &col, NULL, &depleted);
+	GxB_MatrixTupleIter_next(iter, NULL, &col, &val, &depleted);
 	ASSERT_TRUE(depleted);
 
 	//--------------------------------------------------------------------------
@@ -156,11 +164,12 @@ TEST_F(TuplesTest, VectorIteratorTest) {
 
 	GxB_MatrixTupleIter_reset(iter);
 	for(int i = 0; i < nvals; i++) {
-		GxB_MatrixTupleIter_next(iter, NULL, &col, NULL, &depleted);
+		GxB_MatrixTupleIter_next(iter, NULL, &col, &val, &depleted);
 		ASSERT_FALSE(depleted);
 		ASSERT_EQ(col, I_expected[i]);
+		ASSERT_EQ(val, X_expected[i]);
 	}
-	GxB_MatrixTupleIter_next(iter, NULL, &col, NULL, &depleted);
+	GxB_MatrixTupleIter_next(iter, NULL, &col, &val, &depleted);
 	ASSERT_TRUE(depleted);
 
 	//--------------------------------------------------------------------------
@@ -179,11 +188,12 @@ TEST_F(TuplesTest, RandomMatrixTest) {
 	GrB_Index nvals = 0;
 	GrB_Index nrows = 1024;
 	GrB_Index ncols = 1024;
-	GrB_Index *I = (GrB_Index *)malloc(sizeof(GrB_Index) * ncols * nrows);
-	GrB_Index *J = (GrB_Index *)malloc(sizeof(GrB_Index) * ncols * nrows);
-	bool *X = (bool *)malloc(sizeof(bool) * ncols * nrows);
 
-	GrB_Matrix_new(&A, GrB_BOOL, nrows, ncols);
+	uint64_t  *X = (uint64_t  *) malloc(sizeof(GrB_UINT64) * ncols * nrows);
+	GrB_Index *I = (GrB_Index *) malloc(sizeof(GrB_Index)  * ncols * nrows);
+	GrB_Index *J = (GrB_Index *) malloc(sizeof(GrB_Index)  * ncols * nrows);
+
+	GrB_Matrix_new(&A, GrB_UINT64, nrows, ncols);
 
 	double mid_point = RAND_MAX / 2;
 	for(int i = 0; i < nrows; i++) {
@@ -191,37 +201,41 @@ TEST_F(TuplesTest, RandomMatrixTest) {
 			if(rand() > mid_point) {
 				I[nvals] = i;
 				J[nvals] = j;
-				X[nvals] = true;
+				X[nvals] = rand();
 				nvals++;
 			}
 		}
 	}
-	GrB_Matrix_build_BOOL(A, I, J, X, nvals, GrB_FIRST_BOOL);
+	GrB_Matrix_build_UINT64(A, I, J, X, nvals, GrB_FIRST_UINT64);
 
-	GrB_Index *I_expected = (GrB_Index *)malloc(sizeof(GrB_Index) * nvals);
-	GrB_Index *J_expected = (GrB_Index *)malloc(sizeof(GrB_Index) * nvals);
-	GrB_Matrix_extractTuples_BOOL(I_expected, J_expected, NULL, &nvals, A);
+	GrB_Index *I_expected = (GrB_Index *) malloc(sizeof(GrB_Index) * nvals);
+	GrB_Index *J_expected = (GrB_Index *) malloc(sizeof(GrB_Index) * nvals);
+	uint64_t  *X_expected = (uint64_t  *) malloc(sizeof(uint64_t)  * nvals);
+	GrB_Matrix_extractTuples_UINT64(
+			I_expected, J_expected, X_expected, &nvals, A);
 
 	//--------------------------------------------------------------------------
 	// Get an iterator over all matrix nonzero elements.
 	//--------------------------------------------------------------------------
 
-	GxB_MatrixTupleIter *iter;
+	uint64_t             val;
+	GrB_Index            row;
+	GrB_Index            col;
+	GxB_MatrixTupleIter  *iter;
 	GxB_MatrixTupleIter_new(&iter, A);
-	GrB_Index row;
-	GrB_Index col;
 
 	//--------------------------------------------------------------------------
 	// Verify iterator returned values.
 	//--------------------------------------------------------------------------
 	bool depleted = false;
 	for(int i = 0; i < nvals; i++) {
-		GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+		GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 		ASSERT_FALSE(depleted);
 		ASSERT_EQ(row, I_expected[i]);
 		ASSERT_EQ(col, J_expected[i]);
+		ASSERT_EQ(val, X_expected[i]);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 	ASSERT_TRUE(depleted);
 
 	//--------------------------------------------------------------------------
@@ -232,6 +246,7 @@ TEST_F(TuplesTest, RandomMatrixTest) {
 	free(X);
 	free(I_expected);
 	free(J_expected);
+	free(X_expected);
 	GxB_MatrixTupleIter_free(iter);
 	GrB_Matrix_free(&A);
 }
@@ -245,28 +260,32 @@ TEST_F(TuplesTest, MatrixIteratorTest) {
 	GrB_Matrix A = CreateSquareNByNDiagonalMatrix(nvals);
 	GrB_Index I_expected[nvals];
 	GrB_Index J_expected[nvals];
-	GrB_Matrix_extractTuples_BOOL(I_expected, J_expected, NULL, &nvals, A);
+	uint64_t  X_expected[nvals];
+	GrB_Matrix_extractTuples_UINT64(
+			I_expected, J_expected, X_expected, &nvals, A);
 
 	//--------------------------------------------------------------------------
 	// Get an iterator over all matrix nonzero elements.
 	//--------------------------------------------------------------------------
 
-	GxB_MatrixTupleIter *iter;
+	uint64_t             val;
+	GrB_Index            row;
+	GrB_Index            col;
+	GxB_MatrixTupleIter  *iter;
 	GxB_MatrixTupleIter_new(&iter, A);
-	GrB_Index row;
-	GrB_Index col;
 
 	//--------------------------------------------------------------------------
 	// Verify iterator returned values.
 	//--------------------------------------------------------------------------
 	bool depleted = false;
 	for(int i = 0; i < nvals; i++) {
-		GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+		GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 		ASSERT_FALSE(depleted);
 		ASSERT_EQ(row, I_expected[i]);
 		ASSERT_EQ(col, J_expected[i]);
+		ASSERT_EQ(val, X_expected[i]);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 	ASSERT_TRUE(depleted);
 
 	//--------------------------------------------------------------------------
@@ -275,12 +294,13 @@ TEST_F(TuplesTest, MatrixIteratorTest) {
 
 	GxB_MatrixTupleIter_reset(iter);
 	for(int i = 0; i < nvals; i++) {
-		GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+		GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 		ASSERT_FALSE(depleted);
 		ASSERT_EQ(row, I_expected[i]);
 		ASSERT_EQ(col, J_expected[i]);
+		ASSERT_EQ(val, X_expected[i]);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 	ASSERT_TRUE(depleted);
 
 	//--------------------------------------------------------------------------
@@ -307,9 +327,9 @@ TEST_F(TuplesTest, ColumnIteratorTest) {
 	GxB_MatrixTupleIter_new(&iter, A);
 
 	for(int j = 0; j < ncols; j++) {
-		GrB_Vector_new(&v, GrB_BOOL, nrows);
+		GrB_Vector_new(&v, GrB_UINT64, nrows);
 		GrB_Col_extract(v, NULL, NULL, A, GrB_ALL, nrows, j, NULL);
-		GrB_Vector_extractTuples_BOOL(I_expected, NULL, &nvals, v);
+		GrB_Vector_extractTuples_UINT64(I_expected, NULL, &nvals, v);
 
 		//--------------------------------------------------------------------------
 		// Test iterating over each column twice, this is to check
@@ -378,18 +398,19 @@ TEST_F(TuplesTest, ColumnIteratorEmptyMatrixTest) {
 TEST_F(TuplesTest, IteratorJumpToRowTest) {
 
 	// Matrix is 5X5 and will be populated with the following indices.
-	GrB_Index indices[5][2] = {
-		{0, 2},
-		{2, 1},
-		{2, 3},
-		{3, 0},
-		{3, 4}
+	GrB_Index indices[5][3] = {
+		{0, 2, 2},
+		{2, 1, 2},
+		{2, 3, 3},
+		{3, 0, 3},
+		{3, 4, 4}
 	};
 
-	bool depleted;
-	GrB_Info info;
-	GrB_Index row;
-	GrB_Index col;
+	GrB_Info   info;
+	GrB_Index  row;
+	GrB_Index  col;
+	uint64_t   val;
+	bool       depleted;
 
 	// Create and populate the matrix.
 	GrB_Index n = 5;
@@ -397,7 +418,8 @@ TEST_F(TuplesTest, IteratorJumpToRowTest) {
 	for(int i = 0; i < 5; i ++) {
 		row = indices[i][0];
 		col = indices[i][1];
-		GrB_Matrix_setElement_BOOL(A, true, row, col);
+		val = indices[i][2];
+		GrB_Matrix_setElement_UINT64(A, val, row, col);
 	}
 
 	// Create iterator.
@@ -416,13 +438,14 @@ TEST_F(TuplesTest, IteratorJumpToRowTest) {
 
 	// Check that the right indices are retrived.
 	for(int i = 1; i < 5; i++) {
-		info = GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+		info = GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 		ASSERT_EQ(GrB_SUCCESS, info);
 		ASSERT_EQ(indices[i][0], row);
 		ASSERT_EQ(indices[i][1], col);
+		ASSERT_EQ(indices[i][2], val);
 		ASSERT_FALSE(depleted);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 	ASSERT_TRUE(depleted);
 
 	// Jump to start, check that iterator is depleted only when it is done iterating the matrix.
@@ -430,33 +453,34 @@ TEST_F(TuplesTest, IteratorJumpToRowTest) {
 	ASSERT_EQ(GrB_SUCCESS, info);
 
 	for(int i = 0; i < 5; i ++) {
-		info = GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+		info = GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 		ASSERT_EQ(GrB_SUCCESS, info);
 		ASSERT_EQ(indices[i][0], row);
 		ASSERT_EQ(indices[i][1], col);
+		ASSERT_EQ(indices[i][2], val);
 		ASSERT_FALSE(depleted);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 	ASSERT_TRUE(depleted);
 }
-
 
 TEST_F(TuplesTest, IteratorRange) {
 
 	// Matrix is 6X6 and will be populated with the following indices.
-	GrB_Index indices[6][2] = {
-		{0, 2},
-		{2, 1},
-		{2, 3},
-		{3, 0},
-		{3, 4},
-		{5, 5}
+	GrB_Index indices[6][3] = {
+		{0, 2, 2},
+		{2, 1, 2},
+		{2, 3, 3},
+		{3, 0, 3},
+		{3, 4, 4},
+		{5, 5, 5}
 	};
 
-	bool depleted;
-	GrB_Info info;
-	GrB_Index row;
-	GrB_Index col;
+	GrB_Info   info;
+	GrB_Index  row;
+	GrB_Index  col;
+	uint64_t   val;
+	bool       depleted;
 
 	// Create and populate the matrix.
 	GrB_Index n = 6;
@@ -464,7 +488,8 @@ TEST_F(TuplesTest, IteratorRange) {
 	for(int i = 0; i < 6; i ++) {
 		row = indices[i][0];
 		col = indices[i][1];
-		GrB_Matrix_setElement_BOOL(A, true, row, col);
+		val = indices[i][2];
+		GrB_Matrix_setElement_UINT64(A, val, row, col);
 	}
 
 	// Create iterator.
@@ -486,13 +511,14 @@ TEST_F(TuplesTest, IteratorRange) {
 
 	// Check that the right indices are retrived.
 	for(int i = 1; i <= 2; i++) {
-		info = GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+		info = GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 		ASSERT_EQ(GrB_SUCCESS, info);
 		ASSERT_EQ(indices[i][0], row);
 		ASSERT_EQ(indices[i][1], col);
+		ASSERT_EQ(indices[i][2], val);
 		ASSERT_FALSE(depleted);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 	ASSERT_TRUE(depleted);
 
 	// Check for legal range setting.
@@ -501,28 +527,31 @@ TEST_F(TuplesTest, IteratorRange) {
 
 	// Check that the right indices are retrived.
 	for(int i = 1; i <= 4; i++) {
-		info = GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+		info = GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 		ASSERT_EQ(GrB_SUCCESS, info);
 		ASSERT_EQ(indices[i][0], row);
 		ASSERT_EQ(indices[i][1], col);
+		ASSERT_EQ(indices[i][2], val);
 		ASSERT_FALSE(depleted);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 	ASSERT_TRUE(depleted);
 
 
-	// Set the entire rows as range, check that iterator is depleted only when it is done iterating the matrix.
+	// Set the entire rows as range,
+	// check that iterator is depleted only when it is done iterating the matrix
 	info = GxB_MatrixTupleIter_iterate_range(iter, 0, n - 1);
 	ASSERT_EQ(GrB_SUCCESS, info);
 
 	for(int i = 0; i < 6; i ++) {
-		info = GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+		info = GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 		ASSERT_EQ(GrB_SUCCESS, info);
 		ASSERT_EQ(indices[i][0], row);
 		ASSERT_EQ(indices[i][1], col);
+		ASSERT_EQ(indices[i][2], val);
 		ASSERT_FALSE(depleted);
 	}
-	GxB_MatrixTupleIter_next(iter, &row, &col, NULL, &depleted);
+	GxB_MatrixTupleIter_next(iter, &row, &col, &val, &depleted);
 	ASSERT_TRUE(depleted);
 }
 


### PR DESCRIPTION
When performing traversal on a reverse edge (Transpose) of type `R`
we might be inspecting `R` to get information such as dose `R` contains multiple edges, as a result if both `R` and `RT` contain pending changes we will be flushing both.

This PR make sure we inspect the traversed matrix, either `R` or `RT`