### PR TITLE
Refactor apply trees

### DIFF
--- a/src/execution_plan/execution_plan_build/build_match_op_tree.c
+++ b/src/execution_plan/execution_plan_build/build_match_op_tree.c
@@ -77,7 +77,7 @@ static void _ExecutionPlan_ProcessQueryGraph(ExecutionPlan *plan, QueryGraph *qg
 				} else {
 					root = NewAllNodeScanOp(plan, src->alias);
 				}
-				if(tail) ExecutionPlan_AddOp(root, tail);
+				if(tail) root = ExecutionPlan_NewRoot(tail, root);
 				tail = root;
 			}
 

--- a/src/execution_plan/execution_plan_build/execution_plan_modify.h
+++ b/src/execution_plan/execution_plan_build/execution_plan_modify.h
@@ -30,7 +30,7 @@ void ExecutionPlan_AddOp(OpBase *parent, OpBase *newOp);
 void ExecutionPlan_PushBelow(OpBase *a, OpBase *b);
 
 /* Introduce new_root as the parent of old_root. */
-void ExecutionPlan_NewRoot(OpBase *old_root, OpBase *new_root);
+OpBase *ExecutionPlan_NewRoot(OpBase *old_root, OpBase *new_root);
 
 /* Update the root op of the execution plan. */
 void ExecutionPlan_UpdateRoot(ExecutionPlan *plan, OpBase *new_root);
@@ -67,8 +67,8 @@ OpBase **ExecutionPlan_LocateTaps(const ExecutionPlan *plan);
 /* Find the earliest operation at which all references are resolved, if any,
  * both above the provided recurse_limit and without recursing past a blacklisted op. */
 OpBase *ExecutionPlan_LocateReferencesExcludingOps(OpBase *root,
-		const OpBase *recurse_limit, const OPType *blacklisted_ops,
-		int nblacklisted_ops, rax *refs_to_resolve);
+												   const OpBase *recurse_limit, const OPType *blacklisted_ops,
+												   int nblacklisted_ops, rax *refs_to_resolve);
 
 //------------------------------------------------------------------------------
 // ExecutionPlan_Collect API:

