### PR TITLE
do not use block client if deny blocking is specified

### DIFF
--- a/demo/imdb/requirements.txt
+++ b/demo/imdb/requirements.txt
@@ -1,2 +1,2 @@
 redis==2.10.5
-redisgraph>=1.5
+redisgraph

--- a/demo/social/requirements.txt
+++ b/demo/social/requirements.txt
@@ -1,2 +1,2 @@
 redis==2.10.5
-redisgraph>=1.5
+redisgraph

--- a/src/commands/cmd_dispatcher.c
+++ b/src/commands/cmd_dispatcher.c
@@ -199,8 +199,9 @@ int CommandDispatch(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	int flags = RedisModule_GetContextFlags(ctx);
 	bool is_replicated = RedisModule_GetContextFlags(ctx) & REDISMODULE_CTX_FLAGS_REPLICATED;
 
-	ExecutorThread exec_thread = (flags & (REDISMODULE_CTX_FLAGS_MULTI |
-										   REDISMODULE_CTX_FLAGS_LUA  |
+	ExecutorThread exec_thread = (flags & (REDISMODULE_CTX_FLAGS_MULTI         |
+										   REDISMODULE_CTX_FLAGS_LUA           |
+										   REDISMODULE_CTX_FLAGS_DENY_BLOCKING |
 										   REDISMODULE_CTX_FLAGS_LOADING)) ?
 								 EXEC_THREAD_MAIN : EXEC_THREAD_READER;
 


### PR DESCRIPTION
When module A calls a command of module B, B can't use blocked client.