### PR TITLE
OpDistinct does not unique ORDER BY expressions

### DIFF
--- a/src/execution_plan/execution_plan_build/build_projection_ops.c
+++ b/src/execution_plan/execution_plan_build/build_projection_ops.c
@@ -192,14 +192,12 @@ static inline void _buildProjectionOps(ExecutionPlan *plan,
 	if(distinct) {
 		// Prepare the distinct op but do not add it to op tree.
 		// This is required so that it does not operate on order expressions.
-		uint projection_count = array_len(projections);
+		uint n = array_len(projections);
 
 		// Populate a stack array with the aliases to perform Distinct on
-		const char *aliases[projection_count];
-		for(uint i = 0; i < projection_count; i ++) {
-			aliases[i] = projections[i]->resolved_name;
-		}
-		distinct_op = NewDistinctOp(plan, aliases, projection_count);
+		const char *aliases[n];
+		for(uint i = 0; i < n; i ++) aliases[i] = projections[i]->resolved_name;
+		distinct_op = NewDistinctOp(plan, aliases, n);
 	}
 
 	if(order_clause) {

--- a/src/execution_plan/ops/op_distinct.c
+++ b/src/execution_plan/ops/op_distinct.c
@@ -51,6 +51,9 @@ static void _updateOffsets(OpDistinct *op, Record r) {
 }
 
 OpBase *NewDistinctOp(const ExecutionPlan *plan, const char **aliases, uint alias_count) {
+	ASSERT(aliases != NULL);
+	ASSERT(alias_count > 0);
+
 	OpDistinct *op = rm_malloc(sizeof(OpDistinct));
 
 	op->found           =  raxNew();

--- a/src/execution_plan/ops/op_distinct.h
+++ b/src/execution_plan/ops/op_distinct.h
@@ -20,5 +20,5 @@ typedef struct {
 
 } OpDistinct;
 
-OpBase *NewDistinctOp(const ExecutionPlan *plan);
+OpBase *NewDistinctOp(const ExecutionPlan *plan, const char **aliases, uint alias_count);
 

--- a/tests/flow/test_distinct.py
+++ b/tests/flow/test_distinct.py
@@ -78,6 +78,10 @@ class testReturnDistinctFlow1(FlowTestsBase):
         result = graph1.query("MATCH (p:PARENT)-[:HAS]->(c:CHILD) RETURN DISTINCT p.name ORDER BY c.name")
         self.env.assertEqual(result.result_set, [['Stevie'], ['Mike'], ['James']])
 
+        result = graph1.query("UNWIND range(0,3) AS a UNWIND range(4,7) AS b RETURN DISTINCT a ORDER BY b")
+        self.env.assertEqual(result.result_set, [[3], [2], [1], [0]])
+
+
 class testReturnDistinctFlow2(FlowTestsBase):
 
     def __init__(self):

--- a/tests/flow/test_distinct.py
+++ b/tests/flow/test_distinct.py
@@ -73,6 +73,11 @@ class testReturnDistinctFlow1(FlowTestsBase):
         result = graph1.query("MATCH (p:PARENT)-[:HAS]->(:CHILD) RETURN DISTINCT p.name ORDER BY p.name LIMIT 2")
         self.env.assertEqual(result.result_set, [['James'], ['Mike']])
 
+    def test_distinct_with_order(self):
+        # The results of DISTINCT should not be affected by the values in the ORDER BY clause
+        result = graph1.query("MATCH (p:PARENT)-[:HAS]->(c:CHILD) RETURN DISTINCT p.name ORDER BY c.name")
+        self.env.assertEqual(result.result_set, [['Stevie'], ['Mike'], ['James']])
+
 class testReturnDistinctFlow2(FlowTestsBase):
 
     def __init__(self):

--- a/tests/flow/test_union.py
+++ b/tests/flow/test_union.py
@@ -125,8 +125,22 @@ class testUnion(FlowTestsBase):
     def test07_union_with_partial_ordering(self):
         query = """UNWIND range(1, 2) AS v RETURN v ORDER BY v DESC
                    UNION
-                   UNWIND range(1, 2) AS v RETURN v"""
+                   UNWIND range(1, 3) AS v RETURN v"""
         result = redis_graph.query(query)
         expected_result = [[2],
-                           [1]]
+                           [1],
+                           [3]]
+        self.env.assertEquals(result.result_set, expected_result)
+
+        # The results should not be modified when variables are aliased
+        query = """UNWIND range(1, 2) AS a RETURN a AS b ORDER BY a DESC
+                   UNION
+                   UNWIND range(1, 3) AS b RETURN b"""
+        result = redis_graph.query(query)
+        self.env.assertEquals(result.result_set, expected_result)
+
+        query = """UNWIND range(1, 2) AS a RETURN a AS b ORDER BY b DESC
+                   UNION
+                   UNWIND range(1, 3) AS b RETURN b"""
+        result = redis_graph.query(query)
         self.env.assertEquals(result.result_set, expected_result)

--- a/tests/flow/test_union.py
+++ b/tests/flow/test_union.py
@@ -119,3 +119,14 @@ class testUnion(FlowTestsBase):
 
         # The same results should be produced regardless of whether ALL is specified.
         self.env.assertEquals(union_result.result_set, union_all_result.result_set)
+
+    # Union should function properly when one of its subqueries is ordered
+    # and the other is not.
+    def test07_union_with_partial_ordering(self):
+        query = """UNWIND range(1, 2) AS v RETURN v ORDER BY v DESC
+                   UNION
+                   UNWIND range(1, 2) AS v RETURN v"""
+        result = redis_graph.query(query)
+        expected_result = [[2],
+                           [1]]
+        self.env.assertEquals(result.result_set, expected_result)


### PR DESCRIPTION
This PR resolves the bug reported in #1845 and additional misbehaviors in `OpDistinct`.

Previously, `OpDistinct` would extract the expressions to unique from its corresponding `OpProject` or `OpAggregate`. These expressions would include all `ORDER BY` expressions, which should _not_ be considered input to unique.

This had the additional effect of allowing expression lists to be mismatched in `UNION` queries, as `UNION` requires the same variables in the `RETURN` clause but is not affected by `ORDER BY` expressions. As such, if one of the subqueries had an `ORDER BY` and the other did not (or had different expressions), an assertion would fail.

Now `OpDistinct` accepts an explicit array of variables to unique. This is retrieved from the projection list in the case of explicit `DISTINCT` clauses, and is retrieved from the `RETURN` clause in the case of implicit `DISTINCT` (as triggered by `UNION`).

