### PR TITLE
Aliases in WITH...ORDER BY must be valid references

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -75,10 +75,10 @@ static void _AST_GetIdentifiers(const cypher_astnode_t *node, rax *identifiers) 
 		_AST_GetIdentifiers(child, identifiers);
 	}
 
-	if(type == CYPHER_AST_LIST_COMPREHENSION || 
-	   type == CYPHER_AST_ANY || 
-	   type == CYPHER_AST_ALL || 
-	   type == CYPHER_AST_SINGLE || 
+	if(type == CYPHER_AST_LIST_COMPREHENSION ||
+	   type == CYPHER_AST_ANY ||
+	   type == CYPHER_AST_ALL ||
+	   type == CYPHER_AST_SINGLE ||
 	   type == CYPHER_AST_NONE) {
 		// A list comprehension has a local variable that should only be accessed within its scope;
 		// do not leave it in the identifiers map.
@@ -121,6 +121,9 @@ static void _AST_GetWithReferences(const cypher_astnode_t *node, rax *identifier
 		const cypher_astnode_t *child = cypher_ast_with_get_projection(node, i);
 		_AST_GetIdentifiers(child, identifiers);
 	}
+
+	const cypher_astnode_t *order_by = cypher_ast_with_get_order_by(node);
+	if(order_by) _AST_GetIdentifiers(order_by, identifiers);
 }
 
 // Extract identifiers / aliases from a procedure call.
@@ -554,7 +557,7 @@ static AST_Validation _Validate_CALL_Clauses(const AST *ast) {
 
 				// make sure each yield output is mentioned only once
 				if(!raxInsert(identifiers, (unsigned char *)identifier,
-							strlen(identifier), NULL, NULL)) {
+							  strlen(identifier), NULL, NULL)) {
 					ErrorCtx_SetError("Variable `%s` already declared", identifier);
 					res = AST_INVALID;
 					goto cleanup;
@@ -563,7 +566,7 @@ static AST_Validation _Validate_CALL_Clauses(const AST *ast) {
 				// make sure procedure is aware of output
 				if(!Procedure_ContainsOutput(proc, identifier)) {
 					ErrorCtx_SetError("Procedure `%s` does not yield output `%s`",
-							proc_name, identifier);
+									  proc_name, identifier);
 					res = AST_INVALID;
 					goto cleanup;
 				}


### PR DESCRIPTION
This PR causes invalid references in a WITH...ORDER BY clause to be captured as compile-time errors rather than run-time errors, as in:
```
UNWIND [1,2,3] AS a WITH a ORDER BY nonexistent RETURN a
```

This has the effect of resolving #1863. A more concise query exhibiting the crash in this issue is:
```
CREATE (a:label9) WITH a ORDER BY node_0 MERGE path_2 = (node_0 {v: node_0.prop5})
```
This crash is caused by the invalid reference `node_0` causing the `MERGE` clause's `NodeByLabelScan` over `node_0` to erroneously be removed, and subsequently the `tie_segments` step of ExecutionPlan construction fails to link the two sub-ExecutionPlans. This crash is resolved by #1844.