### PR TITLE
Using the docker template system, and official releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,58 +492,57 @@ workflows:
   version: 2
   build_and_package:
     jobs:
-#      - build:
-#          <<: *context
-#          <<: *not-on-integ-branch
-#      - coverage:
-#          <<: *context
-#          <<: *on-any-branch
-#      - build_memcheck:
-#          <<: *context
-#          <<: *on-any-branch
-#      - build_macos:
-#          <<: *context
-#          <<: *on-integ-and-version-tags
+      - build:
+          <<: *context
+          <<: *not-on-integ-branch
+      - coverage:
+          <<: *context
+          <<: *on-any-branch
+      - build_memcheck:
+          <<: *context
+          <<: *on-any-branch
+      - build_macos:
+          <<: *context
+          <<: *on-integ-and-version-tags
       - platform_build:
           <<: *context
-#         <<: *on-integ-and-version-tags
-          <<: *on-any-branch
+          <<: *on-integ-and-version-tags
           matrix:
             parameters:
               platform: [bionic, xenial, centos7, centos8]
-#      - build-arm-platforms:
-#          <<: *on-integ-and-version-tags
-#          context: common
-#          matrix:
-#            parameters:
-#              platform: [bionic]
-#      - deploy_branch:
-#          <<: *context
-#          <<: *on-integ-branch
-#          requires:
-#            - platform_build
-#            - build_macos
-#      - release_automation:
-#          <<: *context
-#          <<: *on-version-tags
-#          requires:
-#            - deploy_release
-#      - deploy_release:
-#          <<: *context
-#          <<: *on-version-tags
-#          requires:
-#            - platform_build
-#            - build_macos
-#      - performance_ci_automation_not_integ:
-#          <<: *context
-#          <<: *not-on-integ-branch
-#          requires:
-#            - build
-#      - performance_ci_automation:
-#          <<: *context
-#          <<: *on-integ-and-version-tags
-#          requires:
-#            - platform_build
+      - build-arm-platforms:
+          <<: *on-integ-and-version-tags
+          context: common
+          matrix:
+            parameters:
+              platform: [bionic]
+      - deploy_branch:
+          <<: *context
+          <<: *on-integ-branch
+          requires:
+            - platform_build
+            - build_macos
+      - release_automation:
+          <<: *context
+          <<: *on-version-tags
+          requires:
+            - deploy_release
+      - deploy_release:
+          <<: *context
+          <<: *on-version-tags
+          requires:
+            - platform_build
+            - build_macos
+      - performance_ci_automation_not_integ:
+          <<: *context
+          <<: *not-on-integ-branch
+          requires:
+            - build
+      - performance_ci_automation:
+          <<: *context
+          <<: *on-integ-and-version-tags
+          requires:
+            - platform_build
 
   nightly:
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -492,57 +492,58 @@ workflows:
   version: 2
   build_and_package:
     jobs:
-      - build:
-          <<: *context
-          <<: *not-on-integ-branch
-      - coverage:
-          <<: *context
-          <<: *on-any-branch
-      - build_memcheck:
-          <<: *context
-          <<: *on-any-branch
-      - build_macos:
-          <<: *context
-          <<: *on-integ-and-version-tags
+#      - build:
+#          <<: *context
+#          <<: *not-on-integ-branch
+#      - coverage:
+#          <<: *context
+#          <<: *on-any-branch
+#      - build_memcheck:
+#          <<: *context
+#          <<: *on-any-branch
+#      - build_macos:
+#          <<: *context
+#          <<: *on-integ-and-version-tags
       - platform_build:
           <<: *context
-          <<: *on-integ-and-version-tags
+#         <<: *on-integ-and-version-tags
+          <<: *on-any-branch
           matrix:
             parameters:
               platform: [bionic, xenial, centos7, centos8]
-      - build-arm-platforms:
-          <<: *on-integ-and-version-tags
-          context: common
-          matrix:
-            parameters:
-              platform: [bionic]
-      - deploy_branch:
-          <<: *context
-          <<: *on-integ-branch
-          requires:
-            - platform_build
-            - build_macos
-      - release_automation:
-          <<: *context
-          <<: *on-version-tags
-          requires:
-            - deploy_release
-      - deploy_release:
-          <<: *context
-          <<: *on-version-tags
-          requires:
-            - platform_build
-            - build_macos
-      - performance_ci_automation_not_integ:
-          <<: *context
-          <<: *not-on-integ-branch
-          requires:
-            - build
-      - performance_ci_automation:
-          <<: *context
-          <<: *on-integ-and-version-tags
-          requires:
-            - platform_build
+#      - build-arm-platforms:
+#          <<: *on-integ-and-version-tags
+#          context: common
+#          matrix:
+#            parameters:
+#              platform: [bionic]
+#      - deploy_branch:
+#          <<: *context
+#          <<: *on-integ-branch
+#          requires:
+#            - platform_build
+#            - build_macos
+#      - release_automation:
+#          <<: *context
+#          <<: *on-version-tags
+#          requires:
+#            - deploy_release
+#      - deploy_release:
+#          <<: *context
+#          <<: *on-version-tags
+#          requires:
+#            - platform_build
+#            - build_macos
+#      - performance_ci_automation_not_integ:
+#          <<: *context
+#          <<: *not-on-integ-branch
+#          requires:
+#            - build
+#      - performance_ci_automation:
+#          <<: *context
+#          <<: *on-integ-and-version-tags
+#          requires:
+#            - platform_build
 
   nightly:
     triggers:

--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -1,8 +1,8 @@
 REDIS_VERSION=6.2.5
 PRODUCT=redisgraph
 
-OSNICK ?= bullseye
-OSNICK_OFFICIAL = bullseye
+OSNICK ?= bionic
+OSNICK_OFFICIAL = bionic
 
 ROOT=../../
 READIES=${ROOT}/deps/readies

--- a/build/docker/Makefile
+++ b/build/docker/Makefile
@@ -1,8 +1,8 @@
 REDIS_VERSION=6.2.5
 PRODUCT=redisgraph
-DOCKER_ORG=redislabs
 
 OSNICK ?= bullseye
+OSNICK_OFFICIAL = bullseye
 
 ROOT=../../
 READIES=${ROOT}/deps/readies


### PR DESCRIPTION
This updates the build to allow our control (even in parallel builds) of the edge/official push. Equally, this restores pushes to redisfab.

The rules now match the following dockerhub requirements

1. Push all tags to redisfab
2. Push versioned (i.e 1.2, edge, etc) tags to redislabs
	a. **ONLY** push in the case where the OSNICK_OFFICIAL matches the OSNICK.