### PR TITLE
Track node count per label in graph statistics

### DIFF
--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -805,7 +805,8 @@ void Graph_DeleteNode
 	// assumption, node is completely detected,
 	// there are no incoming nor outgoing edges
 	// leading to / from node
-	ASSERT(g && n);
+	ASSERT(g != NULL);
+	ASSERT(n != NULL);
 
 	// retrieve the appropriate label matrix if node is labeled
 	// TODO update this logic when introducing multi-label
@@ -813,8 +814,8 @@ void Graph_DeleteNode
 	if(label_id != GRAPH_NO_LABEL) {
 		RG_Matrix M = Graph_GetLabelMatrix(g, label_id);
 		// clear label matrix at position node ID
-		GrB_Info res = RG_Matrix_removeElement_BOOL(M, ENTITY_GET_ID(n),
-				ENTITY_GET_ID(n));
+		EntityID id = ENTITY_GET_ID(n);
+		RG_Matrix_removeElement_BOOL(M, id, id);
 		// update statistics
 		GraphStatistics_DecNodeCount(&g->stats, label_id, 1);
 	}

--- a/src/graph/graph.c
+++ b/src/graph/graph.c
@@ -807,16 +807,16 @@ void Graph_DeleteNode
 	// leading to / from node
 	ASSERT(g && n);
 
-	// clear label matrix at position node ID
-	uint32_t label_count = array_len(g->labels);
-	for(int i = 0; i < label_count; i++) {
-		RG_Matrix M = Graph_GetLabelMatrix(g, i);
+	// retrieve the appropriate label matrix if node is labeled
+	// TODO update this logic when introducing multi-label
+	int label_id = NODE_GET_LABEL_ID(n, g);
+	if(label_id != GRAPH_NO_LABEL) {
+		RG_Matrix M = Graph_GetLabelMatrix(g, label_id);
+		// clear label matrix at position node ID
 		GrB_Info res = RG_Matrix_removeElement_BOOL(M, ENTITY_GET_ID(n),
 				ENTITY_GET_ID(n));
-		if(res == GrB_SUCCESS) {
-			// a node with this label has just been deleted, update statistics
-			GraphStatistics_DecNodeCount(&g->stats, i, 1);
-		}
+		// update statistics
+		GraphStatistics_DecNodeCount(&g->stats, label_id, 1);
 	}
 
 	DataBlock_DeleteItem(g->nodes, ENTITY_GET_ID(n));

--- a/src/graph/graph.h
+++ b/src/graph/graph.h
@@ -238,7 +238,7 @@ size_t Graph_UncompactedNodeCount
 );
 
 // returns number of nodes with given label
