### PR TITLE
[fix] Adjusted VARIABLE_LENGTH_EXPAND_INTO KPIs

### DIFF
--- a/tests/benchmarks/variable_length_traversal.yml
+++ b/tests/benchmarks/variable_length_traversal.yml
@@ -12,9 +12,9 @@ clientconfig:
     - clients: 32
     - threads: 4
     - connections: 32
-    - requests: 100
+    - requests: 1000
     - queries:
       - { q: "MATCH (n), (m) WHERE ID(n) = 0 AND ID(m) = 1 WITH n, m MATCH (n)-[*]->(m) RETURN count(1)", ratio: 1 }
 kpis:
-  - le: { $.OverallClientLatencies.Total.q50: 1.0 }
-  - ge: { $.OverallQueryRates.Total: 25000 }
+  - le: { $.OverallClientLatencies.Total.q50: 70.0 }
+  - ge: { $.OverallQueryRates.Total: 5.0 }


### PR DESCRIPTION
Fixes the following failing perf ci due to wrong KPI constraints:
https://app.circleci.com/pipelines/github/RedisGraph/RedisGraph/3789/workflows/5e003090-bda0-4d76-a37e-1b9cdd94eef7/jobs/14038

Based on the current data:
![image](https://user-images.githubusercontent.com/5832149/128696078-9dc9c5fd-fdae-41d4-b5a5-461d19622230.png)

we see that:
- a "safe" client p50 constraint KPI rule should be 70ms
- a "safe" lower limit for throughput can be 5 ops/sec 
- given the short duration of the benchmark it's better to extend it's total command issued parameter