### PR TITLE
Free thread-local data on graph deletion

### DIFF
--- a/src/arithmetic/arithmetic_expression.c
+++ b/src/arithmetic/arithmetic_expression.c
@@ -469,9 +469,10 @@ static AR_EXP_Result _AR_EXP_EvaluateVariadic(AR_ExpNode *node, const Record r, 
 
 static AR_EXP_Result _AR_EXP_EvaluateParam(AR_ExpNode *node, SIValue *result) {
 	rax *params = QueryCtx_GetParams();
-	AR_ExpNode *param_node = raxFind(params, (unsigned char *)node->operand.param_name,
-									 strlen(node->operand.param_name));
-	if(param_node == raxNotFound) {
+	AR_ExpNode *param_node;
+	if(params) param_node = raxFind(params, (unsigned char *)node->operand.param_name,
+										strlen(node->operand.param_name));
+	if(params == NULL || param_node == raxNotFound) {
 		// Set the query-level error.
 		ErrorCtx_SetError("Missing parameters");
 		return EVAL_ERR;

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 Redis Labs Ltd. and Contributors
+ * Copyright 2018-2021 Redis Labs Ltd. and Contributors
  *
  * This file is available under the Redis Labs Source Available License Agreement
  */
@@ -78,7 +78,7 @@ static void _AST_Extract_Params(const cypher_parse_result_t *parse_result) {
 	const cypher_astnode_t *statement = _AST_parse_result_root(parse_result);
 	uint noptions = cypher_ast_statement_noptions(statement);
 	if(noptions == 0) return;
-	rax *params = QueryCtx_GetParams();
+	rax *params = raxNew();
 	for(uint i = 0; i < noptions; i++) {
 		const cypher_astnode_t *option = cypher_ast_statement_get_option(statement, i);
 		uint nparams = cypher_ast_cypher_option_nparams(option);
@@ -90,6 +90,8 @@ static void _AST_Extract_Params(const cypher_parse_result_t *parse_result) {
 			raxInsert(params, (unsigned char *) paramName, strlen(paramName), (void *)exp, NULL);
 		}
 	}
+	// Add the parameters map to the QueryCtx.
+	QueryCtx_SetParams(params);
 }
 
 static void AST_IncreaseRefCount(AST *ast) {

--- a/src/commands/cmd_bulk_insert.c
+++ b/src/commands/cmd_bulk_insert.c
@@ -110,7 +110,6 @@ int Graph_BulkInsert(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	RedisModule_ReplyWithStringBuffer(ctx, reply, len);
 
 cleanup:
-	QueryCtx_Free();
 	if(gc) GraphContext_Release(gc);
 
 	return REDISMODULE_OK;

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -359,12 +359,12 @@ bool GraphContext_HasIndices(GraphContext *gc) {
 	return false;
 }
 Index *GraphContext_GetIndexByID(const GraphContext *gc, int id,
-		Attribute_ID *attribute_id, IndexType type) {
+								 Attribute_ID *attribute_id, IndexType type) {
 
 	ASSERT(gc     !=  NULL);
 
 	// Retrieve the schema for given id
-	Schema *s= GraphContext_GetSchemaByID(gc, id, SCHEMA_NODE);
+	Schema *s = GraphContext_GetSchemaByID(gc, id, SCHEMA_NODE);
 	if(s == NULL) return NULL;
 
 	return Schema_GetIndex(s, attribute_id, type);
@@ -566,5 +566,12 @@ static void _GraphContext_Free(void *arg) {
 	GraphDecodeContext_Free(gc->decoding_context);
 	rm_free(gc->graph_name);
 	rm_free(gc);
+
+	//--------------------------------------------------------------------------
+	// Free thread-local data
+	//--------------------------------------------------------------------------
+	// a QueryCtx may have been instantiated during a free routine triggered
+	// by Cache_Free (such as in OpDelete); ensure it is released
+	QueryCtx_Free();
 }
 

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -570,8 +570,12 @@ static void _GraphContext_Free(void *arg) {
 	//--------------------------------------------------------------------------
 	// Free thread-local data
 	//--------------------------------------------------------------------------
-	// a QueryCtx may have been instantiated during a free routine triggered
-	// by Cache_Free (such as in OpDelete); ensure it is released
+	// a QueryCtx may have been instantiated during cache eviction.
+	// for example, the query "MATCH (a) DELETE a" will populate the cache with
+	// an ExecutionPlan. when this plan is freed, DeleteFree will check whether
+	// there are entities to delete, and - finding none - will call 
+	// QueryCtx_UnlockCommit. this instantiates a new QueryCtx object that
+	// should be freed here.
 	QueryCtx_Free();
 }
 

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -566,16 +566,5 @@ static void _GraphContext_Free(void *arg) {
 	GraphDecodeContext_Free(gc->decoding_context);
 	rm_free(gc->graph_name);
 	rm_free(gc);
-
-	//--------------------------------------------------------------------------
-	// Free thread-local data
-	//--------------------------------------------------------------------------
-	// a QueryCtx may have been instantiated during cache eviction.
-	// for example, the query "MATCH (a) DELETE a" will populate the cache with
-	// an ExecutionPlan. when this plan is freed, DeleteFree will check whether
-	// there are entities to delete, and - finding none - will call 
-	// QueryCtx_UnlockCommit. this instantiates a new QueryCtx object that
-	// should be freed here.
-	QueryCtx_Free();
 }
 

--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -90,8 +90,8 @@ void QueryCtx_SetLastWriter(OpBase *last_writer) {
 
 AST *QueryCtx_GetAST(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	if(ctx) return ctx->query_data.ast;
-	return NULL;
+	ASSERT(ctx != NULL);
+	return ctx->query_data.ast;
 }
 
 rax *QueryCtx_GetParams(void) {
@@ -102,7 +102,7 @@ rax *QueryCtx_GetParams(void) {
 
 GraphContext *QueryCtx_GetGraphCtx(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	ASSERT(ctx->gc);
+	ASSERT(ctx && ctx->gc);
 	return ctx->gc;
 }
 
@@ -113,14 +113,14 @@ Graph *QueryCtx_GetGraph(void) {
 
 RedisModuleCtx *QueryCtx_GetRedisModuleCtx(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	if(ctx) return ctx->global_exec_ctx.redis_ctx;
-	return NULL;
+	ASSERT(ctx != NULL);
+	return ctx->global_exec_ctx.redis_ctx;
 }
 
 ResultSet *QueryCtx_GetResultSet(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	if(ctx) return ctx->internal_exec_ctx.result_set;
-	return NULL;
+	ASSERT(ctx != NULL);
+	return ctx->internal_exec_ctx.result_set;
 }
 
 ResultSetStatistics *QueryCtx_GetResultSetStatistics(void) {
@@ -237,12 +237,13 @@ void QueryCtx_ForceUnlockCommit() {
 
 double QueryCtx_GetExecutionTime(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
+	ASSERT(ctx != NULL);
 	return simple_toc(ctx->internal_exec_ctx.timer) * 1000;
 }
 
 void QueryCtx_Free(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	if(!ctx) return;
+	ASSERT(ctx != NULL);
 
 	if(ctx->query_data.params) {
 		raxFreeWithCallback(ctx->query_data.params, _ParameterFreeCallback);

--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -16,13 +16,21 @@ extern RedisModuleType *GraphContextRedisModuleType;
 
 pthread_key_t _tlsQueryCtxKey;  // Thread local storage query context key.
 
-static inline QueryCtx *_QueryCtx_GetCtx(void) {
+// retrieve or instantiate new QueryCtx
+static inline QueryCtx *_QueryCtx_GetCreateCtx(void) {
 	QueryCtx *ctx = pthread_getspecific(_tlsQueryCtxKey);
 	if(!ctx) {
 		// Set a new thread-local QueryCtx if one has not been created.
 		ctx = rm_calloc(1, sizeof(QueryCtx));
 		pthread_setspecific(_tlsQueryCtxKey, ctx);
 	}
+	return ctx;
+}
+
+// retrieve QueryCtx, return NULL if one does not exist
+static inline QueryCtx *_QueryCtx_GetCtx(void) {
+	QueryCtx *ctx = pthread_getspecific(_tlsQueryCtxKey);
+	if(!ctx) return NULL;
 	return ctx;
 }
 
@@ -36,7 +44,7 @@ bool QueryCtx_Init(void) {
 }
 
 inline QueryCtx *QueryCtx_GetQueryCtx() {
-	return _QueryCtx_GetCtx();
+	return _QueryCtx_GetCreateCtx();
 }
 
 inline void QueryCtx_SetTLS(QueryCtx *query_ctx) {
@@ -48,12 +56,12 @@ inline void QueryCtx_RemoveFromTLS() {
 }
 
 void QueryCtx_BeginTimer(void) {
-	QueryCtx *ctx = _QueryCtx_GetCtx(); // Attempt to retrieve the QueryCtx.
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx(); // Attempt to retrieve the QueryCtx.
 	simple_tic(ctx->internal_exec_ctx.timer); // Start the execution timer.
 }
 
 void QueryCtx_SetGlobalExecutionCtx(CommandCtx *cmd_ctx) {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
 	ctx->gc = CommandCtx_GetGraphContext(cmd_ctx);
 	ctx->query_data.query = CommandCtx_GetQuery(cmd_ctx);
 	ctx->global_exec_ctx.bc = CommandCtx_GetBlockingClient(cmd_ctx);
@@ -62,32 +70,33 @@ void QueryCtx_SetGlobalExecutionCtx(CommandCtx *cmd_ctx) {
 }
 
 void QueryCtx_SetAST(AST *ast) {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
 	ctx->query_data.ast = ast;
 }
 
 void QueryCtx_SetGraphCtx(GraphContext *gc) {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
 	ctx->gc = gc;
 }
 
 void QueryCtx_SetResultSet(ResultSet *result_set) {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
 	ctx->internal_exec_ctx.result_set = result_set;
 }
 
 void QueryCtx_SetLastWriter(OpBase *last_writer) {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
 	ctx->internal_exec_ctx.last_writer = last_writer;
 }
 
 AST *QueryCtx_GetAST(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	return ctx->query_data.ast;
+	if(ctx) return ctx->query_data.ast;
+	return NULL;
 }
 
 rax *QueryCtx_GetParams(void) {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
 	if(!ctx->query_data.params) ctx->query_data.params = raxNew();
 	return ctx->query_data.params;
 }
@@ -105,12 +114,14 @@ Graph *QueryCtx_GetGraph(void) {
 
 RedisModuleCtx *QueryCtx_GetRedisModuleCtx(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	return ctx->global_exec_ctx.redis_ctx;
+	if(ctx) return ctx->global_exec_ctx.redis_ctx;
+	return NULL;
 }
 
 ResultSet *QueryCtx_GetResultSet(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
-	return ctx->internal_exec_ctx.result_set;
+	if(ctx) return ctx->internal_exec_ctx.result_set;
+	return NULL;
 }
 
 ResultSetStatistics *QueryCtx_GetResultSetStatistics(void) {
@@ -121,7 +132,7 @@ ResultSetStatistics *QueryCtx_GetResultSetStatistics(void) {
 }
 
 void QueryCtx_PrintQuery(void) {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
 	printf("%s\n", ctx->query_data.query);
 }
 
@@ -134,7 +145,7 @@ static void _QueryCtx_ThreadSafeContextUnlock(QueryCtx *ctx) {
 }
 
 bool QueryCtx_LockForCommit(void) {
-	QueryCtx *ctx = _QueryCtx_GetCtx();
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
 	if(ctx->internal_exec_ctx.locked_for_commit) return true;
 	// Lock GIL.
 	RedisModuleCtx *redis_ctx = ctx->global_exec_ctx.redis_ctx;
@@ -199,6 +210,7 @@ static void _QueryCtx_UnlockCommit(QueryCtx *ctx) {
 
 void QueryCtx_UnlockCommit(OpBase *writer_op) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
+	if(!ctx) return;
 
 	// check that the writer_op is entitled to release the lock.
 	if(ctx->internal_exec_ctx.last_writer != writer_op) return;
@@ -211,6 +223,7 @@ void QueryCtx_UnlockCommit(OpBase *writer_op) {
 
 void QueryCtx_ForceUnlockCommit() {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
+	if(!ctx) return;
 
 	// already unlocked?
 	if(!ctx->internal_exec_ctx.locked_for_commit) return;
@@ -230,6 +243,7 @@ double QueryCtx_GetExecutionTime(void) {
 
 void QueryCtx_Free(void) {
 	QueryCtx *ctx = _QueryCtx_GetCtx();
+	if(!ctx) return;
 
 	if(ctx->query_data.params) {
 		raxFreeWithCallback(ctx->query_data.params, _ParameterFreeCallback);

--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */
@@ -83,6 +83,11 @@ void QueryCtx_SetResultSet(ResultSet *result_set) {
 	ctx->internal_exec_ctx.result_set = result_set;
 }
 
+void QueryCtx_SetParams(rax *params) {
+	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
+	ctx->query_data.params = params;
+}
+
 void QueryCtx_SetLastWriter(OpBase *last_writer) {
 	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
 	ctx->internal_exec_ctx.last_writer = last_writer;
@@ -95,8 +100,8 @@ AST *QueryCtx_GetAST(void) {
 }
 
 rax *QueryCtx_GetParams(void) {
-	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
-	if(!ctx->query_data.params) ctx->query_data.params = raxNew();
+	QueryCtx *ctx = _QueryCtx_GetCtx();
+	ASSERT(ctx != NULL);
 	return ctx->query_data.params;
 }
 

--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -84,6 +84,7 @@ void QueryCtx_SetResultSet(ResultSet *result_set) {
 }
 
 void QueryCtx_SetParams(rax *params) {
+	ASSERT(params != NULL);
 	QueryCtx *ctx = _QueryCtx_GetCreateCtx();
 	ctx->query_data.params = params;
 }

--- a/src/query_ctx.c
+++ b/src/query_ctx.c
@@ -30,7 +30,6 @@ static inline QueryCtx *_QueryCtx_GetCreateCtx(void) {
 // retrieve QueryCtx, return NULL if one does not exist
 static inline QueryCtx *_QueryCtx_GetCtx(void) {
 	QueryCtx *ctx = pthread_getspecific(_tlsQueryCtxKey);
-	if(!ctx) return NULL;
 	return ctx;
 }
 

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -74,7 +74,7 @@ void QueryCtx_SetLastWriter(OpBase *op);
 /* Getters */
 /* Retrieve the AST. */
 AST *QueryCtx_GetAST(void);
-/* Retrive the query parameters values map. */
+/* Retrieve the query parameters values map. */
 rax *QueryCtx_GetParams(void);
 /* Retrieve the Graph object. */
 Graph *QueryCtx_GetGraph(void);

--- a/src/query_ctx.h
+++ b/src/query_ctx.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */
@@ -68,6 +68,8 @@ void QueryCtx_SetAST(AST *ast);
 void QueryCtx_SetGraphCtx(GraphContext *gc);
 /* Set the resultset. */
 void QueryCtx_SetResultSet(ResultSet *result_set);
+/* Set the parameters map. */
+void QueryCtx_SetParams(rax *params);
 /* Set the last writer which needs to commit */
 void QueryCtx_SetLastWriter(OpBase *op);
 


### PR DESCRIPTION
A `QueryCtx` struct can be instantiated by certain `OpFree` routines, such as the `QueryCtx_UnlockCommit` call at https://github.com/RedisGraph/RedisGraph/blob/master/src/execution_plan/ops/op_delete.c#L58. To avoid memory leaks, we should call `QueryCtx_Free` as part of the `GraphContext_Free` routine.