### PR TITLE
Fix utilization of record offset in procedure calls, refactor outputs

### DIFF
--- a/src/execution_plan/ops/op_procedure_call.c
+++ b/src/execution_plan/ops/op_procedure_call.c
@@ -32,7 +32,7 @@ static Record _yield(OpProcCall *op) {
 }
 
 static void _evaluate_proc_args(OpProcCall *op) {
-	// Evaluate arguments, free args from previous call.
+	// evaluate arguments, free args from previous call
 	uint arg_count = array_len(op->args);
 	for(uint i = 0; i < arg_count; i++) SIValue_Free(op->args[i]);
 
@@ -43,22 +43,31 @@ static void _evaluate_proc_args(OpProcCall *op) {
 	}
 }
 
-OpBase *NewProcCallOp(const ExecutionPlan *plan, const char *proc_name, AR_ExpNode **arg_exps,
-					  AR_ExpNode **yield_exps) {
+OpBase *NewProcCallOp
+(
+	const ExecutionPlan *plan,
+	const char *proc_name,
+	AR_ExpNode **arg_exps,
+	AR_ExpNode **yield_exps
+) {
 
-	ASSERT(proc_name != NULL);
+	ASSERT(plan        !=  NULL);
+	ASSERT(proc_name   !=  NULL);
+	ASSERT(arg_exps    !=  NULL);
+	ASSERT(yield_exps  !=  NULL);
 
 	OpProcCall *op = rm_malloc(sizeof(OpProcCall));
-	op->r = NULL;
-	op->yield_map = NULL;
-	op->first_call = true;
-	op->arg_exps = arg_exps;
-	op->proc_name = proc_name;
-	op->yield_exps = yield_exps;
-	op->arg_count = array_len(arg_exps);
-	op->args = array_new(SIValue, op->arg_count);
 
-	// Procedure must exist
+	op->r           =  NULL;
+	op->args        =  array_new(SIValue, op->arg_count);
+	op->arg_exps    =  arg_exps;
+	op->arg_count   =  array_len(arg_exps);
+	op->proc_name   =  proc_name;
+	op->yield_map   =  NULL;
+	op->first_call  =  true;
+	op->yield_exps  =  yield_exps;
+
+	// procedure must exist
 	op->procedure = Proc_Get(proc_name);
 	ASSERT(op->procedure != NULL);
 
@@ -66,12 +75,12 @@ OpBase *NewProcCallOp(const ExecutionPlan *plan, const char *proc_name, AR_ExpNo
 	op->output = array_new(const char *, yield_count);
 	op->yield_map = rm_malloc(sizeof(OutputMap) * yield_count);
 
-	// Set operations
+	// set callbacks
 	OpBase_Init((OpBase *)op, OPType_PROC_CALL, "ProcedureCall",
 				NULL, ProcCallConsume, ProcCallReset, NULL, ProcCallClone,
 				ProcCallFree, !Procedure_IsReadOnly(op->procedure), plan);
 
-	// Set modifiers
+	// set modifiers
 	for(uint i = 0; i < yield_count; i ++) {
 		const char *alias = yield_exps[i]->resolved_name;
 		const char *yield = yield_exps[i]->operand.variadic.entity_alias;
@@ -109,8 +118,8 @@ static Record ProcCallConsume(OpBase *opBase) {
 
 		_evaluate_proc_args(op);
 
-		/* Free previous invocation.
-		 * TODO: replace with Proc_Reset */
+		// free previous invocation
+		// TODO: replace with Proc_Reset
 		Proc_Free(op->procedure);
 		op->procedure = Proc_Get(op->proc_name);
 

--- a/src/execution_plan/ops/op_procedure_call.c
+++ b/src/execution_plan/ops/op_procedure_call.c
@@ -59,7 +59,7 @@ OpBase *NewProcCallOp
 	OpProcCall *op = rm_malloc(sizeof(OpProcCall));
 
 	op->r           =  NULL;
-	op->args        =  array_new(SIValue, op->arg_count);
+	op->args        =  array_new(SIValue, array_len(arg_exps));
 	op->arg_exps    =  arg_exps;
 	op->arg_count   =  array_len(arg_exps);
 	op->proc_name   =  proc_name;

--- a/src/procedures/proc_bfs.c
+++ b/src/procedures/proc_bfs.c
@@ -163,11 +163,14 @@ static SIValue *Proc_BFS_Step
 	// return NULL if the BFS for this source has already been emitted or there are no connected nodes
 	if(bfs_ctx->depleted || bfs_ctx->n == 0) return NULL;
 
+	bool yield_nodes = (bfs_ctx->yield_nodes != NULL);
+	bool yield_edges = (bfs_ctx->yield_edges != NULL);
+
 	// build arrays for the outputs the user has requested
 	uint n = bfs_ctx->n;
 	SIValue nodes, edges;
-	if(bfs_ctx->yield_nodes != NULL) nodes = SI_Array(n);
-	if(bfs_ctx->yield_edges != NULL) edges = SI_Array(n);
+	if(yield_nodes) nodes = SI_Array(n);
+	if(yield_edges) edges = SI_Array(n);
 	Edge *edge = array_new(Edge, 1);
 
 	// setup result iterator
@@ -184,7 +187,7 @@ static SIValue *Proc_BFS_Step
 
 	while(!depleted) {
 		// get the reached node
-		if(bfs_ctx->yield_nodes != NULL) {
+		if(yield_nodes) {
 			// append each reachable node to the nodes output array
 			Node n = GE_NEW_NODE();
 			Graph_GetNode(bfs_ctx->g, id, &n);
@@ -192,7 +195,7 @@ static SIValue *Proc_BFS_Step
 		}
 
 		array_clear(edge);
-		if(bfs_ctx->yield_edges != NULL) {
+		if(yield_edges) {
 			GrB_Index parent_id;
 			// find the parent of the reached node
 			GrB_Info res = GrB_Vector_extractElement(&parent_id, bfs_ctx->parents, id);
@@ -211,8 +214,8 @@ static SIValue *Proc_BFS_Step
 	bfs_ctx->depleted = depleted; // mark that this node has been mapped
 
 	// populate output
-	if(bfs_ctx->yield_nodes) *bfs_ctx->yield_nodes = nodes;
-	if(bfs_ctx->yield_edges) *bfs_ctx->yield_edges = edges;
+	if(yield_nodes) *bfs_ctx->yield_nodes = nodes;
+	if(yield_edges) *bfs_ctx->yield_edges = edges;
 
 	// clean up
 	array_free(edge);
@@ -245,7 +248,7 @@ static BFSCtx *_Build_Private_Data() {
 	pdata->n            =  0;
 	pdata->g            =  QueryCtx_GetGraph();
 	pdata->nodes        =  GrB_NULL;
-	pdata->output       =  array_new(SIValue, 4);
+	pdata->output       =  array_new(SIValue, 2);
 	pdata->parents      =  GrB_NULL;
 	pdata->depleted     =  false;
 	pdata->reltype_id   =  GRAPH_NO_RELATION;

--- a/src/procedures/proc_bfs.h
+++ b/src/procedures/proc_bfs.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/proc_ctx.h
+++ b/src/procedures/proc_ctx.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/proc_fulltext_create_index.h
+++ b/src/procedures/proc_fulltext_create_index.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/proc_fulltext_drop_index.c
+++ b/src/procedures/proc_fulltext_drop_index.c
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/proc_fulltext_drop_index.h
+++ b/src/procedures/proc_fulltext_drop_index.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/proc_fulltext_query.h
+++ b/src/procedures/proc_fulltext_query.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/proc_labels.c
+++ b/src/procedures/proc_labels.c
@@ -15,43 +15,55 @@
 // CALL db.labels()
 
 typedef struct {
-	uint schema_id;     // Current schema ID.
-	GraphContext *gc;   // Graph context.
-	SIValue *output;    // Output label.
+	uint schema_id;     // current schema id
+	GraphContext *gc;   // graph context
+	SIValue *output;    // output label
 } LabelsContext;
 
-ProcedureResult Proc_LabelsInvoke(ProcedureCtx *ctx,
-								  const SIValue *args, const char **yield) {
+ProcedureResult Proc_LabelsInvoke
+(
+	ProcedureCtx *ctx,
+	const SIValue *args,
+	const char **yield
+) {
 	if(array_len((SIValue *)args) != 0) return PROCEDURE_ERR;
 
 	LabelsContext *pdata = rm_malloc(sizeof(LabelsContext));
-	pdata->schema_id = 0;
-	pdata->gc = QueryCtx_GetGraphCtx();
-	pdata->output = array_new(SIValue, 1);
+
+	pdata->schema_id  =  0;
+	pdata->gc         =  QueryCtx_GetGraphCtx();
+	pdata->output     =  array_new(SIValue, 1);
+
 	array_append(pdata->output, SI_ConstStringVal("label"));
 
 	ctx->privateData = pdata;
 	return PROCEDURE_OK;
 }
 
-SIValue *Proc_LabelsStep(ProcedureCtx *ctx) {
+SIValue *Proc_LabelsStep
+(
+	ProcedureCtx *ctx
+) {
 	ASSERT(ctx->privateData != NULL);
 
 	LabelsContext *pdata = (LabelsContext *)ctx->privateData;
 
-	// Depleted?
+	// depleted?
 	if(pdata->schema_id >= GraphContext_SchemaCount(pdata->gc, SCHEMA_NODE))
 		return NULL;
 
-	// Get schema label.
+	// get schema label
 	Schema *s = GraphContext_GetSchemaByID(pdata->gc, pdata->schema_id++, SCHEMA_NODE);
 	char *label = (char *)Schema_GetName(s);
 	pdata->output[0] = SI_ConstStringVal(label);
 	return pdata->output;
 }
 
-ProcedureResult Proc_LabelsFree(ProcedureCtx *ctx) {
-	// Clean up.
+ProcedureResult Proc_LabelsFree
+(
+	ProcedureCtx *ctx
+) {
+	// clean up
 	if(ctx->privateData) {
 		LabelsContext *pdata = ctx->privateData;
 		array_free(pdata->output);

--- a/src/procedures/proc_labels.c
+++ b/src/procedures/proc_labels.c
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */
@@ -21,15 +21,14 @@ typedef struct {
 } LabelsContext;
 
 ProcedureResult Proc_LabelsInvoke(ProcedureCtx *ctx,
-		const SIValue *args, const char **yield) {
+								  const SIValue *args, const char **yield) {
 	if(array_len((SIValue *)args) != 0) return PROCEDURE_ERR;
 
 	LabelsContext *pdata = rm_malloc(sizeof(LabelsContext));
 	pdata->schema_id = 0;
 	pdata->gc = QueryCtx_GetGraphCtx();
-	pdata->output = array_new(SIValue, 2);
+	pdata->output = array_new(SIValue, 1);
 	array_append(pdata->output, SI_ConstStringVal("label"));
-	array_append(pdata->output, SI_ConstStringVal("")); // Place holder.
 
 	ctx->privateData = pdata;
 	return PROCEDURE_OK;
@@ -47,7 +46,7 @@ SIValue *Proc_LabelsStep(ProcedureCtx *ctx) {
 	// Get schema label.
 	Schema *s = GraphContext_GetSchemaByID(pdata->gc, pdata->schema_id++, SCHEMA_NODE);
 	char *label = (char *)Schema_GetName(s);
-	pdata->output[1] = SI_ConstStringVal(label);
+	pdata->output[0] = SI_ConstStringVal(label);
 	return pdata->output;
 }
 

--- a/src/procedures/proc_labels.h
+++ b/src/procedures/proc_labels.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/proc_list_indexes.c
+++ b/src/procedures/proc_list_indexes.c
@@ -27,13 +27,18 @@ typedef struct {
 	SIValue *yield_entity_type; // yield index entity type
 } IndexesContext;
 
-static void _process_yield(IndexesContext *ctx, const char **yield) {
+static void _process_yield
+(
+	IndexesContext *ctx,
+	const char **yield
+) {
 	ctx->yield_type        = NULL;
 	ctx->yield_label       = NULL;
 	ctx->yield_properties  = NULL;
 	ctx->yield_language    = NULL;
 	ctx->yield_stopwords   = NULL;
 	ctx->yield_entity_type = NULL;
+
 	int idx = 0;
 	for(uint i = 0; i < array_len(yield); i++) {
 		if(strcasecmp("type", yield[i]) == 0) {
@@ -75,10 +80,16 @@ static void _process_yield(IndexesContext *ctx, const char **yield) {
 }
 
 // CALL db.indexes()
-ProcedureResult Proc_IndexesInvoke(ProcedureCtx *ctx, const SIValue *args,
-								   const char **yield) {
+ProcedureResult Proc_IndexesInvoke
+(
+	ProcedureCtx *ctx,
+	const SIValue *args,
+	const char **yield
+) {
 
-	ASSERT(ctx != NULL && args != NULL && yield != NULL);
+	ASSERT(ctx   != NULL);
+	ASSERT(args  != NULL);
+	ASSERT(yield != NULL);
 
 	// TODO: introduce invoke validation, similar to arithmetic expressions
 	// expecting no arguments
@@ -101,7 +112,12 @@ ProcedureResult Proc_IndexesInvoke(ProcedureCtx *ctx, const SIValue *args,
 	return PROCEDURE_OK;
 }
 
-static bool _EmitIndex(IndexesContext *ctx, const Schema *s, IndexType type) {
+static bool _EmitIndex
+(
+	IndexesContext *ctx,
+	const Schema *s,
+	IndexType type
+) {
 	Index *idx = Schema_GetIndex(s, NULL, type);
 	if(idx == NULL) return false;
 
@@ -160,7 +176,12 @@ static bool _EmitIndex(IndexesContext *ctx, const Schema *s, IndexType type) {
 	return true;
 }
 
-static SIValue *Schema_Step(int *schema_id, SchemaType t, IndexesContext *pdata) {
+static SIValue *Schema_Step
+(
+	int *schema_id,
+	SchemaType t,
+	IndexesContext *pdata
+) {
 	Schema *s = NULL;
 
 	// loop over all schemas from last to first
@@ -190,7 +211,10 @@ static SIValue *Schema_Step(int *schema_id, SchemaType t, IndexesContext *pdata)
 	return NULL;
 }
 
-SIValue *Proc_IndexesStep(ProcedureCtx *ctx) {
+SIValue *Proc_IndexesStep
+(
+	ProcedureCtx *ctx
+) {
 	ASSERT(ctx->privateData != NULL);
 
 	SIValue *res;
@@ -202,7 +226,10 @@ SIValue *Proc_IndexesStep(ProcedureCtx *ctx) {
 	return Schema_Step(&pdata->edge_schema_id, SCHEMA_EDGE, pdata);
 }
 
-ProcedureResult Proc_IndexesFree(ProcedureCtx *ctx) {
+ProcedureResult Proc_IndexesFree
+(
+	ProcedureCtx *ctx
+) {
 	// clean up
 	if(ctx->privateData) {
 		IndexesContext *pdata = ctx->privateData;
@@ -219,37 +246,37 @@ ProcedureCtx *Proc_IndexesCtx() {
 	ProcedureOutput *outputs = array_new(ProcedureOutput, 6);
 
 	// index type (exact-match / fulltext)
-	output  = (ProcedureOutput) {
+	output = (ProcedureOutput) {
 		.name = "type", .type = T_STRING
 	};
 	array_append(outputs, output);
 
 	// indexed label
-	output  = (ProcedureOutput) {
+	output = (ProcedureOutput) {
 		.name = "label", .type = T_STRING
 	};
 	array_append(outputs, output);
 
 	// indexed properties
-	output  = (ProcedureOutput) {
+	output = (ProcedureOutput) {
 		.name = "properties", .type = T_ARRAY
 	};
 	array_append(outputs, output);
 
 	// indexed language
-	output  = (ProcedureOutput) {
+	output = (ProcedureOutput) {
 		.name = "language", .type = T_STRING
 	};
 	array_append(outputs, output);
 
 	// indexed stopwords
-	output  = (ProcedureOutput) {
+	output = (ProcedureOutput) {
 		.name = "stopwords", .type = T_ARRAY
 	};
 	array_append(outputs, output);
 
 	// index entity type (node / relationship)
-	output  = (ProcedureOutput) {
+	output = (ProcedureOutput) {
 		.name = "entitytype", .type = T_STRING
 	};
 	array_append(outputs, output);

--- a/src/procedures/proc_list_indexes.h
+++ b/src/procedures/proc_list_indexes.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/proc_pagerank.c
+++ b/src/procedures/proc_pagerank.c
@@ -19,18 +19,22 @@
 // CALL algo.pageRank('Page', 'LINKS') YIELD node, score
 
 typedef struct {
-	int n;                          // Number of nodes to rank.
-	int i;                          // Current node to return.
-	Graph *g;                       // Graph.
-	Node node;                      // Node.
-	GrB_Index *mapping;             // Mapping between extracted matrix rows and node ids.
-	LAGraph_PageRank *ranking;      // Nodes ranking.
+	int n;                          // number of nodes to rank
+	int i;                          // current node to return
+	Graph *g;                       // graph
+	Node node;                      // node
+	GrB_Index *mapping;             // mapping between extracted matrix rows and node ids
+	LAGraph_PageRank *ranking;      // nodes ranking
 	SIValue *output;                // array with up to 2 entries [node, score]
 	SIValue *yield_node;            // yield node
 	SIValue *yield_score;           // yield score
 } PagerankContext;
 
-static void _process_yield(PagerankContext *ctx, const char **yield) {
+static void _process_yield
+(
+	PagerankContext *ctx,
+	const char **yield
+) {
 	int idx = 0;
 	for(uint i = 0; i < array_len(yield); i++) {
 		if(strcasecmp("node", yield[i]) == 0) {
@@ -47,41 +51,47 @@ static void _process_yield(PagerankContext *ctx, const char **yield) {
 	}
 }
 
-ProcedureResult Proc_PagerankInvoke(ProcedureCtx *ctx,
-									const SIValue *args, const char **yield) {
-	// Expecting 2 arguments.
+ProcedureResult Proc_PagerankInvoke
+(
+	ProcedureCtx *ctx,
+	const SIValue *args,
+	const char **yield
+) {
+	// expecting 2 arguments
 	if(array_len((SIValue *)args) != 2) return PROCEDURE_ERR;
+
 	// arg0 and arg1 can be either String or NULL
 	SIType arg0_t = SI_TYPE(args[0]);
 	SIType arg1_t = SI_TYPE(args[1]);
 	if(!(arg0_t & (T_STRING | T_NULL))) return PROCEDURE_ERR;
 	if(!(arg1_t & (T_STRING | T_NULL))) return PROCEDURE_ERR;
 
-	// Read arguments.
-	const char *label = NULL;    // Node filter.
-	const char *relation = NULL; // Edge filter.
+	// read arguments
+	const char *label = NULL;    // node filter
+	const char *relation = NULL; // edge filter
 	if(arg0_t == T_STRING) label = args[0].stringval;
 	if(arg1_t == T_STRING) relation = args[1].stringval;
 
-	// Pagerank config arguments
-	int iters;         // iterations performed
+	// pagerank config arguments
+	int iters;               // iterations performed
 	const double tol = 1e-4; // tolerance
 	const int itermax = 100; // max iterations
 
 	GrB_Info info;
 	UNUSED(info);
-	GrB_Index n = 0;               // Node count
-	GrB_Index nvals;               // Number of entries in 'r'
-	GrB_Index nrows;               // Relation matrix row count
+
+	GrB_Index n = 0;               // node count
+	GrB_Index nvals;               // number of entries in 'r'
+	GrB_Index nrows;               // relation matrix row count
 	Schema *s = NULL;
-	GrB_Matrix l = NULL;           // Label matrix
-	GrB_Matrix r = NULL;           // Relation matrix
-	GrB_Index *mapping = NULL;     // Mapping, array for returning row indices of tuples
+	GrB_Matrix l = NULL;           // label matrix
+	GrB_Matrix r = NULL;           // relation matrix
+	GrB_Index *mapping = NULL;     // mapping, array for returning row indices of tuples
 	Graph *g = QueryCtx_GetGraph();
 	LAGraph_PageRank *ranking = NULL;
 	GraphContext *gc = QueryCtx_GetGraphCtx();
 
-	// Setup context.
+	// setup context
 	PagerankContext *pdata = rm_malloc(sizeof(PagerankContext));
 	pdata->n = n;
 	pdata->i = 0;
@@ -94,18 +104,18 @@ ProcedureResult Proc_PagerankInvoke(ProcedureCtx *ctx,
 
 	ctx->privateData = pdata;
 
-	// Get label matrix.
+	// get label matrix
 	if(label) {
 		s = GraphContext_GetSchema(gc, label, SCHEMA_NODE);
-		// Unknown label, quickly return.
+		// unknown label, quickly return
 		if(!s) return PROCEDURE_OK;
 		RG_Matrix_export(&l, Graph_GetLabelMatrix(g, s->id));
 	}
 
-	// Get relation matrix.
+	// get relation matrix
 	if(relation) {
 		s = GraphContext_GetSchema(gc, relation, SCHEMA_EDGE);
-		// Unknown relation, quickly return.
+		// unknown relation, quickly return
 		if(!s) return PROCEDURE_OK;
 		RG_Matrix_export(&r, Graph_GetRelationMatrix(g, s->id, false));
 
@@ -113,27 +123,27 @@ ProcedureResult Proc_PagerankInvoke(ProcedureCtx *ctx,
 		info = GrB_Matrix_apply(r, NULL, NULL, GxB_ONE_BOOL, r, GrB_DESC_R);
 		ASSERT(info == GrB_SUCCESS);
 	} else {
-		// Relation isn't specified, 'r' is the adjacency matrix.
+		// relation isn't specified, 'r' is the adjacency matrix
 		RG_Matrix_export(&r, Graph_GetAdjacencyMatrix(g, false));
 	}
-	/* if label is specified:
-	 * filter 'r' to contain only rows and columns associated with
-	 * nodes of type 'l' */
+	// if label is specified:
+	// filter 'r' to contain only rows and columns associated with
+	// nodes of type 'l'
 	if(label != NULL) {
 		//----------------------------------------------------------------------
-		// Create a NxN matrix, one row for each labeled entity
+		// create a NxN matrix, one row for each labeled entity
 		//----------------------------------------------------------------------
 		info = GrB_Matrix_nvals(&n, l);
 		ASSERT(info == GrB_SUCCESS);
 
-		GrB_Matrix reduced; // Relation matrix reduced to only 'l' rows/cols
+		GrB_Matrix reduced; // relation matrix reduced to only 'l' rows/cols
 		info = GrB_Matrix_new(&reduced, GrB_BOOL, n, n);
 		ASSERT(info == GrB_SUCCESS);
 
-		// Discard rows of 'r' associated with nodes of a different type than 'l'
-		// this will also perform casting to boolean.
+		// discard rows of 'r' associated with nodes of a different type than 'l'
+		// this will also perform casting to boolean
 		mapping = rm_malloc(sizeof(GrB_Index) * n);
-		// Extract row indecies from 'l', coresponding to node IDs.
+		// extract row indecies from 'l', coresponding to node IDs
 		info = GrB_Matrix_extractTuples_BOOL(mapping, GrB_NULL, GrB_NULL, &n, l);
 		ASSERT(info == GrB_SUCCESS);
 
@@ -144,12 +154,12 @@ ProcedureResult Proc_PagerankInvoke(ProcedureCtx *ctx,
 		GrB_free(&r);
 		r = reduced;
 	} else {
-		// Resize to remove unused rows.
+		// resize to remove unused rows
 		n = Graph_UncompactedNodeCount(g);
 		GxB_Matrix_resize(r, n, n);
 	}
 
-	// Invoke Pagerank only if 'r' contains entries.
+	// invoke Pagerank only if 'r' contains entries
 	info = GrB_Matrix_nvals(&nvals, r);
 	ASSERT(info == GrB_SUCCESS);
 
@@ -158,44 +168,51 @@ ProcedureResult Proc_PagerankInvoke(ProcedureCtx *ctx,
 		ASSERT(info == GrB_SUCCESS);
 	}
 
-	// Clean up.
+	// clean up
 	GrB_free(&r);
 	if(label) {
 		GrB_free(&l);
 	}
 
-	// Update context.
-	pdata->n = n;
-	pdata->mapping = mapping;
-	pdata->ranking = ranking;
+	// update context
+	pdata->n        =  n;
+	pdata->mapping  =  mapping;
+	pdata->ranking  =  ranking;
+
 	return PROCEDURE_OK;
 }
 
-SIValue *Proc_PagerankStep(ProcedureCtx *ctx) {
+SIValue *Proc_PagerankStep
+(
+	ProcedureCtx *ctx
+) {
 	ASSERT(ctx->privateData);
 
 	PagerankContext *pdata = (PagerankContext *)ctx->privateData;
 
-	// Depleted/no results
+	// depleted/no results
 	if(pdata->i >= pdata->n || pdata->ranking == NULL) return NULL;
 
 	LAGraph_PageRank rank = pdata->ranking[pdata->i++];
 	NodeID node_id = (pdata->mapping) ? pdata->mapping[rank.page] : rank.page;
 
 	Graph_GetNode(pdata->g, node_id, &pdata->node);
-	if(pdata->yield_node) *pdata->yield_node = SI_Node(&pdata->node);
-	if(pdata->yield_score) *pdata->yield_score = SI_DoubleVal(rank.pagerank);
+	if(pdata->yield_node)   *pdata->yield_node   =  SI_Node(&pdata->node);
+	if(pdata->yield_score)  *pdata->yield_score  =  SI_DoubleVal(rank.pagerank);
 
 	return pdata->output;
 }
 
-ProcedureResult Proc_PagerankFree(ProcedureCtx *ctx) {
-	// Clean up.
+ProcedureResult Proc_PagerankFree
+(
+	ProcedureCtx *ctx
+) {
+	// clean up
 	if(ctx->privateData) {
 		PagerankContext *pdata = ctx->privateData;
-		if(pdata->output) array_free(pdata->output);
-		if(pdata->mapping) rm_free(pdata->mapping);
-		if(pdata->ranking) rm_free(pdata->ranking);
+		if(pdata->output)   array_free(pdata->output);
+		if(pdata->mapping)  rm_free(pdata->mapping);
+		if(pdata->ranking)  rm_free(pdata->ranking);
 		rm_free(ctx->privateData);
 	}
 

--- a/src/procedures/proc_pagerank.h
+++ b/src/procedures/proc_pagerank.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/proc_procedures.c
+++ b/src/procedures/proc_procedures.c
@@ -15,8 +15,8 @@ extern rax *__procedures;
 // CALL dbms.procedures()
 
 typedef struct {
-	SIValue *output;      // Array with a maximum of 4 entries: ["name", name, "mode", mode].
-	raxIterator iter;     // Procedures iterator.
+	SIValue *output;      // array with a maximum of 2 entries: [name, mode]
+	raxIterator iter;     // procedures iterator
 	SIValue *yield_name;  // yield name
 	SIValue *yield_mode;  // yield mode
 } ProcProceduresPrivateData;

--- a/src/procedures/proc_procedures.c
+++ b/src/procedures/proc_procedures.c
@@ -21,7 +21,11 @@ typedef struct {
 	SIValue *yield_mode;  // yield mode
 } ProcProceduresPrivateData;
 
-static void _process_yield(ProcProceduresPrivateData *ctx, const char **yield) {
+static void _process_yield
+(
+	ProcProceduresPrivateData *ctx,
+	const char **yield
+) {
 	ctx->yield_name = NULL;
 	ctx->yield_mode = NULL;
 	int idx = 0;
@@ -39,13 +43,17 @@ static void _process_yield(ProcProceduresPrivateData *ctx, const char **yield) {
 	}
 }
 
-ProcedureResult Proc_ProceduresInvoke(ProcedureCtx *ctx,
-									  const SIValue *args, const char **yield) {
+ProcedureResult Proc_ProceduresInvoke
+(
+	ProcedureCtx *ctx,
+	const SIValue *args,
+	const char **yield
+) {
 	if(array_len((SIValue *)args) != 0) return PROCEDURE_ERR;
 
 	ProcProceduresPrivateData *pdata = rm_malloc(sizeof(ProcProceduresPrivateData));
 
-	// Initialize an iterator to the rax that contains all procedures
+	// initialize an iterator to the rax that contains all procedures
 	rax *procedures = __procedures;
 	raxStart(&pdata->iter, procedures);
 	raxSeek(&pdata->iter, "^", NULL, 0);
@@ -56,28 +64,36 @@ ProcedureResult Proc_ProceduresInvoke(ProcedureCtx *ctx,
 	return PROCEDURE_OK;
 }
 
-// Promote the rax iterator to the next procedure and return its name and mode.
-SIValue *Proc_ProceduresStep(ProcedureCtx *ctx) {
+// promote the rax iterator to the next procedure and return its name and mode.
+SIValue *Proc_ProceduresStep
+(
+	ProcedureCtx *ctx
+) {
 	ASSERT(ctx->privateData);
 
 	ProcProceduresPrivateData *pdata = (ProcProceduresPrivateData *)ctx->privateData;
-	// Depleted?
+	// depleted?
 	if(!raxNext(&pdata->iter)) return NULL;
 
-	// Returns the current procedure's name and mode.
+	// returns the current procedure's name and mode
 	ProcGenerator gen = pdata->iter.data;
 	ProcedureCtx *curr_proc_ctx = gen();
+
 	if(pdata->yield_name) *pdata->yield_name =
 			SI_ConstStringVal(Procedure_GetName(curr_proc_ctx));
 	if(pdata->yield_mode) *pdata->yield_mode =
 			Procedure_IsReadOnly(curr_proc_ctx) ? SI_ConstStringVal("READ") :
 			SI_ConstStringVal("WRITE");
+
 	Proc_Free(curr_proc_ctx);
 	return pdata->output;
 }
 
-ProcedureResult Proc_ProceduresFree(ProcedureCtx *ctx) {
-	// Clean up.
+ProcedureResult Proc_ProceduresFree
+(
+	ProcedureCtx *ctx
+) {
+	// clean up
 	if(ctx->privateData) {
 		ProcProceduresPrivateData *pdata = ctx->privateData;
 		array_free(pdata->output);

--- a/src/procedures/proc_procedures.h
+++ b/src/procedures/proc_procedures.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/proc_property_keys.c
+++ b/src/procedures/proc_property_keys.c
@@ -15,41 +15,54 @@
 // CALL db.propertyKeys()
 
 typedef struct {
-	uint prop_id;       // Current property ID.
-	GraphContext *gc;   // Graph context.
-	SIValue *output;    // Output label.
+	uint prop_id;       // current property ID
+	GraphContext *gc;   // graph context
+	SIValue *output;    // output label
 } RelationsContext;
 
-ProcedureResult Proc_PropKeysInvoke(ProcedureCtx *ctx, const SIValue *args, const char **yield) {
+ProcedureResult Proc_PropKeysInvoke
+(
+	ProcedureCtx *ctx,
+	const SIValue *args,
+	const char **yield
+) {
 	if(array_len((SIValue *)args) != 0) return PROCEDURE_ERR;
 
 	RelationsContext *pdata = rm_malloc(sizeof(RelationsContext));
-	pdata->prop_id = 0;
-	pdata->gc = QueryCtx_GetGraphCtx();
-	pdata->output = array_new(SIValue, 1);
+
+	pdata->prop_id  =  0;
+	pdata->gc       =  QueryCtx_GetGraphCtx();
+	pdata->output   =  array_new(SIValue, 1);
+
 	array_append(pdata->output, SI_ConstStringVal("propertyKey"));
 
 	ctx->privateData = pdata;
 	return PROCEDURE_OK;
 }
 
-SIValue *Proc_PropKeysStep(ProcedureCtx *ctx) {
+SIValue *Proc_PropKeysStep
+(
+	ProcedureCtx *ctx
+) {
 	ASSERT(ctx->privateData != NULL);
 
 	RelationsContext *pdata = (RelationsContext *)ctx->privateData;
 
-	// Depleted?
+	// depleted?
 	if(pdata->prop_id >= GraphContext_AttributeCount(pdata->gc))
 		return NULL;
 
-	// Get attribute name.
+	// get attribute name
 	char *name = (char *)GraphContext_GetAttributeString(pdata->gc, pdata->prop_id++);
 	pdata->output[0] = SI_ConstStringVal(name);
 	return pdata->output;
 }
 
-ProcedureResult Proc_PropKeysFree(ProcedureCtx *ctx) {
-	// Clean up.
+ProcedureResult Proc_PropKeysFree
+(
+	ProcedureCtx *ctx
+) {
+	// clean up
 	if(ctx->privateData) {
 		RelationsContext *pdata = ctx->privateData;
 		array_free(pdata->output);

--- a/src/procedures/proc_property_keys.c
+++ b/src/procedures/proc_property_keys.c
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */
@@ -26,9 +26,8 @@ ProcedureResult Proc_PropKeysInvoke(ProcedureCtx *ctx, const SIValue *args, cons
 	RelationsContext *pdata = rm_malloc(sizeof(RelationsContext));
 	pdata->prop_id = 0;
 	pdata->gc = QueryCtx_GetGraphCtx();
-	pdata->output = array_new(SIValue, 2);
+	pdata->output = array_new(SIValue, 1);
 	array_append(pdata->output, SI_ConstStringVal("propertyKey"));
-	array_append(pdata->output, SI_ConstStringVal("")); // Place holder.
 
 	ctx->privateData = pdata;
 	return PROCEDURE_OK;
@@ -45,7 +44,7 @@ SIValue *Proc_PropKeysStep(ProcedureCtx *ctx) {
 
 	// Get attribute name.
 	char *name = (char *)GraphContext_GetAttributeString(pdata->gc, pdata->prop_id++);
-	pdata->output[1] = SI_ConstStringVal(name);
+	pdata->output[0] = SI_ConstStringVal(name);
 	return pdata->output;
 }
 

--- a/src/procedures/proc_property_keys.h
+++ b/src/procedures/proc_property_keys.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/proc_relations.c
+++ b/src/procedures/proc_relations.c
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */
@@ -26,9 +26,7 @@ ProcedureResult Proc_RelationsInvoke(ProcedureCtx *ctx, const SIValue *args, con
 	RelationsContext *pdata = rm_malloc(sizeof(RelationsContext));
 	pdata->schema_id = 0;
 	pdata->gc = QueryCtx_GetGraphCtx();
-	pdata->output = array_new(SIValue, 2);
-	array_append(pdata->output, SI_ConstStringVal("relationshipType"));
-	array_append(pdata->output, SI_ConstStringVal("")); // Place holder.
+	pdata->output = array_new(SIValue, 1);
 
 	ctx->privateData = pdata;
 	return PROCEDURE_OK;
@@ -45,8 +43,7 @@ SIValue *Proc_RelationsStep(ProcedureCtx *ctx) {
 
 	// Get schema name.
 	Schema *s = GraphContext_GetSchemaByID(pdata->gc, pdata->schema_id++, SCHEMA_EDGE);
-	char *name = (char *)Schema_GetName(s);
-	pdata->output[1] = SI_ConstStringVal(name);
+	pdata->output[0] = SI_ConstStringVal(Schema_GetName(s));
 	return pdata->output;
 }
 

--- a/src/procedures/proc_relations.c
+++ b/src/procedures/proc_relations.c
@@ -20,35 +20,47 @@ typedef struct {
 	SIValue *output;    // Output label.
 } RelationsContext;
 
-ProcedureResult Proc_RelationsInvoke(ProcedureCtx *ctx, const SIValue *args, const char **yield) {
+ProcedureResult Proc_RelationsInvoke
+(
+	ProcedureCtx *ctx,
+	const SIValue *args,
+	const char **yield
+) {
 	if(array_len((SIValue *)args) != 0) return PROCEDURE_ERR;
 
 	RelationsContext *pdata = rm_malloc(sizeof(RelationsContext));
-	pdata->schema_id = 0;
-	pdata->gc = QueryCtx_GetGraphCtx();
-	pdata->output = array_new(SIValue, 1);
+
+	pdata->schema_id  =  0;
+	pdata->gc         =  QueryCtx_GetGraphCtx();
+	pdata->output     =  array_new(SIValue, 1);
 
 	ctx->privateData = pdata;
 	return PROCEDURE_OK;
 }
 
-SIValue *Proc_RelationsStep(ProcedureCtx *ctx) {
+SIValue *Proc_RelationsStep
+(
+	ProcedureCtx *ctx
+) {
 	ASSERT(ctx->privateData != NULL);
 
 	RelationsContext *pdata = (RelationsContext *)ctx->privateData;
 
-	// Depleted?
+	// depleted?
 	if(pdata->schema_id >= GraphContext_SchemaCount(pdata->gc, SCHEMA_EDGE))
 		return NULL;
 
-	// Get schema name.
+	// get schema name
 	Schema *s = GraphContext_GetSchemaByID(pdata->gc, pdata->schema_id++, SCHEMA_EDGE);
 	pdata->output[0] = SI_ConstStringVal(Schema_GetName(s));
 	return pdata->output;
 }
 
-ProcedureResult Proc_RelationsFree(ProcedureCtx *ctx) {
-	// Clean up.
+ProcedureResult Proc_RelationsFree
+(
+	ProcedureCtx *ctx
+) {
+	// clean up
 	if(ctx->privateData) {
 		RelationsContext *pdata = ctx->privateData;
 		array_free(pdata->output);

--- a/src/procedures/proc_relations.h
+++ b/src/procedures/proc_relations.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/procedure.c
+++ b/src/procedures/procedure.c
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/procedure.h
+++ b/src/procedures/procedure.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/src/procedures/procedures.h
+++ b/src/procedures/procedures.h
@@ -1,5 +1,5 @@
 /*
-* Copyright 2018-2020 Redis Labs Ltd. and Contributors
+* Copyright 2018-2021 Redis Labs Ltd. and Contributors
 *
 * This file is available under the Redis Labs Source Available License Agreement
 */

--- a/tests/flow/test_bfs.py
+++ b/tests/flow/test_bfs.py
@@ -177,3 +177,9 @@ class testBFS(FlowTestsBase):
         actual_result = graph.query(query)
         self.env.assertEquals(actual_result.result_set, empty_result_set)
 
+    # test a query which calls BFS multiple times in the same scope
+    def test07_multiple_bfs_calls(self):
+        query = """MATCH (a {v: 'a'}) CALL algo.BFS(a, 1, NULL) YIELD nodes as n1 MATCH (b {v: 'd'}) CALL algo.BFS(b, 1, NULL) YIELD nodes as n2 RETURN [n IN n1 | n.v] AS x, [n IN n2 | n.v] AS y ORDER BY x.v"""
+        actual_result = graph.query(query)
+        expected_result = [[['b'], ['e']]]
+        self.env.assertEquals(actual_result.result_set, expected_result)

--- a/tests/flow/test_procedures.py
+++ b/tests/flow/test_procedures.py
@@ -64,7 +64,7 @@ class testProcedures(FlowTestsBase):
         self.env.assertEquals(len(actual_resultset), len(expected_results))
         for i in range(len(actual_resultset)):
             self.env.assertTrue(self._inResultSet(expected_results[i], actual_resultset))
-    
+
     # Call procedure, omit yield, expecting all procedure outputs to
     # be included in result-set.
     def test01_no_yield(self):
@@ -94,7 +94,7 @@ class testProcedures(FlowTestsBase):
         except redis.exceptions.ResponseError:
             # Expecting an error.
             pass
-        
+
         # Yield the same output multiple times.
         # Expect an error when trying to use the same output multiple times.
         try:
@@ -103,7 +103,7 @@ class testProcedures(FlowTestsBase):
         except redis.exceptions.ResponseError:
             # Expecting an error.
             pass
-    
+
     def test03_arguments(self):
         # Omit arguments.
         # Expect an error when trying to omit arguments.
@@ -113,7 +113,7 @@ class testProcedures(FlowTestsBase):
         except redis.exceptions.ResponseError:
             # Expecting an error.
             pass
-        
+
         # Omit arguments, queryNodes expecting 2 argument, provide 1.
         # Expect an error when trying to omit arguments.
         try:
@@ -275,14 +275,14 @@ class testProcedures(FlowTestsBase):
 
     def test05_procedure_labels(self):
         actual_resultset = redis_graph.call_procedure("db.labels").result_set
-        expected_results = [["fruit"]]        
+        expected_results = [["fruit"]]
         self.env.assertEquals(actual_resultset, expected_results)
-    
+
     def test06_procedure_relationshipTypes(self):
         actual_resultset = redis_graph.call_procedure("db.relationshipTypes").result_set
         expected_results = [["goWellWith"]]
         self.env.assertEquals(actual_resultset, expected_results)
-    
+
     def test07_procedure_propertyKeys(self):
         actual_resultset = redis_graph.call_procedure("db.propertyKeys").result_set
         expected_results = [["name"], ["value"]]
@@ -363,3 +363,18 @@ class testProcedures(FlowTestsBase):
                             ["fruit"]]
         self.env.assertEquals(actual_resultset, expected_results)
 
+    def test12_procedure_reordered_yields(self):
+        # Yield results of procedure in a non-default sequence
+        actual_resultset = redis_graph.query("CALL dbms.procedures() YIELD mode, name RETURN mode, name ORDER BY name").result_set
+
+        expected_result = [["READ", "algo.BFS"],
+                           ["READ", "algo.pageRank"],
+                           ["WRITE", "db.idx.fulltext.createNodeIndex"],
+                           ["WRITE", "db.idx.fulltext.drop"],
+                           ["READ", "db.idx.fulltext.queryNodes"],
+                           ["READ", "db.indexes"],
+                           ["READ", "db.labels"],
+                           ["READ", "db.propertyKeys"],
+                           ["READ", "db.relationshipTypes"],
+                           ["READ", "dbms.procedures"]]
+        self.env.assertEquals(actual_resultset, expected_result)


### PR DESCRIPTION
Resolves #1701 

Previously, the default variable names for `YIELD` expressions were placed in the record map and any aliases applied to them were linked to them using `OpBase_AliasModifier`. This function increases the size of the record map without introducing new members, introducing empty spaces in the record, and should be avoided. Additionally, mapping the default variable names causes collisions when the same procedure is called twice in one query, in the case of `nodes` on the linked issue. This causes both aliases to be mapped to the first `nodes` output and the second BFS call to never have its outputs checked. This led to a double free when emitting results.

This PR also standardizes and simplifies the way procedures register their outputs. Non-yielded results are not computed, only values are stored rather than key-value pairs with output names, and other changes have been made.