### PR TITLE
sync matrices on parent process before fork

### DIFF
--- a/src/execution_plan/execution_plan.c
+++ b/src/execution_plan/execution_plan.c
@@ -475,7 +475,9 @@ static void _ExecutionPlan_FreeInternals(ExecutionPlan *plan) {
 
 	if(plan->connected_components) {
 		uint connected_component_count = array_len(plan->connected_components);
-		for(uint i = 0; i < connected_component_count; i ++) QueryGraph_Free(plan->connected_components[i]);
+		for(uint i = 0; i < connected_component_count; i ++) {
+			QueryGraph_Free(plan->connected_components[i]);
+		}
 		array_free(plan->connected_components);
 	}
 

--- a/src/graph/entities/qg_node.c
+++ b/src/graph/entities/qg_node.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Redis Labs Ltd. and Contributors
+ * Copyright 2018-2021 Redis Labs Ltd. and Contributors
  *
  * This file is available under the Redis Labs Source Available License Agreement
  */
@@ -10,7 +10,11 @@
 #include "../graph.h"
 #include "../../util/arr.h"
 
-static void _QGNode_RemoveEdge(QGEdge **edges, QGEdge *e) {
+static void _QGNode_RemoveEdge
+(
+	QGEdge **edges,
+	QGEdge *e
+) {
 	uint edge_count = array_len(edges);
 	for(uint i = 0; i < edge_count; i++) {
 		QGEdge *ie = edges[i];
@@ -21,7 +25,10 @@ static void _QGNode_RemoveEdge(QGEdge **edges, QGEdge *e) {
 	}
 }
 
-QGNode *QGNode_New(const char *alias) {
+QGNode *QGNode_New
+(
+	const char *alias
+) {
 	QGNode *n = rm_malloc(sizeof(QGNode));
 	n->label = NULL;
 	n->alias = alias;
@@ -32,32 +39,55 @@ QGNode *QGNode_New(const char *alias) {
 	return n;
 }
 
-uint QGNode_LabelCount(const QGNode *n) {
+uint QGNode_LabelCount
+(
+	const QGNode *n
+) {
 	ASSERT(n != NULL);
 	return (n->label != NULL) ? 1 : 0;
 }
 
-bool QGNode_HighlyConnected(const QGNode *n) {
+bool QGNode_HighlyConnected
+(
+	const QGNode *n
+) {
 	return n->highly_connected;
 }
 
-int QGNode_Degree(const QGNode *n) {
+int QGNode_Degree
+(
+	const QGNode *n
+) {
 	return QGNode_IncomeDegree(n) + QGNode_OutgoingDegree(n);
 }
 
-int QGNode_IncomeDegree(const QGNode *n) {
+int QGNode_IncomeDegree
+(
+	const QGNode *n
+) {
 	return array_len(n->incoming_edges);
 }
 
-int QGNode_OutgoingDegree(const QGNode *n) {
+int QGNode_OutgoingDegree
+(
+	const QGNode *n
+) {
 	return array_len(n->outgoing_edges);
 }
 
-int QGNode_EdgeCount(const QGNode *n) {
+int QGNode_EdgeCount
+(
+	const QGNode *n
+) {
 	return QGNode_IncomeDegree(n) + QGNode_OutgoingDegree(n);
 }
 
-void QGNode_ConnectNode(QGNode *src, QGNode *dest, QGEdge *e) {
+void QGNode_ConnectNode
+(
+	QGNode *src,
+	QGNode *dest,
+	QGEdge *e
+) {
 	array_append(src->outgoing_edges, e);
 	array_append(dest->incoming_edges, e);
 
@@ -72,38 +102,58 @@ void QGNode_ConnectNode(QGNode *src, QGNode *dest, QGEdge *e) {
 	}
 }
 
-void QGNode_RemoveIncomingEdge(QGNode *n, QGEdge *e) {
+void QGNode_RemoveIncomingEdge
+(
+	QGNode *n, QGEdge *e
+) {
 	_QGNode_RemoveEdge(n->incoming_edges, e);
 }
 
-void QGNode_RemoveOutgoingEdge(QGNode *n, QGEdge *e) {
+void QGNode_RemoveOutgoingEdge
+(
+	QGNode *n,
+	QGEdge *e
+) {
 	_QGNode_RemoveEdge(n->outgoing_edges, e);
 }
 
-QGNode *QGNode_Clone(const QGNode *orig) {
+QGNode *QGNode_Clone
+(
+	const QGNode *orig
+) {
+	ASSERT(orig != NULL);
+
 	QGNode *n = rm_malloc(sizeof(QGNode));
 	memcpy(n, orig, sizeof(QGNode));
-	// Don't save edges when duplicating a node
+
+	// don't save edges when duplicating a node
 	n->incoming_edges = array_new(QGEdge *, 0);
 	n->outgoing_edges = array_new(QGEdge *, 0);
 
 	return n;
 }
 
-void QGNode_ToString(const QGNode *n, sds *buff) {
+void QGNode_ToString
+(
+	const QGNode *n,
+	sds *buff
+) {
 	ASSERT(n && buff);
 
 	*buff = sdscatprintf(*buff, "(");
-	if(n->alias) *buff = sdscatprintf(*buff, "%s", n->alias);
-	if(n->label) *buff = sdscatprintf(*buff, ":%s", n->label);
+	if(n->alias != NULL) *buff = sdscatprintf(*buff, "%s", n->alias);
+	if(n->label != NULL) *buff = sdscatprintf(*buff, ":%s", n->label);
 	*buff = sdscatprintf(*buff, ")");
 }
 
-void QGNode_Free(QGNode *node) {
-	if(!node) return;
+void QGNode_Free
+(
+	QGNode *node
+) {
+	if(node == NULL) return;
 
-	if(node->outgoing_edges) array_free(node->outgoing_edges);
-	if(node->incoming_edges) array_free(node->incoming_edges);
+	if(node->outgoing_edges != NULL) array_free(node->outgoing_edges);
+	if(node->incoming_edges != NULL) array_free(node->incoming_edges);
 
 	rm_free(node);
 }

--- a/src/graph/query_graph.c
+++ b/src/graph/query_graph.c
@@ -1,53 +1,63 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */
 
 #include "query_graph.h"
-#include "../RG.h"
+#include "RG.h"
 #include "../util/arr.h"
 #include "../util/strcmp.h"
 #include "../query_ctx.h"
 #include "../schema/schema.h"
 #include "../../deps/rax/rax.h"
 
-// Sets node label and label ID
-static void _QueryGraphSetNodeLabel(QGNode *n, const cypher_astnode_t *ast_entity) {
+// sets node label and label ID
+static void _QueryGraphSetNodeLabel
+(
+	QGNode *n,
+	const cypher_astnode_t *ast_entity
+) {
 	// node label already set
 	if(n->labelID != GRAPH_NO_LABEL) return;
 
-	// Retrieve node labels from the AST entity.
+	// retrieve node labels from the AST entity
 	uint nlabels = cypher_ast_node_pattern_nlabels(ast_entity);
-	// We currently only support 0 or 1 labels per node, so if any are specified just select the first.
+	// we currently only support 0 or 1 labels per node
+	// so if any are specified just select the first
 	const char *label = NULL;
 	if(nlabels > 0) label = cypher_ast_label_get_name(cypher_ast_node_pattern_get_label(ast_entity, 0));
 
-	// Set node label ID.
+	// set node label ID
 	if(label) {
 		GraphContext *gc = QueryCtx_GetGraphCtx();
 		Schema *s = GraphContext_GetSchema(gc, label, SCHEMA_NODE);
 		uint label_id = GRAPH_UNKNOWN_LABEL;
-		// If a schema is found, the AST refers to an existing label.
+		// if a schema is found, the AST refers to an existing label
 		if(s) label_id = s->id;
 		n->label = label;
 		n->labelID = label_id;
 	} else {
-		// Label isn't known to the graph.
+		// label isn't known to the graph
 		n->labelID = GRAPH_NO_LABEL;
 	}
 }
 
-// Adds node to query graph
-static void _QueryGraphAddNode(QueryGraph *qg, const cypher_astnode_t *ast_entity) {
+// adds node to query graph
+static void _QueryGraphAddNode
+(
+	QueryGraph *qg,
+	const cypher_astnode_t *ast_entity
+) {
 	AST *ast = QueryCtx_GetAST();
 	const char *alias = AST_GetEntityName(ast, ast_entity);
 
-	/* Look up this alias in the QueryGraph.
-	 * This node may already exist if it appears multiple times in query patterns. */
+	// look up this alias in the QueryGraph
+	// this node may already exist
+	// if it appears multiple times in query patterns
 	QGNode *n = QueryGraph_GetNodeByAlias(qg, alias);
 	if(n == NULL) {
-		// Node has not been mapped; create it.
+		// node has not been mapped; create it
 		n = QGNode_New(alias);
 		QueryGraph_AddNode(qg, n);
 	}
@@ -55,22 +65,27 @@ static void _QueryGraphAddNode(QueryGraph *qg, const cypher_astnode_t *ast_entit
 	_QueryGraphSetNodeLabel(n, ast_entity);
 }
 
-// Adds edge to query graph
-static void _QueryGraphAddEdge(QueryGraph *qg, const cypher_astnode_t *ast_entity,
-							   QGNode *src, QGNode *dest) {
+// adds edge to query graph
+static void _QueryGraphAddEdge
+(
+	QueryGraph *qg,
+	const cypher_astnode_t *ast_entity,
+	QGNode *src,
+	QGNode *dest
+) {
 
 	AST *ast = QueryCtx_GetAST();
 	GraphContext *gc = QueryCtx_GetGraphCtx();
 	const char *alias = AST_GetEntityName(ast, ast_entity);
 	enum cypher_rel_direction dir = cypher_ast_rel_pattern_get_direction(ast_entity);
 
-	// Each edge can only appear once in a QueryGraph.
+	// each edge can only appear once in a QueryGraph
 	ASSERT(QueryGraph_GetEdgeByAlias(qg, alias) == NULL);
 
 	QGEdge *edge = QGEdge_New(NULL, alias);
 	edge->bidirectional = (dir == CYPHER_REL_BIDIRECTIONAL);
 
-	// Add the IDs of all reltype matrixes
+	// add the IDs of all reltype matrixes
 	uint nreltypes = cypher_ast_rel_pattern_nreltypes(ast_entity);
 	for(uint i = 0; i < nreltypes; i ++) {
 		const char *reltype = cypher_ast_reltype_get_name(cypher_ast_rel_pattern_get_reltype(ast_entity,
@@ -78,7 +93,7 @@ static void _QueryGraphAddEdge(QueryGraph *qg, const cypher_astnode_t *ast_entit
 		array_append(edge->reltypes, reltype);
 		Schema *s = GraphContext_GetSchema(gc, reltype, SCHEMA_EDGE);
 		if(!s) {
-			// Unknown relationship
+			// unknown relationship
 			array_append(edge->reltypeIDs, GRAPH_UNKNOWN_RELATION);
 			qg->unknown_reltype_ids = true;
 			continue;
@@ -86,7 +101,7 @@ static void _QueryGraphAddEdge(QueryGraph *qg, const cypher_astnode_t *ast_entit
 		array_append(edge->reltypeIDs, s->id);
 	}
 
-	// Incase of a variable length edge, set edge min/max hops.
+	// incase of a variable length edge, set edge min/max hops
 	const cypher_astnode_t *range = cypher_ast_rel_pattern_get_varlength(ast_entity);
 	if(range) {
 		const cypher_astnode_t *start = cypher_ast_range_get_start(range);
@@ -96,72 +111,91 @@ static void _QueryGraphAddEdge(QueryGraph *qg, const cypher_astnode_t *ast_entit
 		else edge->maxHops = EDGE_LENGTH_INF;
 	}
 
-	// Build and add a QGEdge representing this entity to the QueryGraph.
-	// Swap the source and destination for left-pointing relations
+	// build and add a QGEdge representing this entity to the QueryGraph
+	// swap the source and destination for left-pointing relations
 	if(dir != CYPHER_REL_INBOUND) QueryGraph_ConnectNodes(qg, src, dest, edge);
 	else QueryGraph_ConnectNodes(qg, dest, src, edge);
 }
 
-// Extracts node from 'qg' and places a copy of into 'graph'
-static void _QueryGraph_ExtractNode(const QueryGraph *qg, QueryGraph *graph,
-									AST *ast, const cypher_astnode_t *ast_node) {
+// extracts node from 'qg' and places a copy of into 'graph'
+static void _QueryGraph_ExtractNode
+(
+	const QueryGraph *qg,
+	QueryGraph *graph,
+	AST *ast,
+	const cypher_astnode_t *ast_node
+) {
 
-	// Validate inputs.
-	ASSERT(qg != NULL && graph != NULL && ast != NULL && ast_node != NULL);
+	// validate inputs
+	ASSERT(qg        !=  NULL);
+	ASSERT(graph     !=  NULL);
+	ASSERT(ast       !=  NULL);
+	ASSERT(ast_node  !=  NULL);
 
-	// See if node is already in 'graph'.
+	// see if node is already in 'graph'
 	const char *alias = AST_GetEntityName(ast, ast_node);
 	QGNode *n = QueryGraph_GetNodeByAlias(graph, alias);
 
 	if(n == NULL) {
-		// Node is missing from 'graph', try getting it from 'qg'.
+		// node is missing from 'graph', try getting it from 'qg'
 		n = QueryGraph_GetNodeByAlias(qg, alias);
 		if(n == NULL) {
-			/* Node is missing from 'qg', create it.
-			 * It is possible to get into a situation where we try to extract
-			 * a path which contains entities that are missing from the
-			 * "holistic" query graph consider:
-			 * MATCH (a) WITH a WHERE (a)-[]->(:L1) in this case due to
-			 * clause scoping only node 'a' is in 'qg' the filtered pattern
-			 * which is being extracted from 'qg' has additional entities:
-			 * an anonymous edge and node. */
+			// node is missing from 'qg', create it
+			// it is possible to get into a situation where we try to extract
+			// a path which contains entities that are missing from the
+			// "holistic" query graph consider:
+			// MATCH (a) WITH a WHERE (a)-[]->(:L1) in this case due to
+			// clause scoping only node 'a' is in 'qg' the filtered pattern
+			// which is being extracted from 'qg' has additional entities:
+			// an anonymous edge and node
 			_QueryGraphAddNode(graph, ast_node);
 		} else {
-			// Add a clone of the original node.
+			// add a clone of the original node
 			n = QGNode_Clone(n);
 
-			// Clear node label information.
+			// clear node label information
 			n->label = NULL;
 			n->labelID = GRAPH_NO_LABEL;
 
 			QueryGraph_AddNode(graph, n);
-			// Set node label information.
+			// set node label information
 			_QueryGraphSetNodeLabel(n, ast_node);
 		}
 	}
 }
 
-// Extracts edge from 'qg' and places a copy of into 'graph'
-static void _QueryGraph_ExtractEdge(const QueryGraph *qg, QueryGraph *graph,
-									QGNode *left, QGNode *right, AST *ast, const cypher_astnode_t *ast_edge) {
+// extracts edge from 'qg' and places a copy of into 'graph'
+static void _QueryGraph_ExtractEdge
+(
+	const QueryGraph *qg,
+	QueryGraph *graph,
+	QGNode *left,
+	QGNode *right,
+	AST *ast,
+	const cypher_astnode_t *ast_edge
+) {
 	const char *alias = AST_GetEntityName(ast, ast_edge);
 
-	// Validate input, edge shouldn't be in graph.
+	// validate input, edge shouldn't be in graph
 	ASSERT(left != NULL && right != NULL);
 	ASSERT(QueryGraph_GetEdgeByAlias(graph, alias) == NULL);
-	/* Unlike nodes that can show up multiple times within a pattern
-	 * e.g. MATCH (a), (a:L)
-	 * where each occurance might add an additional piece of information
-	 * an edge can only be mentioned once, as such there's no value in
-	 * cloning an edge. therefor we simply add it.*/
+	// Unlike nodes that can show up multiple times within a pattern
+	// e.g. MATCH (a), (a:L)
+	// where each occurance might add an additional piece of information
+	// an edge can only be mentioned once, as such there's no value in
+	// cloning an edge. therefor we simply add it
 	_QueryGraphAddEdge(graph, ast_edge, left, right);
 }
 
-// Clones path from 'qg' into 'graph'.
-static void _QueryGraph_ExtractPath(const QueryGraph *qg, QueryGraph *graph,
-									const cypher_astnode_t *path) {
+// clones path from 'qg' into 'graph'
+static void _QueryGraph_ExtractPath
+(
+	const QueryGraph *qg,
+	QueryGraph *graph,
+	const cypher_astnode_t *path
+) {
 
-	// Validate input.
+	// validate input
 	ASSERT(qg != NULL && graph != NULL && path != NULL);
 
 	const char *alias;
@@ -169,22 +203,22 @@ static void _QueryGraph_ExtractPath(const QueryGraph *qg, QueryGraph *graph,
 	const cypher_astnode_t *ast_node;
 	uint nelems = cypher_ast_pattern_path_nelements(path);
 
-	/* Introduce nodes to graph
-	 * Nodes are at even indices */
+	// introduce nodes to graph
+	// nodes are at even indices
 	for(uint i = 0; i < nelems; i += 2) {
 		ast_node = cypher_ast_pattern_path_get_element(path, i);
 		_QueryGraph_ExtractNode(qg, graph, ast, ast_node);
 	}
 
-	/* Introduce edges to graph
-	 * edges are at odd indices */
+	// introduce edges to graph
+	// edges are at odd indices
 	for(uint i = 1; i < nelems; i += 2) {
-		// Retrieve the QGNode corresponding to the node left of this edge.
+		// retrieve the QGNode corresponding to the node left of this edge
 		const cypher_astnode_t *l_node = cypher_ast_pattern_path_get_element(path, i - 1);
 		const char *l_alias = AST_GetEntityName(ast, l_node);
 		QGNode *left = QueryGraph_GetNodeByAlias(graph, l_alias);
 
-		// Retrieve the QGNode corresponding to the node right of this edge.
+		// retrieve the QGNode corresponding to the node right of this edge
 		const cypher_astnode_t *r_node = cypher_ast_pattern_path_get_element(path, i + 1);
 		const char *r_alias = AST_GetEntityName(ast, r_node);
 		QGNode *right = QueryGraph_GetNodeByAlias(graph, r_alias);
@@ -194,7 +228,11 @@ static void _QueryGraph_ExtractPath(const QueryGraph *qg, QueryGraph *graph,
 	}
 }
 
-QueryGraph *QueryGraph_New(uint node_cap, uint edge_cap) {
+QueryGraph *QueryGraph_New
+(
+	uint node_cap,
+	uint edge_cap
+) {
 	QueryGraph *qg = rm_malloc(sizeof(QueryGraph));
 
 	qg->nodes = array_new(QGNode *, node_cap);
@@ -204,51 +242,70 @@ QueryGraph *QueryGraph_New(uint node_cap, uint edge_cap) {
 	return qg;
 }
 
-void QueryGraph_AddNode(QueryGraph *qg, QGNode *n) {
+void QueryGraph_AddNode
+(
+	QueryGraph *qg,
+	QGNode *n
+) {
 	array_append(qg->nodes, n);
 }
 
-void QueryGraph_ConnectNodes(QueryGraph *qg, QGNode *src, QGNode *dest, QGEdge *e) {
+void QueryGraph_ConnectNodes
+(
+	QueryGraph *qg,
+	QGNode *src,
+	QGNode *dest,
+	QGEdge *e
+) {
 	QGNode_ConnectNode(src, dest, e);
 	e->src = src;
 	e->dest = dest;
 	array_append(qg->edges, e);
 }
 
-void QueryGraph_AddPath(QueryGraph *qg, const cypher_astnode_t *path) {
+void QueryGraph_AddPath
+(
+	QueryGraph *qg,
+	const cypher_astnode_t *path
+) {
 	AST *ast = QueryCtx_GetAST();
 	uint nelems = cypher_ast_pattern_path_nelements(path);
-	/* Introduce nodes first. Nodes are positioned at every even offset
-	 * into the path (0, 2, ...) */
+	// introduce nodes first. Nodes are positioned at every even offset
+	// into the path (0, 2, ...)
 	for(uint i = 0; i < nelems; i += 2) {
 		const cypher_astnode_t *ast_node = cypher_ast_pattern_path_get_element(path, i);
 		_QueryGraphAddNode(qg, ast_node);
 	}
 
-	/* Every odd offset corresponds to an edge in a path. */
+	// every odd offset corresponds to an edge in a path
 	for(uint i = 1; i < nelems; i += 2) {
-		// Retrieve the QGNode corresponding to the node left of this edge.
+		// retrieve the QGNode corresponding to the node left of this edge
 		const cypher_astnode_t *l_node = cypher_ast_pattern_path_get_element(path, i - 1);
 		const char *l_alias = AST_GetEntityName(ast, l_node);
 		QGNode *left = QueryGraph_GetNodeByAlias(qg, l_alias);
 
-		// Retrieve the QGNode corresponding to the node right of this edge.
+		// retrieve the QGNode corresponding to the node right of this edge
 		const cypher_astnode_t *r_node = cypher_ast_pattern_path_get_element(path, i + 1);
 		const char *r_alias = AST_GetEntityName(ast, r_node);
 		QGNode *right = QueryGraph_GetNodeByAlias(qg, r_alias);
 
-		// Retrieve the AST reference to this edge.
+		// retrieve the AST reference to this edge
 		const cypher_astnode_t *edge = cypher_ast_pattern_path_get_element(path, i);
 		_QueryGraphAddEdge(qg, edge, left, right);
 	}
 }
 
-// Clones path from 'qg' into 'graph'
-QueryGraph *QueryGraph_ExtractPaths(const QueryGraph *qg, const cypher_astnode_t **paths, uint n) {
-	// Validate input.
+// clones path from 'qg' into 'graph'
+QueryGraph *QueryGraph_ExtractPaths
+(
+	const QueryGraph *qg,
+	const cypher_astnode_t **paths,
+	uint n
+) {
+	// validate input
 	ASSERT(qg != NULL && paths != NULL);
 
-	// Create an empty query graph.
+	// create an empty query graph
 	uint node_count = QueryGraph_NodeCount(qg);
 	uint edge_count = QueryGraph_EdgeCount(qg);
 	QueryGraph *graph = QueryGraph_New(node_count, edge_count);
@@ -262,14 +319,18 @@ QueryGraph *QueryGraph_ExtractPaths(const QueryGraph *qg, const cypher_astnode_t
 	return graph;
 }
 
-// Clones patterns from 'qg' into 'graph'
-QueryGraph *QueryGraph_ExtractPatterns(const QueryGraph *qg,
-									   const cypher_astnode_t **patterns, uint n) {
+// clones patterns from 'qg' into 'graph'
+QueryGraph *QueryGraph_ExtractPatterns
+(
+	const QueryGraph *qg,
+	const cypher_astnode_t **patterns,
+	uint n
+) {
 
-	// Validate inputs.
+	// validate inputs
 	ASSERT(qg != NULL && patterns != NULL);
 
-	// Create an empty query graph.
+	// create an empty query graph
 	uint node_count = QueryGraph_NodeCount(qg);
 	uint edge_count = QueryGraph_EdgeCount(qg);
 	QueryGraph *graph = QueryGraph_New(node_count, edge_count);
@@ -288,8 +349,11 @@ QueryGraph *QueryGraph_ExtractPatterns(const QueryGraph *qg,
 	return graph;
 }
 
-// Build a query graph from AST
-QueryGraph *BuildQueryGraph(const AST *ast) {
+// build a query graph from AST
+QueryGraph *BuildQueryGraph
+(
+	const AST *ast
+) {
 	uint node_count;
 	uint edge_count;
 
@@ -329,37 +393,45 @@ QueryGraph *BuildQueryGraph(const AST *ast) {
 	return qg;
 }
 
-void QueryGraph_MergeGraphs(QueryGraph *to, QueryGraph *from) {
+void QueryGraph_MergeGraphs
+(
+	QueryGraph *to,
+	QueryGraph *from
+) {
 	uint node_count = QueryGraph_NodeCount(from);
 	uint edge_count = QueryGraph_EdgeCount(from);
 
 	for(uint i = 0; i < node_count; i++) {
 		QGNode *n = from->nodes[i];
-		/* If the entity already exists in the "to" graph, do nothing.
-		 * We could have more complex logic to merge entity data, but this is not
-		 * currently necessary as this logic only benefits toString calls like EXPLAIN. */
+		// if the entity already exists in the "to" graph, do nothing
+		// we could have more complex logic to merge entity data, but this is not
+		// currently necessary as this logic only benefits toString calls like EXPLAIN
 		if(QueryGraph_GetNodeByAlias(to, n->alias)) continue;
-		// New entity, clone and add it.
+		// new entity, clone and add it
 		QueryGraph_AddNode(to, QGNode_Clone(n));
 	}
 
 	for(uint i = 0; i < edge_count; i++) {
 		QGEdge *e = from->edges[i];
-		/* If the entity already exists in the "to" graph, do nothing.
-		 * We could have more complex logic to merge entity data, but this is not
-		 * currently necessary as this logic only benefits toString calls like EXPLAIN. */
+		// if the entity already exists in the "to" graph, do nothing
+		// we could have more complex logic to merge entity data, but this is not
+		// currently necessary as this logic only benefits toString calls like EXPLAIN
 		if(QueryGraph_GetEdgeByAlias(to, e->alias)) continue;
 
-		// Retrieve the edge's endpoints in the "to" graph.
+		// retrieve the edge's endpoints in the "to" graph
 		QGNode *src = QueryGraph_GetNodeByAlias(to, e->src->alias);
 		QGNode *dest = QueryGraph_GetNodeByAlias(to, e->dest->alias);
-		// Clone and add the unmatched edge.
+		// clone and add the unmatched edge
 		QGEdge *clone_edge = QGEdge_Clone(e);
 		QueryGraph_ConnectNodes(to, src, dest, clone_edge);
 	}
 }
 
-QGNode *QueryGraph_GetNodeByAlias(const QueryGraph *qg, const char *alias) {
+QGNode *QueryGraph_GetNodeByAlias
+(
+	const QueryGraph *qg,
+	const char *alias
+) {
 	uint node_count = QueryGraph_NodeCount(qg);
 	for(uint i = 0; i < node_count; i ++) {
 		if(!RG_STRCMP(qg->nodes[i]->alias, alias)) return qg->nodes[i];
@@ -367,7 +439,11 @@ QGNode *QueryGraph_GetNodeByAlias(const QueryGraph *qg, const char *alias) {
 	return NULL;
 }
 
-QGEdge *QueryGraph_GetEdgeByAlias(const QueryGraph *qg, const char *alias) {
+QGEdge *QueryGraph_GetEdgeByAlias
+(
+	const QueryGraph *qg,
+	const char *alias
+) {
 	uint edge_count = QueryGraph_EdgeCount(qg);
 	for(uint i = 0; i < edge_count; i ++) {
 		if(!RG_STRCMP(qg->edges[i]->alias, alias)) return qg->edges[i];
@@ -375,14 +451,21 @@ QGEdge *QueryGraph_GetEdgeByAlias(const QueryGraph *qg, const char *alias) {
 	return NULL;
 }
 
-EntityType QueryGraph_GetEntityTypeByAlias(const QueryGraph *qg, const char *alias) {
+EntityType QueryGraph_GetEntityTypeByAlias
+(
+	const QueryGraph *qg,
+	const char *alias
+) {
 	if(QueryGraph_GetNodeByAlias(qg, alias) != NULL) return ENTITY_NODE;
 	if(QueryGraph_GetEdgeByAlias(qg, alias) != NULL) return ENTITY_EDGE;
 	return ENTITY_UNKNOWN;
 }
 
-void QueryGraph_ResolveUnknownRelIDs(QueryGraph *qg) {
-	// No unknown relationships - no need to updated.
+void QueryGraph_ResolveUnknownRelIDs
+(
+	QueryGraph *qg
+) {
+	// no unknown relationships - no need to updated
 	if(!qg->unknown_reltype_ids) return;
 
 	Schema *s = NULL;
@@ -390,7 +473,7 @@ void QueryGraph_ResolveUnknownRelIDs(QueryGraph *qg) {
 	GraphContext *gc = QueryCtx_GetGraphCtx();
 	uint edge_count = QueryGraph_EdgeCount(qg);
 
-	// Update edges.
+	// update edges
 	for(uint i = 0; i < edge_count; i++) {
 		QGEdge *edge = qg->edges[i];
 		uint rel_types_count = array_len(edge->reltypeIDs);
@@ -398,7 +481,7 @@ void QueryGraph_ResolveUnknownRelIDs(QueryGraph *qg) {
 			if(edge->reltypeIDs[j] == GRAPH_UNKNOWN_RELATION) {
 				s = GraphContext_GetSchema(gc, edge->reltypes[j], SCHEMA_EDGE);
 				if(s) edge->reltypeIDs[j] = s->id;
-				else unkown_relationships = true; // Cannot update the unkown relationship.
+				else unkown_relationships = true; // cannot update the unkown relationship
 			}
 		}
 	}
@@ -406,24 +489,28 @@ void QueryGraph_ResolveUnknownRelIDs(QueryGraph *qg) {
 	qg->unknown_reltype_ids = unkown_relationships;
 }
 
-QueryGraph *QueryGraph_Clone(const QueryGraph *qg) {
-	uint node_count = QueryGraph_NodeCount(qg);
-	uint edge_count = QueryGraph_EdgeCount(qg);
-	QueryGraph *clone = QueryGraph_New(node_count, edge_count);
+QueryGraph *QueryGraph_Clone
+(
+	const QueryGraph *qg
+) {
+	uint        node_count  =  QueryGraph_NodeCount(qg);
+	uint        edge_count  =  QueryGraph_EdgeCount(qg);
+	QueryGraph  *clone      =  QueryGraph_New(node_count, edge_count);
 
-	// Clone nodes.
+	// clone nodes
 	for(uint i = 0; i < node_count; i++) {
-		// Clones node without its edges.
+		// clones node without its edges
 		QGNode *n = QGNode_Clone(qg->nodes[i]);
 		QueryGraph_AddNode(clone, n);
 	}
 
-	// Clone edges.
+	// clone edges
 	for(uint i = 0; i < edge_count; i++) {
-		QGEdge *e = qg->edges[i];
-		QGNode *src = QueryGraph_GetNodeByAlias(clone, e->src->alias);
-		QGNode *dest = QueryGraph_GetNodeByAlias(clone, e->dest->alias);
+		QGEdge  *e     =  qg->edges[i];
+		QGNode  *src   =  QueryGraph_GetNodeByAlias(clone, e->src->alias);
+		QGNode  *dest  =  QueryGraph_GetNodeByAlias(clone, e->dest->alias);
 		ASSERT(src != NULL && dest != NULL);
+
 		QGEdge *clone_edge = QGEdge_Clone(e);
 		QueryGraph_ConnectNodes(clone, src, dest, clone_edge);
 	}
@@ -431,11 +518,15 @@ QueryGraph *QueryGraph_Clone(const QueryGraph *qg) {
 	return clone;
 }
 
-QGNode *QueryGraph_RemoveNode(QueryGraph *qg, QGNode *n) {
+QGNode *QueryGraph_RemoveNode
+(
+	QueryGraph *qg,
+	QGNode *n
+) {
 	ASSERT(qg != NULL && n != NULL);
 
-	/* Remove node from query graph.
-	 * Remove and free all edges associated with node. */
+	// remove node from query graph
+	// remove and free all edges associated with node
 	uint incoming_edge_count = array_len(n->incoming_edges);
 	for(uint i = 0; i < incoming_edge_count; i++) {
 		QGEdge *e = n->incoming_edges[i];
@@ -450,7 +541,7 @@ QGNode *QueryGraph_RemoveNode(QueryGraph *qg, QGNode *n) {
 		QGEdge_Free(e);
 	}
 
-	// Remove node from graph nodes.
+	// remove node from graph nodes
 	uint node_count = QueryGraph_NodeCount(qg);
 	uint i = 0;
 	for(; i < node_count; i++) {
@@ -463,14 +554,18 @@ QGNode *QueryGraph_RemoveNode(QueryGraph *qg, QGNode *n) {
 	return n;
 }
 
-QGEdge *QueryGraph_RemoveEdge(QueryGraph *qg, QGEdge *e) {
+QGEdge *QueryGraph_RemoveEdge
+(
+	QueryGraph *qg,
+	QGEdge *e
+) {
 	ASSERT(qg != NULL && e != NULL);
 
-	// Disconnect nodes connected by edge.
+	// disconnect nodes connected by edge
 	QGNode_RemoveOutgoingEdge(e->src, e);
 	QGNode_RemoveIncomingEdge(e->dest, e);
 
-	/* Remove edge from query graph. */
+	// remove edge from query graph
 	uint edge_count = QueryGraph_EdgeCount(qg);
 	uint i = 0;
 	for(; i < edge_count; i++) {
@@ -482,65 +577,73 @@ QGEdge *QueryGraph_RemoveEdge(QueryGraph *qg, QGEdge *e) {
 	return e;
 }
 
-QueryGraph **QueryGraph_ConnectedComponents(const QueryGraph *qg) {
-	QGNode *n;                              // Current node.
-	QGNode **q = array_new(QGNode *, 1);    // Node frontier.
-	void *seen;                             // Has node been visited?
-	QueryGraph *g = QueryGraph_Clone(qg);   // Clone query graph.
-	rax *visited;                           // Dictionary of visited nodes.
-	QueryGraph **connected_components;      // List of connected components.
+QueryGraph **QueryGraph_ConnectedComponents
+(
+	const QueryGraph *qg
+) {
+	QGNode *n;                              // current node
+	QGNode **q = array_new(QGNode *, 1);    // node frontier
+	void *seen;                             // has node been visited?
+	QueryGraph *g = QueryGraph_Clone(qg);   // clone query graph
+	rax *visited;                           // dictionary of visited nodes
+	QueryGraph **connected_components;      // list of connected components
 
-	// At least one connected component (the original graph).
+	// at least one connected component (the original graph)
 	connected_components = array_new(QueryGraph *, 1);
 
-	// As long as there are nodes to process.
+	// as long as there are nodes to process
 	while(true) {
 		visited = raxNew();
 
-		// Get a random node and add it to the frontier.
+		// get a random node and add it to the frontier
 		QGNode *s = g->nodes[0];
 		array_append(q, s);
 
-		// As long as there are nodes in the frontier.
+		// as long as there are nodes in the frontier
 		while(array_len(q) > 0) {
 			n = array_pop(q);
 
-			// Mark n as visited.
-			if(!raxInsert(visited, (unsigned char *)n->alias, strlen(n->alias), NULL, NULL)) {
-				// We've already processed n.
+			// mark n as visited
+			if(!raxInsert(visited, (unsigned char *)n->alias, strlen(n->alias),
+						NULL, NULL)) {
+				// we've already processed n
 				continue;
 			}
 
-			// Expand node N by visiting all of its neighbors
+			// expand node N by visiting all of its neighbors
 			for(int i = 0; i < array_len(n->outgoing_edges); i++) {
 				QGEdge *e = n->outgoing_edges[i];
-				seen = raxFind(visited, (unsigned char *)e->dest->alias, strlen(e->dest->alias));
+				seen = raxFind(visited, (unsigned char *)e->dest->alias,
+						strlen(e->dest->alias));
 				if(seen == raxNotFound) array_append(q, e->dest);
 			}
+
 			for(int i = 0; i < array_len(n->incoming_edges); i++) {
 				QGEdge *e = n->incoming_edges[i];
-				seen = raxFind(visited, (unsigned char *)e->src->alias, strlen(e->src->alias));
+				seen = raxFind(visited, (unsigned char *)e->src->alias,
+						strlen(e->src->alias));
 				if(seen == raxNotFound) array_append(q, e->src);
 			}
 		}
 
-		/* Visited comprise the connected component defined by S.
-		 * Remove all non-reachable nodes from current connected component.
-		 * Remove connected component from graph. */
+		// visited comprise the connected component defined by S
+		// remove all non-reachable nodes from current connected component.
+		// remove connected component from graph
 		QueryGraph *cc = QueryGraph_Clone(g);
 		uint node_count = QueryGraph_NodeCount(g);
 		for(uint i = 0; i < node_count; i++) {
 			void *reachable;
 			n = g->nodes[i];
-			reachable = raxFind(visited, (unsigned char *)n->alias, strlen(n->alias));
+			reachable = raxFind(visited, (unsigned char *)n->alias,
+					strlen(n->alias));
 
-			/* If node is reachable, which means it is part of the
-			 * connected component, then remove it from the graph,
-			 * otherwise, node isn't reachable, not part of the
-			 * connected component. */
+			// if node is reachable, which means it is part of the
+			// connected component, then remove it from the graph,
+			// otherwise, node isn't reachable, not part of the
+			// connected component
 			if(reachable != raxNotFound) {
-				QGNode *removed = QueryGraph_RemoveNode(g, n);
-				QGNode_Free(removed);
+				n = QueryGraph_RemoveNode(g, n);
+				QGNode_Free(n);
 			} else {
 				n = QueryGraph_GetNodeByAlias(cc, n->alias);
 				QueryGraph_RemoveNode(cc, n);
@@ -550,10 +653,10 @@ QueryGraph **QueryGraph_ConnectedComponents(const QueryGraph *qg) {
 
 		array_append(connected_components, cc);
 
-		// Clear visited dict for next iteration.
+		// clear visited dict for next iteration
 		raxFree(visited);
 
-		// Exit when graph is empty.
+		// exit when graph is empty
 		if(QueryGraph_NodeCount(g) == 0) break;
 	}
 
@@ -563,31 +666,40 @@ QueryGraph **QueryGraph_ConnectedComponents(const QueryGraph *qg) {
 	return connected_components;
 }
 
-uint QueryGraph_NodeCount(const QueryGraph *qg) {
+uint QueryGraph_NodeCount
+(
+	const QueryGraph *qg
+) {
 	return array_len(qg->nodes);
 }
 
-/* Retrieve the number of edges in a QueryGraph. */
-uint QueryGraph_EdgeCount(const QueryGraph *qg) {
+// retrieve the number of edges in a QueryGraph
+uint QueryGraph_EdgeCount
+(
+	const QueryGraph *qg
+) {
 	return array_len(qg->edges);
 }
 
-GrB_Matrix QueryGraph_MatrixRepresentation(const QueryGraph *qg) {
+GrB_Matrix QueryGraph_MatrixRepresentation
+(
+	const QueryGraph *qg
+) {
 	ASSERT(qg != NULL);
 
-	// Make a clone of the given graph as we're about to modify it.
+	// make a clone of the given graph as we're about to modify it
 	QueryGraph *qg_clone = QueryGraph_Clone(qg);
 
-	// Give an ID for each node, abuse of `labelID`.
+	// give an ID for each node, abuse of `labelID`
 	uint node_count = QueryGraph_NodeCount(qg_clone);
 	for(uint i = 0; i < node_count; i++) qg_clone->nodes[i]->labelID = i;
 
-	GrB_Matrix m;   // Matrix representation of QueryGraph.
+	GrB_Matrix m;   // matrix representation of QueryGraph
 	GrB_Info res = GrB_Matrix_new(&m, GrB_BOOL, node_count, node_count);
 	UNUSED(res);
 	ASSERT(res == GrB_SUCCESS);
 
-	// Build matrix representation of query graph.
+	// build matrix representation of query graph
 	for(uint i = 0; i < node_count; i++) {
 		const QGNode *n = qg_clone->nodes[i];
 		GrB_Index src = n->labelID;
@@ -596,7 +708,7 @@ GrB_Matrix QueryGraph_MatrixRepresentation(const QueryGraph *qg) {
 		for(uint j = 0; j < outgoing_degree; j++) {
 			const QGEdge *e = n->outgoing_edges[j];
 			GrB_Index dest = e->dest->labelID;
-			// Populate `m`.
+			// populate `m`
 			res = GrB_Matrix_setElement_BOOL(m, true, src, dest);
 			ASSERT(res == GrB_SUCCESS);
 		}
@@ -606,7 +718,10 @@ GrB_Matrix QueryGraph_MatrixRepresentation(const QueryGraph *qg) {
 	return m;
 }
 
-void QueryGraph_Print(const QueryGraph *qg) {
+void QueryGraph_Print
+(
+	const QueryGraph *qg
+) {
 	char *buff = calloc(1024, sizeof(char));
 
 	uint node_count = QueryGraph_NodeCount(qg);
@@ -615,7 +730,7 @@ void QueryGraph_Print(const QueryGraph *qg) {
 	for(int i = 0; i < node_count; i++) {
 		QGNode *n = qg->nodes[i];
 		if(QGNode_IncomeDegree(n) + QGNode_OutgoingDegree(n) == 0) {
-			// Floating node.
+			// floating node
 			asprintf(&buff, "%s%s;\n", buff, n->alias);
 		}
 	}
@@ -629,19 +744,22 @@ void QueryGraph_Print(const QueryGraph *qg) {
 	free(buff);
 }
 
-/* Frees entire graph. */
-void QueryGraph_Free(QueryGraph *qg) {
-	if(!qg) return;
+// frees entire graph
+void QueryGraph_Free
+(
+	QueryGraph *qg
+) {
+	if(qg == NULL) return;
 
-	/* Free QueryGraph nodes. */
+	// free QueryGraph nodes
 	uint nodeCount = QueryGraph_NodeCount(qg);
-	for(uint i = 0; i < nodeCount; i ++) {
+	for(uint i = 0; i < nodeCount; i++) {
 		QGNode_Free(qg->nodes[i]);
 	}
 
-	/* Free QueryGraph edges. */
+	// free QueryGraph edges
 	uint edgeCount = QueryGraph_EdgeCount(qg);
-	for(uint i = 0; i < edgeCount; i ++) {
+	for(uint i = 0; i < edgeCount; i++) {
 		QGEdge_Free(qg->edges[i]);
 	}
 

--- a/src/module_event_handlers.c
+++ b/src/module_event_handlers.c
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */
@@ -16,36 +16,36 @@
 #include "serializers/graphmeta_type.h"
 #include "serializers/graphcontext_type.h"
 
-// Global array tracking all extant GraphContexts.
+// global array tracking all extant GraphContexts
 extern GraphContext **graphs_in_keyspace;
-// Flag indicating whether the running process is a child.
+// flag indicating whether the running process is a child
 extern bool process_is_child;
-// GraphContext type as it is registered at Redis.
+// graphContext type as it is registered at Redis
 extern RedisModuleType *GraphContextRedisModuleType;
-// Graph meta keys type as it is registered at Redis.
+// graph meta keys type as it is registered at Redis
 extern RedisModuleType *GraphMetaRedisModuleType;
 
-/* Both of the following fields are required to verify that the module is replicated
- * in a successful manner. In a sharded environment, there could be a race condition between the decoding of
- * the last key, and the last aux_fields, so both counters should be zeroed in order to verify
- * that the module replicated properly.*/
+// both of the following fields are required to verify that the module is replicated
+// in a successful manner. In a sharded environment, there could be a race condition between the decoding of
+// the last key, and the last aux_fields, so both counters should be zeroed in order to verify
+// that the module replicated properly.*/
 
-/* Holds the number of aux fields encountered during decoding of RDB file.
- * This field is used to represent when the module is replicating its graphs. */
+// holds the number of aux fields encountered during decoding of RDB file
+// this field is used to represent when the module is replicating its graphs
 uint aux_field_counter = 0 ;
 
-/* Holds the number of graphs encountered during decoding of RDB file.
- * This field is used to represent when the module is replicating its graphs. */
+// holds the number of graphs encountered during decoding of RDB file
+// this field is used to represent when the module is replicating its graphs
 uint currently_decoding_graphs = 0;
 
-/* Holds the id of the Redis Main thread in order to figure out the context the fork is running on */
+// holds the id of the Redis Main thread in order to figure out the context the fork is running on
 static pthread_t redis_main_thread_id;
 
-/* This callback invokes once rename for a graph is done. Since the key value is a graph context
- * which saves the name of the graph for later key accesses, this data must be consistent with the key name,
- * otherwise, the graph context will remain with the previous graph name, and a key access to this name might
- * yield an empty key or wrong value. This method changes the graph name value at the graph context to be
- * consistent with the key name. */
+// this callback invokes once rename for a graph is done. Since the key value is a graph context
+// which saves the name of the graph for later key accesses, this data must be consistent with the key name,
+// otherwise, the graph context will remain with the previous graph name, and a key access to this name might
+// yield an empty key or wrong value. This method changes the graph name value at the graph context to be
+// consistent with the key name
 static int _RenameGraphHandler(RedisModuleCtx *ctx, int type, const char *event,
 							   RedisModuleString *key_name) {
 	if(type != REDISMODULE_NOTIFY_GENERIC) return REDISMODULE_OK;

--- a/tests/flow/test_persistency.py
+++ b/tests/flow/test_persistency.py
@@ -7,7 +7,6 @@ from redisgraph import Graph, Node, Edge
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
-
 redis_con = None
 
 class testGraphPersistency(FlowTestsBase):

--- a/tests/flow/test_stress.py
+++ b/tests/flow/test_stress.py
@@ -26,24 +26,24 @@ def query_crud(graph, query_id):
             return False
 
 # run n_iterations and create n node in each iteration
-def create_nodes(graph, n_iterations, n):
+def create_nodes(graph, n_iterations):
     for i in range(n_iterations):
-        graph.query("UNWIND range(0, %d) AS x CREATE (:Node {val: x})" % n)
+        graph.query("CREATE (:Node {val: %d})-[:R]->()" % i)
 
 # run n_iterations and delete n in each iteration
-def delete_nodes(graph, n_iterations, n):
+def delete_nodes(graph, n_iterations):
     for i in range(n_iterations):
-        graph.query("MATCH (n) WITH n LIMIT %d DELETE n" % n)
+        graph.query("MATCH (n:Node) WITH n LIMIT 1 DELETE n")
 
 # run n_iterations and update all nodes in each iteration
 def update_nodes(graph, n_iterations):
     for i in range(n_iterations):
-        graph.query("MATCH (n) SET n.v = 1")
+        graph.query("MATCH (n:Node) WITH n LIMIT 1 SET n.v = 1")
 
 # run n_iterations and execute a read query in each iteration
 def read_nodes(graph, n_iterations):
     for i in range(n_iterations):
-        graph.query("MATCH (n) return n")
+        graph.query("MATCH (n:Node)-[:R]->() RETURN n LIMIT 1")
 
 # calls BGSAVE every 0.2 second
 def BGSAVE_loop(env, conn, n_iterations):
@@ -102,22 +102,25 @@ class testStressFlow(FlowTestsBase):
         conn.close()
 
     def test01_bgsave_stress(self):
-        n_nodes = 1000
-        n_iterations = 10
+        n_reads = 50000
+        n_creations = 50000
+        n_updates = n_creations/10
+        n_deletions = n_creations/2
+
         conn = self.env.getConnection()
         graphs[0].query("CREATE INDEX ON :Node(val)")
 
         pool = Pool(nodes=5)
 
-        t1 = pool.apipe(create_nodes, graphs[0], n_iterations, n_nodes)
+        t1 = pool.apipe(create_nodes, graphs[0], n_creations)
 
-        t2 = pool.apipe(delete_nodes, graphs[1], n_iterations, n_nodes/2)
+        t2 = pool.apipe(delete_nodes, graphs[1], n_deletions)
 
-        t3 = pool.apipe(read_nodes, graphs[2], n_iterations)
+        t3 = pool.apipe(read_nodes, graphs[2], n_reads)
 
-        t4 = pool.apipe(update_nodes, graphs[3], n_iterations)
+        t4 = pool.apipe(update_nodes, graphs[3], n_updates)
 
-        t5 = pool.apipe(BGSAVE_loop, self.env, conn, 3)
+        t5 = pool.apipe(BGSAVE_loop, self.env, conn, 10000)
 
         # wait for processes to join
         t1.wait()
@@ -151,3 +154,4 @@ class testStressFlow(FlowTestsBase):
         m.wait()
 
         self.env.assertTrue(self.env.checkExitCode())
+


### PR DESCRIPTION
#599
in case a readers is syncing a matrix while `BGSAVE` is called child process might inherit a lock matrix
this PR moves matrix sync to parent just before forking