### PR TITLE
Use new param style when invoking redisgraph-py from tests

### DIFF
--- a/tests/flow/test_index_scans.py
+++ b/tests/flow/test_index_scans.py
@@ -249,21 +249,19 @@ class testIndexScanFlow(FlowTestsBase):
 
     def test09_index_scan_with_params(self):
         query = "MATCH (p:person) WHERE p.age = $age RETURN p.name"
-        params = {'age':30}
-        query = redis_graph.build_params_header(params) + query
-        plan = redis_graph.execution_plan(query)
+        params = {'age': 30}
+        plan = redis_graph.execution_plan(query, params=params)
         self.env.assertIn('Index Scan', plan)
-        query_result = redis_graph.query(query)
+        query_result = redis_graph.query(query, params=params)
         expected_result = ["Lucy Yanfital"]
         self.env.assertEquals(query_result.result_set[0], expected_result)
 
     def test10_index_scan_with_param_array(self):
         query = "MATCH (p:person) WHERE p.age in $ages RETURN p.name"
-        params = {'ages':[30]}
-        query = redis_graph.build_params_header(params) + query
-        plan = redis_graph.execution_plan(query)
+        params = {'ages': [30]}
+        plan = redis_graph.execution_plan(query, params=params)
         self.env.assertIn('Index Scan', plan)
-        query_result = redis_graph.query(query)
+        query_result = redis_graph.query(query, params=params)
         expected_result = ["Lucy Yanfital"]
         self.env.assertEquals(query_result.result_set[0], expected_result)
 

--- a/tests/flow/test_params.py
+++ b/tests/flow/test_params.py
@@ -127,12 +127,11 @@ class testParams(FlowTestsBase):
 
     def test_id_scan(self):
         redis_graph.query("CREATE ({val:1})")
-        expected_results=[[1]]
-        params = {'id' : 0}
+        expected_results = [[1]]
+        params = {'id': 0}
         query = "MATCH (n) WHERE id(n)=$id return n.val"
-        query_info = QueryInfo(query = query, description="Test id scan with params", expected_result = expected_results)
+        query_info = QueryInfo(query=query, description="Test id scan with params", expected_result=expected_results)
         self._assert_resultset_equals_expected(redis_graph.query(query, params), query_info)
-        query = redis_graph.build_params_header(params) + query
-        plan = redis_graph.execution_plan(query)
+        plan = redis_graph.execution_plan(query, params=params)
         self.env.assertIn('NodeByIdSeek', plan)
 


### PR DESCRIPTION
(cherry picked from commit b599c5746e2560af699611ca6e7259a96c92a3ea)