-size_t Graph_LabeledNodeCount
+uint64_t Graph_LabeledNodeCount
 (
 	const Graph *g,
 	int label

--- a/src/graph/graph_statistics.c
+++ b/src/graph/graph_statistics.c
@@ -25,12 +25,14 @@ void GraphStatistics_IntroduceLabel(GraphStatistics *stats) {
 
 uint64_t GraphStatistics_EdgeCount(const GraphStatistics *stats,
 								   int relation_idx) {
+	ASSERT(stats);
 	ASSERT(relation_idx < array_len(stats->edge_count));
 	return stats->edge_count[relation_idx];
 }
 
 uint64_t GraphStatistics_NodeCount(const GraphStatistics *stats,
 								   int label_idx) {
+	ASSERT(stats);
 	ASSERT(label_idx < array_len(stats->node_count));
 	return stats->node_count[label_idx];
 }

--- a/src/graph/graph_statistics.c
+++ b/src/graph/graph_statistics.c
@@ -6,23 +6,38 @@
 
 #include "graph_statistics.h"
 
-// Initialize the edge_count array
+// Initialize the node_count and edge_count arrays
 void GraphStatistics_init(GraphStatistics *stats) {
-    ASSERT(stats);
-    stats->edge_count = array_new(uint64_t, 0);
+	ASSERT(stats);
+	stats->node_count = array_new(uint64_t, 0);
+	stats->edge_count = array_new(uint64_t, 0);
 }
 
 void GraphStatistics_IntroduceRelationship(GraphStatistics *stats) {
-    ASSERT(stats && stats->edge_count);
-    array_append(stats->edge_count, 0);
+	ASSERT(stats && stats->edge_count);
+	array_append(stats->edge_count, 0);
 }
 
-uint64_t GraphStatistics_EdgeCount(const GraphStatistics *stats, int relation_idx) {
-    ASSERT(relation_idx < array_len(stats->edge_count));
-    return stats->edge_count[relation_idx];
+void GraphStatistics_IntroduceLabel(GraphStatistics *stats) {
+	ASSERT(stats && stats->node_count);
+	array_append(stats->node_count, 0);
+}
+
+uint64_t GraphStatistics_EdgeCount(const GraphStatistics *stats,
+								   int relation_idx) {
+	ASSERT(relation_idx < array_len(stats->edge_count));
+	return stats->edge_count[relation_idx];
+}
+
+uint64_t GraphStatistics_NodeCount(const GraphStatistics *stats,
+								   int label_idx) {
+	ASSERT(label_idx < array_len(stats->node_count));
+	return stats->node_count[label_idx];
 }
 
 void GraphStatistics_FreeInternals(GraphStatistics *stats) {
-    ASSERT(stats);
-    if(stats->edge_count) array_free(stats->edge_count);
+	ASSERT(stats);
+	if(stats->node_count) array_free(stats->node_count);
+	if(stats->edge_count) array_free(stats->edge_count);
 }
+

--- a/src/graph/graph_statistics.h
+++ b/src/graph/graph_statistics.h
@@ -12,29 +12,57 @@
 // Graph related statistics
 
 typedef struct {
+	uint64_t *node_count; // Array of node count per label matrix
 	uint64_t *edge_count; // Array of edge count per relationship matrix
 } GraphStatistics;
 
-// Initialize the edge_count array
+// Initialize the node_count and edge_count arrays
 void GraphStatistics_init(GraphStatistics *stats);
 
 // New relationship is added, resize the edge_count array.
 void GraphStatistics_IntroduceRelationship(GraphStatistics *stats);
 
+// New label is added, resize the node_count array.
+void GraphStatistics_IntroduceLabel(GraphStatistics *stats);
+
 // Increment the edge counter by amount
-static inline void GraphStatistics_IncEdgeCount(GraphStatistics *stats, int relation_idx, uint64_t amount) {
-    ASSERT(relation_idx < array_len(stats->edge_count));
-    stats->edge_count[relation_idx] += amount;
+static inline void GraphStatistics_IncEdgeCount(GraphStatistics *stats,
+												int relation_idx, uint64_t amount) {
+	ASSERT(relation_idx < array_len(stats->edge_count));
+	stats->edge_count[relation_idx] += amount;
 }
 
 // Decrement the edge counter by amount
-static inline void GraphStatistics_DecEdgeCount(GraphStatistics *stats, int relation_idx, uint64_t amount) {
-    ASSERT(relation_idx < array_len(stats->edge_count) && stats->edge_count[relation_idx] >= amount);
-    stats->edge_count[relation_idx] -= amount;
+static inline void GraphStatistics_DecEdgeCount(GraphStatistics *stats,
+												int relation_idx, uint64_t amount) {
+	ASSERT(relation_idx < array_len(stats->edge_count) &&
+		   stats->edge_count[relation_idx] >= amount);
+	stats->edge_count[relation_idx] -= amount;
+}
+
+// Increment the node counter by amount
+static inline void GraphStatistics_IncNodeCount(GraphStatistics *stats,
+												int label_idx, uint64_t amount) {
+	ASSERT(label_idx < array_len(stats->node_count));
+	stats->node_count[label_idx] += amount;
+}
+
+// Decrement the node counter by amount
+static inline void GraphStatistics_DecNodeCount(GraphStatistics *stats,
+												int label_idx, uint64_t amount) {
+	ASSERT(label_idx < array_len(stats->node_count) &&
+		   stats->node_count[label_idx] >= amount);
+	stats->node_count[label_idx] -= amount;
 }
 
 // Retrieves edge count for given relationship type
-uint64_t GraphStatistics_EdgeCount(const GraphStatistics *stats, int relation_idx);
+uint64_t GraphStatistics_EdgeCount(const GraphStatistics *stats,
+								   int relation_idx);
+
+// Retrieves node count for given label
+uint64_t GraphStatistics_NodeCount(const GraphStatistics *stats,
+								   int label_idx);
 
 // Free the internal structures.
 void GraphStatistics_FreeInternals(GraphStatistics *stats);
+

--- a/src/serializers/decoders/current/v9/decode_graph.c
+++ b/src/serializers/decoders/current/v9/decode_graph.c
@@ -190,22 +190,20 @@ GraphContext *RdbLoadGraph_v9(RedisModuleIO *rdb) {
 		Graph_SetMatrixPolicy(g, SYNC_POLICY_FLUSH_RESIZE);
 		Graph_ApplyAllPending(g, true);
 
-		uint node_schemas_count = array_len(gc->node_schemas);
-		// update the node statistics
-		for(uint i = 0; i < node_schemas_count; i++) {
-			GrB_Index nvals;
-			RG_Matrix L = g->labels[i];
-			RG_Matrix_nvals(&nvals, L);
-			GraphStatistics_IncNodeCount(&g->stats, i, nvals);
-		}
-
 		// set the thread-local GraphContext
 		// as it will be accessed when creating indexes
 		QueryCtx_SetGraphCtx(gc);
-
+		
+		uint label_count = Graph_LabelTypeCount(g);
+		// update the node statistics
 		// index the nodes
-		for(uint i = 0; i < node_schemas_count; i++) {
-			Schema *s = gc->node_schemas[i];
+		for(uint i = 0; i < label_count; i++) {
+			GrB_Index nvals;
+			RG_Matrix L = Graph_GetLabelMatrix(g, i);
+			RG_Matrix_nvals(&nvals, L);
+			GraphStatistics_IncNodeCount(&g->stats, i, nvals);
+
+			Schema *s = GraphContext_GetSchemaByID(gc, i, SCHEMA_NODE);
 			if(s->index) Index_Construct(s->index);
 			if(s->fulltextIdx) Index_Construct(s->fulltextIdx);
 		}

--- a/src/serializers/decoders/current/v9/decode_graph.c
+++ b/src/serializers/decoders/current/v9/decode_graph.c
@@ -190,12 +190,20 @@ GraphContext *RdbLoadGraph_v9(RedisModuleIO *rdb) {
 		Graph_SetMatrixPolicy(g, SYNC_POLICY_FLUSH_RESIZE);
 		Graph_ApplyAllPending(g, true);
 
+		uint node_schemas_count = array_len(gc->node_schemas);
+		// update the node statistics
+		for(uint i = 0; i < node_schemas_count; i++) {
+			GrB_Index nvals;
+			RG_Matrix L = g->labels[i];
+			RG_Matrix_nvals(&nvals, L);
+			GraphStatistics_IncNodeCount(&g->stats, i, nvals);
+		}
+
 		// set the thread-local GraphContext
 		// as it will be accessed when creating indexes
 		QueryCtx_SetGraphCtx(gc);
 
 		// index the nodes
-		uint node_schemas_count = array_len(gc->node_schemas);
 		for(uint i = 0; i < node_schemas_count; i++) {
 			Schema *s = gc->node_schemas[i];
 			if(s->index) Index_Construct(s->index);

--- a/src/serializers/decoders/prev/v6/decode_graph.c
+++ b/src/serializers/decoders/prev/v6/decode_graph.c
@@ -165,11 +165,8 @@ void RdbLoadGraph_v6(RedisModuleIO *rdb, GraphContext *gc) {
 		RG_Matrix L = Graph_GetLabelMatrix(g, i);
 		RG_Matrix_nvals(&nvals, L);
 		GraphStatistics_IncNodeCount(&g->stats, i, nvals);
-
-		Schema *s = GraphContext_GetSchemaByID(gc, i, SCHEMA_NODE);
 	}
 
 	// make sure graph doesn't contains may pending changes
 	ASSERT(Graph_Pending(g) == false);
 }
-

--- a/src/serializers/decoders/prev/v6/decode_graph.c
+++ b/src/serializers/decoders/prev/v6/decode_graph.c
@@ -141,8 +141,10 @@ void RdbLoadGraph_v6(RedisModuleIO *rdb, GraphContext *gc) {
 	 *      (name, value type, value) X N
 	 */
 
+	Graph *g = gc->g;
+
 	// While loading the graph, minimize matrix realloc and synchronization calls.
-	Graph_SetMatrixPolicy(gc->g, SYNC_POLICY_RESIZE);
+	Graph_SetMatrixPolicy(g, SYNC_POLICY_RESIZE);
 
 	// Load nodes.
 	_RdbLoadNodes(rdb, gc);
@@ -151,12 +153,23 @@ void RdbLoadGraph_v6(RedisModuleIO *rdb, GraphContext *gc) {
 	_RdbLoadEdges(rdb, gc);
 
 	// Revert to default synchronization behavior
-	Graph_SetMatrixPolicy(gc->g, SYNC_POLICY_FLUSH_RESIZE);
+	Graph_SetMatrixPolicy(g, SYNC_POLICY_FLUSH_RESIZE);
 
 	// Resize and flush all pending changes to matrices.
-	Graph_ApplyAllPending(gc->g, true);
+	Graph_ApplyAllPending(g, true);
+
+	uint label_count = Graph_LabelTypeCount(g);
+	// update the node statistics
+	for(uint i = 0; i < label_count; i++) {
+		GrB_Index nvals;
+		RG_Matrix L = Graph_GetLabelMatrix(g, i);
+		RG_Matrix_nvals(&nvals, L);
+		GraphStatistics_IncNodeCount(&g->stats, i, nvals);
+
+		Schema *s = GraphContext_GetSchemaByID(gc, i, SCHEMA_NODE);
+	}
 
 	// make sure graph doesn't contains may pending changes
-	ASSERT(Graph_Pending(gc->g) == false);
+	ASSERT(Graph_Pending(g) == false);
 }
 

--- a/src/serializers/decoders/prev/v7/decode_graph.c
+++ b/src/serializers/decoders/prev/v7/decode_graph.c
@@ -183,7 +183,7 @@ GraphContext *RdbLoadGraphContext_v7(RedisModuleIO *rdb) {
 		// Graph has finished decoding, inform the module.
 		ModuleEventHandler_DecreaseDecodingGraphsCount();
 		RedisModuleCtx *ctx = RedisModule_GetContextFromIO(rdb);
-		RedisModule_Log(ctx, "notice", "Done decoding graph %s", *GraphContext_GetName(gc));
+		RedisModule_Log(ctx, "notice", "Done decoding graph %s", GraphContext_GetName(gc));
 	}
 
 	return gc;

--- a/src/serializers/decoders/prev/v7/decode_graph.c
+++ b/src/serializers/decoders/prev/v7/decode_graph.c
@@ -155,38 +155,37 @@ GraphContext *RdbLoadGraphContext_v7(RedisModuleIO *rdb) {
 	}
 
 	if(GraphDecodeContext_Finished(gc->decoding_context)) {
+		Graph *g = gc->g;
+
 		// revert to default synchronization behavior
-		Graph_SetMatrixPolicy(gc->g, SYNC_POLICY_FLUSH_RESIZE);
-		Graph_ApplyAllPending(gc->g, true);
-
-		uint node_schemas_count = array_len(gc->node_schemas);
+		Graph_SetMatrixPolicy(g, SYNC_POLICY_FLUSH_RESIZE);
+		Graph_ApplyAllPending(g, true);
+		
+		uint label_count = Graph_LabelTypeCount(g);
 		// update the node statistics
-		for(uint i = 0; i < node_schemas_count; i++) {
+		// index the nodes
+		for(uint i = 0; i < label_count; i++) {
 			GrB_Index nvals;
-			RG_Matrix L = gc->g->labels[i];
+			RG_Matrix L = Graph_GetLabelMatrix(g, i);
 			RG_Matrix_nvals(&nvals, L);
-			GraphStatistics_IncNodeCount(&gc->g->stats, i, nvals);
-		}
+			GraphStatistics_IncNodeCount(&g->stats, i, nvals);
 
-		// Set the thread-local GraphContext, as it will be accessed when creating indexes.
-		QueryCtx_SetGraphCtx(gc);
-		// Index the nodes when decoding ends.
-		for(uint i = 0; i < node_schemas_count; i++) {
-			Schema *s = gc->node_schemas[i];
+			Schema *s = GraphContext_GetSchemaByID(gc, i, SCHEMA_NODE);
 			if(s->index) Index_Construct(s->index);
 			if(s->fulltextIdx) Index_Construct(s->fulltextIdx);
 		}
 
 		// make sure graph doesn't contains may pending changes
-		ASSERT(Graph_Pending(gc->g) == false);
+		ASSERT(Graph_Pending(g) == false);
 
 		QueryCtx_Free(); // Release thread-local variables.
 		GraphDecodeContext_Reset(gc->decoding_context);
 		// Graph has finished decoding, inform the module.
 		ModuleEventHandler_DecreaseDecodingGraphsCount();
 		RedisModuleCtx *ctx = RedisModule_GetContextFromIO(rdb);
-		RedisModule_Log(ctx, "notice", "Done decoding graph %s", gc->graph_name);
+		RedisModule_Log(ctx, "notice", "Done decoding graph %s", *GraphContext_GetName(gc));
 	}
+
 	return gc;
 }
 

--- a/src/serializers/decoders/prev/v8/decode_graph.c
+++ b/src/serializers/decoders/prev/v8/decode_graph.c
@@ -175,10 +175,18 @@ GraphContext *RdbLoadGraphContext_v8(RedisModuleIO *rdb) {
 		Graph_SetMatrixPolicy(gc->g, SYNC_POLICY_FLUSH_RESIZE);
 		Graph_ApplyAllPending(gc->g, true);
 
+		uint node_schemas_count = array_len(gc->node_schemas);
+		// update the node statistics
+		for(uint i = 0; i < node_schemas_count; i++) {
+			GrB_Index nvals;
+			RG_Matrix L = gc->g->labels[i];
+			RG_Matrix_nvals(&nvals, L);
+			GraphStatistics_IncNodeCount(&gc->g->stats, i, nvals);
+		}
+
 		// set the thread-local GraphContext, as it will be accessed when creating indexes
 		QueryCtx_SetGraphCtx(gc);
 		// Index the nodes when decoding ends.
-		uint node_schemas_count = array_len(gc->node_schemas);
 		for(uint i = 0; i < node_schemas_count; i++) {
 			Schema *s = gc->node_schemas[i];
 			if(s->index) Index_Construct(s->index);

--- a/src/serializers/graph_extensions.c
+++ b/src/serializers/graph_extensions.c
@@ -34,9 +34,6 @@ void Serializer_Graph_SetNode(Graph *g, NodeID id, int label, Node *n) {
 		
 		// Optimize set only for decoder
 		GrB_Matrix_setElement_BOOL(m, true, id, id);
-
-		// a node with 'label' has just been created, update statistics
-		GraphStatistics_IncNodeCount(&g->stats, label, 1);
 	}
 }
 

--- a/src/serializers/graph_extensions.c
+++ b/src/serializers/graph_extensions.c
@@ -34,6 +34,9 @@ void Serializer_Graph_SetNode(Graph *g, NodeID id, int label, Node *n) {
 		
 		// Optimize set only for decoder
 		GrB_Matrix_setElement_BOOL(m, true, id, id);
+
+		// a node with 'label' has just been created, update statistics
+		GraphStatistics_IncNodeCount(&g->stats, label, 1);
 	}
 }
 

--- a/tests/unit/test_graph.cpp
+++ b/tests/unit/test_graph.cpp
@@ -885,6 +885,7 @@ TEST_F(GraphTest, GraphStatistics) {
 
 	ASSERT_EQ(Graph_RelationEdgeCount(g, r0), 0);
 	ASSERT_EQ(Graph_RelationEdgeCount(g, r1), 0);
+	ASSERT_EQ(Graph_LabeledNodeCount(g, l), 0);
 
 	for(int i = 0; i < node_count; i++) Graph_CreateNode(g, l, &n[i]);
 	ASSERT_EQ(g->stats.node_count[l], 4);
@@ -982,6 +983,12 @@ TEST_F(GraphTest, GraphStatistics) {
 	ASSERT_EQ(g->stats.node_count[l], 3);
 	ASSERT_EQ(node_deleted, 1);
 	ASSERT_EQ(edge_deleted, 3);
+
+	// delete disconnected node
+	Graph_DeleteNode(g, &n[3]);
+	ASSERT_EQ(Graph_RelationEdgeCount(g, r0), 1);
+	ASSERT_EQ(Graph_RelationEdgeCount(g, r1), 2);
+	ASSERT_EQ(g->stats.node_count[l], 2);
 
 	// Clean up.
 	Graph_Free(g);

--- a/tests/unit/test_graph.cpp
+++ b/tests/unit/test_graph.cpp
@@ -887,6 +887,7 @@ TEST_F(GraphTest, GraphStatistics) {
 	ASSERT_EQ(Graph_RelationEdgeCount(g, r1), 0);
 
 	for(int i = 0; i < node_count; i++) Graph_CreateNode(g, l, &n[i]);
+	ASSERT_EQ(g->stats.node_count[l], 4);
 
 	/* Connect nodes:
 	*
@@ -978,6 +979,7 @@ TEST_F(GraphTest, GraphStatistics) {
 	ASSERT_FALSE(Graph_RelationshipContainsMultiEdge(g, r1, transpose));
 	ASSERT_EQ(Graph_RelationEdgeCount(g, r0), 1);
 	ASSERT_EQ(Graph_RelationEdgeCount(g, r1), 2);
+	ASSERT_EQ(g->stats.node_count[l], 3);
 	ASSERT_EQ(node_deleted, 1);
 	ASSERT_EQ(edge_deleted, 3);
 


### PR DESCRIPTION
This PR augments the `GraphStatistics` struct to track node count per label, mirroring the logic that tracks edge count per relationship type.