### PR TITLE
Update thread-local AST for every cloned op

### DIFF
--- a/src/algorithms/all_paths.c
+++ b/src/algorithms/all_paths.c
@@ -109,6 +109,7 @@ AllPathsCtx *AllPathsCtx_New(Node *src, Node *dst, Graph *g, int *relationIDs, i
 
 	_AllPathsCtx_AddConnectionToLevel(ctx, 0, src, NULL);
 
+	// in case we have filter tree validate that we can add edge to record 
 	ASSERT(!ctx->ft || ctx->edge_idx < Record_length(ctx->r));
 	return ctx;
 }

--- a/src/algorithms/all_paths.c
+++ b/src/algorithms/all_paths.c
@@ -109,7 +109,7 @@ AllPathsCtx *AllPathsCtx_New(Node *src, Node *dst, Graph *g, int *relationIDs, i
 
 	_AllPathsCtx_AddConnectionToLevel(ctx, 0, src, NULL);
 
-	// in case we have filter tree validate that we can add edge to record 
+	// in case we have filter tree validate that we can access the filtered edge
 	ASSERT(!ctx->ft || ctx->edge_idx < Record_length(ctx->r));
 	return ctx;
 }

--- a/src/algorithms/all_paths.c
+++ b/src/algorithms/all_paths.c
@@ -48,6 +48,7 @@ static void _addNeighbors(AllPathsCtx *ctx, LevelConnection *frontier, uint32_t 
 		for(uint32_t i = 0; i < neighborsCount; i++) {
 			Edge e = ctx->neighbors[i];
 
+			ASSERT(ctx->edge_idx < Record_length(ctx->r));
 			// update the record with the current edge
 			Record_AddEdge(ctx->r, ctx->edge_idx, e);
 
@@ -102,7 +103,7 @@ AllPathsCtx *AllPathsCtx_New(Node *src, Node *dst, Graph *g, int *relationIDs, i
 	ctx->maxLen         =  maxLen + 1;
 	ctx->relationIDs    =  relationIDs;
 	ctx->relationCount  =  relationCount;
-	ctx->levels         =  array_new(LevelConnection*, 1);
+	ctx->levels         =  array_new(LevelConnection *, 1);
 	ctx->path           =  Path_New(1);
 	ctx->neighbors      =  array_new(Edge, 32);
 	ctx->dst            =  dst;

--- a/src/algorithms/all_paths.c
+++ b/src/algorithms/all_paths.c
@@ -48,7 +48,6 @@ static void _addNeighbors(AllPathsCtx *ctx, LevelConnection *frontier, uint32_t 
 		for(uint32_t i = 0; i < neighborsCount; i++) {
 			Edge e = ctx->neighbors[i];
 
-			ASSERT(ctx->edge_idx < Record_length(ctx->r));
 			// update the record with the current edge
 			Record_AddEdge(ctx->r, ctx->edge_idx, e);
 
@@ -109,6 +108,8 @@ AllPathsCtx *AllPathsCtx_New(Node *src, Node *dst, Graph *g, int *relationIDs, i
 	ctx->dst            =  dst;
 
 	_AllPathsCtx_AddConnectionToLevel(ctx, 0, src, NULL);
+
+	ASSERT(!ctx->ft || ctx->edge_idx < Record_length(ctx->r));
 	return ctx;
 }
 

--- a/src/execution_plan/execution_plan_clone.c
+++ b/src/execution_plan/execution_plan_clone.c
@@ -24,9 +24,6 @@ static ExecutionPlan *_ClonePlanInternals(const ExecutionPlan *template) {
 		array_clone_with_cb(clone->connected_components, template->connected_components, QueryGraph_Clone);
 	}
 
-	// Temporarily set the thread-local AST to be the one referenced by this ExecutionPlan segment.
-	QueryCtx_SetAST(clone->ast_segment);
-
 	return clone;
 }
 
@@ -41,6 +38,9 @@ static OpBase *_CloneOpTree(OpBase *template_parent, OpBase *template_current,
 		// This op was built as part of the same segment as its parent, don't change ExecutionPlans.
 		plan_segment = clone_parent->plan;
 	}
+
+	// Temporarily set the thread-local AST to be the one referenced by this ExecutionPlan segment.
+	QueryCtx_SetAST(plan_segment->ast_segment);
 
 	// Clone the current operation.
 	OpBase *clone_current = OpBase_Clone(plan_segment, template_current);


### PR DESCRIPTION
This PR resolves a bug in which the AST segment scoped to each ExecutionPlan segment was only updated in thread-local storage upon instantiation in the clone routine. As such, if a subtree had a parent op describing AST 2, and 2 children respectively describing AST 1 and AST 2, the second child would inappropriately be linked to AST 1. This would cause crashes in queries like:
```
MATCH (a) WITH a OPTIONAL MATCH (a)-[e*]->(b) WHERE e.v = 5 RETURN a, b
```
Which produces the execution plan:
```
1) "Results"
2) "    Project"
3) "        Apply"
4) "            Project"
5) "                All Node Scan | (a)"
6) "            Optional"
7) "                Conditional Variable Length Traverse | (a)-[e*1..INF]->(b)"
8) "                    Argument"
```

The first AST segment only holds the reference to `a`, while the second segment holds references to `a` and `e`, and `b`.

The second segment is cloned first, as operations 1-4 use it. The first segment is cloned when we clone the `AllNodeScan` op (5), and this reference was retained in thread-local storage by operations 6-8. As the edge reference in the variable-length traversal (7) is required to update the record correctly for filtering, and that reference was no longer visible, the server would crash upon trying to populate the record with that edge.

This bug is solved by updating the AST segment in thread-local storage before cloning each operation.