--- a/src/execution_plan/ops/op.h
+++ b/src/execution_plan/ops/op.h
@@ -63,6 +63,9 @@ typedef enum {
 // Macro for checking whether an operation is an Apply variant.
 #define OP_IS_APPLY(op) ((op)->type == OPType_OR_APPLY_MULTIPLEXER || (op)->type == OPType_AND_APPLY_MULTIPLEXER || (op)->type == OPType_SEMI_APPLY || (op)->type == OPType_ANTI_SEMI_APPLY)
 
+// Macro for checking whether an operation is a tap.
+#define OP_IS_TAP(op) ((op)->type == OPType_ALL_NODE_SCAN || (op)->type == OPType_NODE_BY_LABEL_SCAN || (op)->type == OPType_INDEX_SCAN || (op)->type == OPType_NODE_BY_ID_SEEK || (op)->type == OPType_NODE_BY_LABEL_AND_ID_SCAN)
+
 #define PROJECT_OP_COUNT 2
 static const OPType PROJECT_OPS[] = {OPType_PROJECT, OPType_AGGREGATE};
 

--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -37,7 +37,6 @@ OpBase *NewAllNodeScanOp(const ExecutionPlan *plan, const char *alias) {
 static OpResult AllNodeScanInit(OpBase *opBase) {
 	AllNodeScan *op = (AllNodeScan *)opBase;
 	if(opBase->childCount > 0) OpBase_UpdateConsume(opBase, AllNodeScanConsumeFromChild);
-	else op->iter = Graph_ScanNodes(QueryCtx_GetGraph());
 	return OP_OK;
 }
 
@@ -78,6 +77,9 @@ static Record AllNodeScanConsumeFromChild(OpBase *opBase) {
 
 static Record AllNodeScanConsume(OpBase *opBase) {
 	AllNodeScan *op = (AllNodeScan *)opBase;
+
+	// Create iterator on first invocation
+	if(!op->iter) op->iter = Graph_ScanNodes(QueryCtx_GetGraph());
 
 	Node n = GE_NEW_NODE();
 	n.entity = (Entity *)DataBlockIterator_Next(op->iter, &n.id);

--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -42,6 +42,8 @@ static OpResult AllNodeScanInit(OpBase *opBase) {
 
 static Record AllNodeScanConsumeFromChild(OpBase *opBase) {
 	AllNodeScan *op = (AllNodeScan *)opBase;
+	ASSERT(op->op.children[0]->type == OPType_ARGUMENT ||
+		   op->op.children[0]->type == OPType_PROJECT);
 
 	if(op->child_record == NULL) {
 		op->child_record = OpBase_Consume(op->op.children[0]);

--- a/src/execution_plan/ops/op_all_node_scan.c
+++ b/src/execution_plan/ops/op_all_node_scan.c
@@ -42,8 +42,6 @@ static OpResult AllNodeScanInit(OpBase *opBase) {
 
 static Record AllNodeScanConsumeFromChild(OpBase *opBase) {
 	AllNodeScan *op = (AllNodeScan *)opBase;
-	ASSERT(op->op.children[0]->type == OPType_ARGUMENT ||
-		   op->op.children[0]->type == OPType_PROJECT);
 
 	if(op->child_record == NULL) {
 		op->child_record = OpBase_Consume(op->op.children[0]);

--- a/src/execution_plan/ops/op_apply.c
+++ b/src/execution_plan/ops/op_apply.c
@@ -39,7 +39,6 @@ static OpResult ApplyInit(OpBase *opBase) {
 
 	// Locate branch's Argument op tap.
 	op->op_arg = (Argument *)ExecutionPlan_LocateOp(op->rhs_branch, OPType_ARGUMENT);
-	ASSERT(op->op_arg);
 
 	return OP_OK;
 }
@@ -54,7 +53,7 @@ static Record ApplyConsume(OpBase *opBase) {
 			if(!op->r) return NULL; // Bound branch and this op are depleted.
 
 			// Successfully pulled a new Record, propagate to the top of the RHS branch.
-			Argument_AddRecord(op->op_arg, OpBase_CloneRecord(op->r));
+			if(op->op_arg) Argument_AddRecord(op->op_arg, OpBase_CloneRecord(op->r));
 		}
 
 		// Pull a Record from the RHS branch.

--- a/src/execution_plan/ops/op_index_scan.c
+++ b/src/execution_plan/ops/op_index_scan.c
@@ -211,10 +211,10 @@ static OpResult IndexScanReset(OpBase *opBase) {
 	IndexScan *op = (IndexScan *)opBase;
 
 	if(op->rebuild_index_query) {
-		RediSearch_ResultsIteratorFree(op->iter);
+		if(op->iter) RediSearch_ResultsIteratorFree(op->iter);
 		op->iter = NULL;
 	} else {
-		RediSearch_ResultsIteratorReset(op->iter);
+		if(op->iter) RediSearch_ResultsIteratorReset(op->iter);
 	}
 
 	return OP_OK;

--- a/src/execution_plan/ops/op_index_scan.c
+++ b/src/execution_plan/ops/op_index_scan.c
@@ -22,7 +22,7 @@ static int IndexScanToString(const OpBase *ctx, char *buf, uint buf_len) {
 }
 
 OpBase *NewIndexScanOp(const ExecutionPlan *plan, Graph *g, NodeScanCtx n,
-		RSIndex *idx, FT_FilterNode *filter) {
+					   RSIndex *idx, FT_FilterNode *filter) {
 	// validate inputs
 	ASSERT(g      != NULL);
 	ASSERT(idx    != NULL);
@@ -51,7 +51,7 @@ static OpResult IndexScanInit(OpBase *opBase) {
 	IndexScan *op = (IndexScan *)opBase;
 
 	if(opBase->childCount > 0) {
-		// find out how many different entities are refered to 
+		// find out how many different entities are referred to
 		// within the filter tree, if number of entities equals 1
 		// (current node being scanned) there's no need to re-build the index
 		// query for every input record
@@ -89,8 +89,6 @@ static inline bool _PassUnresolvedFilters(const IndexScan *op, Record r) {
 
 static Record IndexScanConsumeFromChild(OpBase *opBase) {
 	IndexScan *op = (IndexScan *)opBase;
-	ASSERT(op->op.children[0]->type == OPType_ARGUMENT ||
-		   op->op.children[0]->type == OPType_PROJECT);
 	const EntityID *nodeId = NULL;
 
 pull_index:
@@ -100,7 +98,7 @@ pull_index:
 
 	if(op->iter != NULL) {
 		while((nodeId = RediSearch_ResultsIteratorNext(op->iter, op->idx, NULL))
-				!= NULL) {
+			  != NULL) {
 			// populate record with node
 			_UpdateRecord(op, op->child_record, *nodeId);
 			// apply unresolved filters
@@ -161,7 +159,7 @@ pull_index:
 
 		// convert filter into a RediSearch query
 		RSQNode *rs_query_node = FilterTreeToQueryNode(&op->unresolved_filters,
-				filter, op->idx);
+													   filter, op->idx);
 		FilterTree_Free(filter);
 
 		// create iterator
@@ -192,14 +190,14 @@ static Record IndexScanConsume(OpBase *opBase) {
 	// create iterator on first call
 	if(op->iter == NULL) {
 		RSQNode *rs_query_node = FilterTreeToQueryNode(&op->unresolved_filters,
-				op->filter, op->idx);
+													   op->filter, op->idx);
 		ASSERT(op->unresolved_filters == NULL);
 
 		op->iter = RediSearch_GetResultsIterator(rs_query_node, op->idx);
 	}
 
 	const EntityID *nodeId = RediSearch_ResultsIteratorNext(op->iter, op->idx,
-			NULL);
+															NULL);
 	if(!nodeId) return NULL;
 
 	// populate the Record with the actual node

--- a/src/execution_plan/ops/op_index_scan.c
+++ b/src/execution_plan/ops/op_index_scan.c
@@ -89,6 +89,8 @@ static inline bool _PassUnresolvedFilters(const IndexScan *op, Record r) {
 
 static Record IndexScanConsumeFromChild(OpBase *opBase) {
 	IndexScan *op = (IndexScan *)opBase;
+	ASSERT(op->op.children[0]->type == OPType_ARGUMENT ||
+		   op->op.children[0]->type == OPType_PROJECT);
 	const EntityID *nodeId = NULL;
 
 pull_index:

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -14,7 +14,6 @@
 static OpResult NodeByLabelScanInit(OpBase *opBase);
 static Record NodeByLabelScanConsume(OpBase *opBase);
 static Record NodeByLabelScanConsumeFromChild(OpBase *opBase);
-static Record NodeByLabelScanNoOp(OpBase *opBase);
 static OpResult NodeByLabelScanReset(OpBase *opBase);
 static OpBase *NodeByLabelScanClone(const ExecutionPlan *plan, const OpBase *opBase);
 static void NodeByLabelScanFree(OpBase *opBase);
@@ -62,31 +61,10 @@ static GrB_Info _ConstructIterator(NodeByLabelScan *op, Schema *schema) {
 
 static OpResult NodeByLabelScanInit(OpBase *opBase) {
 	NodeByLabelScan *op = (NodeByLabelScan *)opBase;
-	OpBase_UpdateConsume(opBase, NodeByLabelScanConsume); // Default consume function.
 
-	// Operation has children, consume from child.
 	if(opBase->childCount > 0) {
+		// Operation has children, consume from child.
 		OpBase_UpdateConsume(opBase, NodeByLabelScanConsumeFromChild);
-		return OP_OK;
-	}
-
-	// If we have no children, we can build the iterator now.
-	GraphContext *gc = QueryCtx_GetGraphCtx();
-	Schema *schema = GraphContext_GetSchema(gc, op->n.label, SCHEMA_NODE);
-	if(!schema) {
-		// Missing schema, use the NOP consume function.
-		OpBase_UpdateConsume(opBase, NodeByLabelScanNoOp);
-		return OP_OK;
-	}
-	// Resolve label ID at runtime.
-	op->n.label_id = schema->id;
-
-	// The iterator build may fail if the ID range does not match the matrix dimensions.
-	GrB_Info iterator_built = _ConstructIterator(op, schema);
-	if(iterator_built != GrB_SUCCESS) {
-		// Invalid range, use the NOP consume function.
-		OpBase_UpdateConsume(opBase, NodeByLabelScanNoOp);
-		return OP_OK;
 	}
 
 	return OP_OK;
@@ -107,6 +85,8 @@ static inline void _ResetIterator(NodeByLabelScan *op) {
 
 static Record NodeByLabelScanConsumeFromChild(OpBase *opBase) {
 	NodeByLabelScan *op = (NodeByLabelScan *)opBase;
+	ASSERT(op->op.children[0]->type == OPType_ARGUMENT ||
+		   op->op.children[0]->type == OPType_PROJECT);
 
 	// Try to get new nodeID.
 	GrB_Index nodeId;
@@ -152,6 +132,21 @@ static Record NodeByLabelScanConsumeFromChild(OpBase *opBase) {
 static Record NodeByLabelScanConsume(OpBase *opBase) {
 	NodeByLabelScan *op = (NodeByLabelScan *)opBase;
 
+	// Create iterator on first invocation
+	if(!op->iter) {
+		GraphContext *gc = QueryCtx_GetGraphCtx();
+		Schema *schema = GraphContext_GetSchema(gc, op->n.label, SCHEMA_NODE);
+		// Missing schema, return NULL
+		if(!schema) return NULL;
+
+		// Resolve label ID
+		op->n.label_id = schema->id;
+
+		// The iterator build may fail if the ID range does not match the matrix dimensions.
+		GrB_Info iterator_built = _ConstructIterator(op, schema);
+		if(iterator_built != GrB_SUCCESS) return NULL;
+	}
+
 	GrB_Index nodeId;
 	bool depleted = false;
 	GxB_MatrixTupleIter_next(op->iter, NULL, &nodeId, NULL, &depleted);
@@ -163,12 +158,6 @@ static Record NodeByLabelScanConsume(OpBase *opBase) {
 	_UpdateRecord(op, r, nodeId);
 
 	return r;
-}
-
-/* This function is invoked when the op has no children and no valid label is requested (either no label, or non existing label).
- * The op simply needs to return NULL */
-static Record NodeByLabelScanNoOp(OpBase *opBase) {
-	return NULL;
 }
 
 static OpResult NodeByLabelScanReset(OpBase *ctx) {

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -85,8 +85,6 @@ static inline void _ResetIterator(NodeByLabelScan *op) {
 
 static Record NodeByLabelScanConsumeFromChild(OpBase *opBase) {
 	NodeByLabelScan *op = (NodeByLabelScan *)opBase;
-	ASSERT(op->op.children[0]->type == OPType_ARGUMENT ||
-		   op->op.children[0]->type == OPType_PROJECT);
 
 	// Try to get new nodeID.
 	GrB_Index nodeId;

--- a/src/execution_plan/ops/op_node_by_label_scan.c
+++ b/src/execution_plan/ops/op_node_by_label_scan.c
@@ -164,7 +164,7 @@ static OpResult NodeByLabelScanReset(OpBase *ctx) {
 		OpBase_DeleteRecord(op->child_record); // Free old record.
 		op->child_record = NULL;
 	}
-	_ResetIterator(op);
+	if(op->iter) _ResetIterator(op);
 	return OP_OK;
 }
 

--- a/src/execution_plan/optimizations/reduce_scans.c
+++ b/src/execution_plan/optimizations/reduce_scans.c
@@ -26,9 +26,6 @@ static OpBase *_LabelScanToConditionalTraverse(NodeByLabelScan *op) {
 }
 
 static void _reduceScans(ExecutionPlan *plan, OpBase *scan) {
-	// Return early if the scan has no child operations.
-	// if(scan->childCount == 0) return;
-
 	// The scan operation should be operating on a single alias.
 	ASSERT(array_len(scan->modifies) == 1);
 	const char *scanned_alias = scan->modifies[0];

--- a/src/execution_plan/optimizations/reduce_scans.c
+++ b/src/execution_plan/optimizations/reduce_scans.c
@@ -27,7 +27,7 @@ static OpBase *_LabelScanToConditionalTraverse(NodeByLabelScan *op) {
 
 static void _reduceScans(ExecutionPlan *plan, OpBase *scan) {
 	// Return early if the scan has no child operations.
-	if(scan->childCount == 0) return;
+	// if(scan->childCount == 0) return;
 
 	// The scan operation should be operating on a single alias.
 	ASSERT(array_len(scan->modifies) == 1);

--- a/src/execution_plan/optimizations/utilize_indices.c
+++ b/src/execution_plan/optimizations/utilize_indices.c
@@ -255,17 +255,17 @@ static FT_FilterNode *_Concat_Filters(OpFilter **filter_ops) {
 	// concat using AND nodes
 	FT_FilterNode *root = FilterTree_CreateConditionFilter(OP_AND);
 	FilterTree_AppendLeftChild(root,
-			FilterTree_Clone(filter_ops[0]->filterTree));
+							   FilterTree_Clone(filter_ops[0]->filterTree));
 	FilterTree_AppendRightChild(root,
-			FilterTree_Clone(filter_ops[1]->filterTree));
+								FilterTree_Clone(filter_ops[1]->filterTree));
 
 	for(uint i = 2; i < count; i++) {
 		// new and root node
-		FT_FilterNode *and = FilterTree_CreateConditionFilter(OP_AND);
-		FilterTree_AppendLeftChild(and, root);
+		FT_FilterNode * and = FilterTree_CreateConditionFilter(OP_AND);
+		FilterTree_AppendLeftChild( and, root);
 		root = and;
 		FilterTree_AppendRightChild(root,
-				FilterTree_Clone(filter_ops[i]->filterTree));
+									FilterTree_Clone(filter_ops[i]->filterTree));
 	}
 
 	return root;
@@ -318,6 +318,7 @@ void reduce_scan_op(ExecutionPlan *plan, NodeByLabelScan *scan) {
 		OpBase *arg = NewArgumentOp(plan, vars);
 		// add the Argument as a child of the IndexScan
 		ExecutionPlan_AddOp(indexOp, arg);
+		array_free(vars);
 		raxFree(bound_vars);
 	}
 

--- a/tests/flow/test_bound_variables.py
+++ b/tests/flow/test_bound_variables.py
@@ -91,3 +91,13 @@ class testBoundVariables(FlowTestsBase):
         expected_result = [['v1', 'v2']]
         self.env.assertEquals(actual_result.result_set, expected_result)
 
+        query = """MERGE (a:L {val: 'v1'}) WITH a MATCH (a)-[e]->(b), (c:L) RETURN DISTINCT a.val, b.val"""
+        actual_result = redis_graph.query(query)
+
+        # Verify that this query generates exactly 2 scan ops.
+        execution_plan = redis_graph.execution_plan(query)
+        self.env.assertEquals(2, execution_plan.count('Scan'))
+
+        # Verify results.
+        expected_result = [['v1', 'v2']]
+        self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
This PR reorganizes ExecutionPlan trees such that in most cases, tap operations like scans will not perform nested loops over their children. Instead, the earlier operations will form the left-hand stream of an `Apply` subtree, and the tap will be the right-hand side:
```
redis-cli GRAPH.EXPLAIN G "UNWIND range(1,3) AS v MATCH (a {v: v}) RETURN a"
1) "Results"
2) "    Project"
3) "        Filter"
4) "            Apply"
5) "                Unwind"
6) "                All Node Scan | (a)"
```
jV
This is the advanced version of the fix proposed by #1761.

With the logic currently in this PR, it is still possible for a tap to have non-argument roots in cases like:
```
MATCH (n) OPTIONAL MATCH (m {v:'v1'})--() WHERE (n)--() RETURN n.v, m.v
```
In the execution plan built for this query, the scan over `m` has a `SemiApply` child. The logic which builds this op (to handle path filters) uses independent logic for op tree placement. I'm unsure whether we want to dig into this further.

