### PR TITLE
Memcheck script only checks for server-process leaks

### DIFF
--- a/tests/memcheck.sh
+++ b/tests/memcheck.sh
@@ -3,8 +3,7 @@
 rc=0
 # For each Valgrind log in the flow and TCK tests,
 # print contents if memory has definitely been lost
-dirs=("flow" "tck")
-for testdir in "${dirs[@]}"; do
+for testdir in flow tck; do
 	for file in $(ls $testdir/logs/*.valgrind.log); do
 		# If the last "definitely lost: " line of a logfile
 		# has a nonzero value, print the file contents.


### PR DESCRIPTION
This PR modifies the memory-checking logic so that only the final heap summary is checked for leaks, not earlier summaries such as those triggered by `bgsave`.

Adding @rafie as a reviewer because of his talents at parsing Bash weirdness!