### PR TITLE
Allow reconfiguring several configuration fields to 0 (default)

### DIFF
--- a/src/configuration/config.c
+++ b/src/configuration/config.c
@@ -94,6 +94,14 @@ static inline bool _Config_ParsePositiveInteger(const char *integer_str, long lo
 	return (res == true && *value > 0);
 }
 
+// parse non-negative integer
+// return true if string represents an integer >= 0
+static inline bool _Config_ParseNonNegativeInteger(const char *integer_str, long long *value) {
+	bool res = _Config_ParseInteger(integer_str, value);
+	// Return an error code if integer parsing fails or value is negative.
+	return (res == true && *value >= 0);
+}
+
 // return true if 'str' is either "yes" or "no" otherwise returns false
 // sets 'value' to true if 'str' is "yes"
 // sets 'value to false if 'str' is "no"
@@ -615,7 +623,7 @@ bool Config_Option_set(Config_Option_Field field, const char *val) {
 		case Config_TIMEOUT:
 			{
 				long long timeout;
-				if(!_Config_ParsePositiveInteger(val, &timeout)) return false;
+				if(!_Config_ParseNonNegativeInteger(val, &timeout)) return false;
 				Config_timeout_set(timeout);
 			}
 			break;
@@ -704,7 +712,7 @@ bool Config_Option_set(Config_Option_Field field, const char *val) {
 		case Config_QUERY_MEM_CAPACITY:
 			{
 				long long query_mem_capacity;
-				if (!_Config_ParseInteger(val, &query_mem_capacity)) return false;
+				if (!_Config_ParseNonNegativeInteger(val, &query_mem_capacity)) return false;
 
 				Config_query_mem_capacity_set(query_mem_capacity);
 			}
@@ -717,7 +725,7 @@ bool Config_Option_set(Config_Option_Field field, const char *val) {
 		case Config_DELTA_MAX_PENDING_CHANGES:
 			{
 				long long delta_max_pending_changes;
-				if (!_Config_ParsePositiveInteger(val, &delta_max_pending_changes)) return false;
+				if (!_Config_ParseNonNegativeInteger(val, &delta_max_pending_changes)) return false;
 
 				Config_delta_max_pending_changes_set(delta_max_pending_changes);
 			}

--- a/tests/flow/test_config.py
+++ b/tests/flow/test_config.py
@@ -144,3 +144,29 @@ class testConfig(FlowTestsBase):
             assert("Unknown subcommand for GRAPH.CONFIG" in str(e))
             pass
 
+    def test08_config_restore_timeout_to_default(self):
+        # Revert memory limit to default
+        response = redis_con.execute_command("GRAPH.CONFIG SET QUERY_MEM_CAPACITY 0")
+        self.env.assertEqual(response, "OK")
+
+        # Change timeout value from default
+        response = redis_con.execute_command("GRAPH.CONFIG SET TIMEOUT 10")
+        self.env.assertEqual(response, "OK")
+
+        # Make sure config been updated.
+        response = redis_con.execute_command("GRAPH.CONFIG GET TIMEOUT")
+        expected_response = ["TIMEOUT", 10]
+        self.env.assertEqual(response, expected_response)
+
+        # Revert timeout to unlimited
+        response = redis_con.execute_command("GRAPH.CONFIG SET TIMEOUT 0")
+        self.env.assertEqual(response, "OK")
+
+        # Make sure config been updated.
+        response = redis_con.execute_command("GRAPH.CONFIG GET TIMEOUT")
+        expected_response = ["TIMEOUT", 0]
+        self.env.assertEqual(response, expected_response)
+
+        # Issue long-running query to validate the reconfiguration
+        result = redis_graph.query("UNWIND range(1,1000000) AS v RETURN COUNT(v)")
+        self.env.assertEqual(result.result_set[0][0], 1000000)


### PR DESCRIPTION
Previously, GRAPH.CONFIG SET erroneously would not allow the timeout to be returned to 0 (unlimited), as it would only accept positive integers.

This PR removes that limitation by accepting any non-negative integer for the timeout value. It additionally resolves the same bug for `DELTA_MAX_PENDING_CHANGES` and `QUERY_MEM_CAPACITY`.