### PR TITLE
Emit error on query that only contains parameters

### DIFF
--- a/src/commands/execution_ctx.c
+++ b/src/commands/execution_ctx.c
@@ -89,8 +89,14 @@ ExecutionCtx *ExecutionCtx_FromQuery(const char *query) {
 
 	// No cached execution plan, try to parse the query.
 	AST *ast = _ExecutionCtx_ParseAST(query_string, params_parse_result);
-	// If query parsing failed, return NULL.
-	if(!ast) return NULL;
+	// if query parsing failed, return NULL
+	if(!ast) {
+		// if no error has been set, emit one now
+		if(!ErrorCtx_EncounteredError()) {
+			ErrorCtx_SetError("Error: could not parse query");
+		}
+		return NULL;
+	}
 
 	ExecutionType exec_type = _GetExecutionTypeFromAST(ast);
 	// In case of valid query, create execution plan, and cache it and the AST.

--- a/tests/flow/test_empty_query.py
+++ b/tests/flow/test_empty_query.py
@@ -18,3 +18,9 @@ class testEmptyQuery(FlowTestsBase):
             graph.query("")
         except ResponseError as e:
             self.env.assertIn("Error: empty query.", str(e))
+
+    def test02_query_with_only_params(self):
+        try:
+            graph.query("CYPHER v=1")
+        except ResponseError as e:
+            self.env.assertIn("Error: could not parse query", str(e))


### PR DESCRIPTION
On OSS Redis, the following query will never return, and on Enterprise it brings down the node:
```
GRAPH.QUERY G "CYPHER v=1" 
```

This PR resolves this by adding an error message when parsing has failed but no explicit error has been emitted.