### PR TITLE
Synchronize matrices on creation in RDB load

### DIFF
--- a/tests/flow/test_persistency.py
+++ b/tests/flow/test_persistency.py
@@ -203,3 +203,19 @@ class testGraphPersistency(FlowTestsBase):
             actual_result = graph.query(q)
             self.env.assertEquals(actual_result.result_set, expected_result)
 
+    # Verify that graphs larger than the
+    # default capacity are persisted correctly.
+    def test05_load_large_graph(self):
+        graph_name = "LARGE_GRAPH"
+        graph = Graph(graph_name, redis_con)
+        q = """UNWIND range(1, 50000) AS v CREATE (:L)-[:R {v: v}]->(:L)"""
+        actual_result = graph.query(q)
+        self.env.assertEquals(actual_result.nodes_created, 100_000)
+        self.env.assertEquals(actual_result.relationships_created, 50_000)
+
+        redis_con.execute_command("DEBUG", "RELOAD")
+
+        q = """MATCH (:L)-[r:R {v: 50000}]->(:L) RETURN r.v"""
+        expected_result = [[50000]]
+        actual_result = graph.query(q)
+        self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
This PR resolves an assertion failure when loading a graph with edge endpoint IDs greater than 16,384 in debug mode.

The specific error is a `GRB_INVALID_INDEX` on https://github.com/RedisGraph/RedisGraph/blob/master/src/serializers/graph_extensions.c#L67