### PR TITLE
Allow copying of entity attribute sets in SET clauses

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -458,6 +458,16 @@ SET n = {age: 33, name: 'Bob'}"
 
 Using `=` in this way replaces all of the entity's previous properties, while `+=` will only set the properties it explicitly mentions.
 
+In the same way, the full property set of a graph entity can be assigned or merged:
+
+```sh
+GRAPH.QUERY DEMO_GRAPH
+"MATCH (jim {name: 'Jim'}), (pam {name: 'Pam'})
+SET jim = pam"
+```
+
+After executing this query, the `jim` node will have the same property set as the `pam` node.
+
 To remove a node's property, simply set property value to NULL.
 
 ```sh

--- a/src/execution_plan/ops/shared/update_functions.c
+++ b/src/execution_plan/ops/shared/update_functions.c
@@ -256,7 +256,10 @@ void EvalEntityUpdates(GraphContext *gc, PendingUpdateCtx **node_updates,
 		if(SI_TYPE(new_value) == T_MAP) {
 			// value is of type map e.g. n.v = {a:1, b:2}
 			SIValue m = new_value;
-			ASSERT(attr_id == ATTRIBUTE_ALL);
+			if(attr_id != ATTRIBUTE_ALL) {
+				Error_InvalidPropertyValue();
+				ErrorCtx_RaiseRuntimeException(NULL);
+			}
 			// iterate over all map elements to build updates
 			uint map_size = Map_KeyCount(m);
 			for(uint j = 0; j < map_size; j ++) {
@@ -292,6 +295,8 @@ void EvalEntityUpdates(GraphContext *gc, PendingUpdateCtx **node_updates,
 			}
 			continue;
 		} else if(attr_id == ATTRIBUTE_ALL) {
+			// left-hand side is alias reference but right-hand side is a
+			// scalar, emit an error
 			Error_InvalidPropertyValue();
 			ErrorCtx_RaiseRuntimeException(NULL);
 		}

--- a/tests/flow/test_entity_update.py
+++ b/tests/flow/test_entity_update.py
@@ -18,7 +18,9 @@ class testEntityUpdate(FlowTestsBase):
 
         # create a graph with a two nodes connected by an edge
         multiple_entity_graph = Graph('multiple_entity_update', self.env.getConnection())
-        multiple_entity_graph.query("CREATE ({v1: 1})-[:R {v1: 3}]->({v2: 2})")
+        multiple_entity_graph.query("CREATE (:L {v1: 1})-[:R {v1: 3}]->(:L {v2: 2})")
+        multiple_entity_graph.query("CREATE INDEX ON :L(v1)")
+        multiple_entity_graph.query("CREATE INDEX ON :L(v2)")
 
     def test01_update_attribute(self):
         # update existing attribute 'v'
@@ -140,22 +142,92 @@ class testEntityUpdate(FlowTestsBase):
             except ResponseError as e:
                 self.env.assertContains("Property values can only be of primitive types or arrays of primitive types", str(e))
 
+    # fail when attempting to perform invalid map assignment
+    def test14_invalid_map_assignment(self):
+        try:
+            graph.query("MATCH (a) SET a.v = {f: true}")
+            self.env.assertTrue(False)
+        except ResponseError as e:
+            self.env.assertContains("Property values can only be of primitive types or arrays of primitive types", str(e))
+
     # update properties by attribute set reassignment
-    def test14_assign_entity_properties(self):
+    def test15_assign_entity_properties(self):
         # merge attribute set of a node with existing properties
-        node = Node(properties={"v1": 1, "v2": 2})
+        node = Node(label="L", properties={"v1": 1, "v2": 2})
         result = multiple_entity_graph.query("MATCH (n1 {v1: 1}), (n2 {v2: 2}) SET n1 += n2 RETURN n1")
         expected_result = [[node]]
         self.env.assertEqual(result.result_set, expected_result)
+        # validate index updates
+        result = multiple_entity_graph.query("MATCH (n:L) WHERE n.v1 > 0 RETURN n.v1 ORDER BY n.v1")
+        expected_result = [[1]]
+        self.env.assertEqual(result.result_set, expected_result)
+        result = multiple_entity_graph.query("MATCH (n:L) WHERE n.v2 > 0 RETURN n.v2 ORDER BY n.v2")
+        expected_result = [[2],
+                           [2]]
+        self.env.assertEqual(result.result_set, expected_result)
 
         # overwrite attribute set of node with attribute set of edge
-        node = Node(properties={"v1": 3})
+        node = Node(label="L", properties={"v1": 3})
         result = multiple_entity_graph.query("MATCH (n {v1: 1})-[e]->() SET n = e RETURN n")
         expected_result = [[node]]
         self.env.assertEqual(result.result_set, expected_result)
+        # validate index updates
+        result = multiple_entity_graph.query("MATCH (n:L) WHERE n.v1 > 0 RETURN n.v1 ORDER BY n.v1")
+        expected_result = [[3]]
+        self.env.assertEqual(result.result_set, expected_result)
+        result = multiple_entity_graph.query("MATCH (n:L) WHERE n.v2 > 0 RETURN n.v2 ORDER BY n.v2")
+        expected_result = [[2]]
+        self.env.assertEqual(result.result_set, expected_result)
 
-    # Fail when attempting to perform invalid entity assignment
-    def test13_invalid_entity_assignment(self):
+    # repeated attribute set reassignment
+    def test16_assign_entity_properties(self):
+        # repeated merges to the attribute set of a node
+        node = Node(label="L", properties={"v1": 3, "v2": 2})
+        result = multiple_entity_graph.query("MATCH (n), (x) WHERE ID(n) = 0 SET n += x RETURN n")
+        expected_result = [[node],
+                           [node]]
+        self.env.assertEqual(result.result_set, expected_result)
+        # validate index updates
+        result = multiple_entity_graph.query("MATCH (n:L) WHERE n.v1 > 0 RETURN n.v1 ORDER BY n.v1")
+        expected_result = [[3]]
+        self.env.assertEqual(result.result_set, expected_result)
+        result = multiple_entity_graph.query("MATCH (n:L) WHERE n.v2 > 0 RETURN n.v2 ORDER BY n.v2")
+        expected_result = [[2],
+                           [2]]
+        self.env.assertEqual(result.result_set, expected_result)
+
+        # repeated updates to the attribute set of a node
+        node = Node(label="L", properties={"v2": 2})
+        result = multiple_entity_graph.query("MATCH (n), (x) WHERE ID(n) = 0 SET n = x RETURN n")
+        expected_result = [[node],
+                           [node]]
+        self.env.assertEqual(result.result_set, expected_result)
+        # validate index updates
+        result = multiple_entity_graph.query("MATCH (n:L) WHERE n.v1 > 0 RETURN n.v1 ORDER BY n.v1")
+        expected_result = []
+        self.env.assertEqual(result.result_set, expected_result)
+        result = multiple_entity_graph.query("MATCH (n:L) WHERE n.v2 > 0 RETURN n.v2 ORDER BY n.v2")
+        expected_result = [[2],
+                           [2]]
+        self.env.assertEqual(result.result_set, expected_result)
+
+        # repeated multiple updates to the attribute set of a node
+        node = Node(label="L", properties={"v2": 2})
+        result = multiple_entity_graph.query("MATCH (n), (x) WHERE ID(n) = 0 SET n = x, n += x RETURN n")
+        expected_result = [[node],
+                           [node]]
+        self.env.assertEqual(result.result_set, expected_result)
+        # validate index updates
+        result = multiple_entity_graph.query("MATCH (n:L) WHERE n.v1 > 0 RETURN n.v1 ORDER BY n.v1")
+        expected_result = []
+        self.env.assertEqual(result.result_set, expected_result)
+        result = multiple_entity_graph.query("MATCH (n:L) WHERE n.v2 > 0 RETURN n.v2 ORDER BY n.v2")
+        expected_result = [[2],
+                           [2]]
+        self.env.assertEqual(result.result_set, expected_result)
+
+    # fail when attempting to perform invalid entity assignment
+    def test17_invalid_entity_assignment(self):
         queries = ["MATCH (a) SET a.v = [a]",
                    "MATCH (a) SET a = a.v",
                    "MATCH (a) SET a = NULL"]

--- a/tests/flow/test_entity_update.py
+++ b/tests/flow/test_entity_update.py
@@ -183,7 +183,7 @@ class testEntityUpdate(FlowTestsBase):
     def test16_assign_entity_properties(self):
         # repeated merges to the attribute set of a node
         node = Node(label="L", properties={"v1": 3, "v2": 2})
-        result = multiple_entity_graph.query("MATCH (n), (x) WHERE ID(n) = 0 SET n += x RETURN n")
+        result = multiple_entity_graph.query("MATCH (n), (x) WHERE ID(n) = 0 WITH n, x ORDER BY ID(x) SET n += x RETURN n")
         expected_result = [[node],
                            [node]]
         self.env.assertEqual(result.result_set, expected_result)
@@ -198,7 +198,7 @@ class testEntityUpdate(FlowTestsBase):
 
         # repeated updates to the attribute set of a node
         node = Node(label="L", properties={"v2": 2})
-        result = multiple_entity_graph.query("MATCH (n), (x) WHERE ID(n) = 0 SET n = x RETURN n")
+        result = multiple_entity_graph.query("MATCH (n), (x) WHERE ID(n) = 0 WITH n, x ORDER BY ID(x) SET n = x RETURN n")
         expected_result = [[node],
                            [node]]
         self.env.assertEqual(result.result_set, expected_result)
@@ -213,7 +213,7 @@ class testEntityUpdate(FlowTestsBase):
 
         # repeated multiple updates to the attribute set of a node
         node = Node(label="L", properties={"v2": 2})
-        result = multiple_entity_graph.query("MATCH (n), (x) WHERE ID(n) = 0 SET n = x, n += x RETURN n")
+        result = multiple_entity_graph.query("MATCH (n), (x) WHERE ID(n) = 0 WITH n, x ORDER BY ID(x) SET n = x, n += x RETURN n")
         expected_result = [[node],
                            [node]]
         self.env.assertEqual(result.result_set, expected_result)


### PR DESCRIPTION
This PR allows graph entities to be used as right-hand values in `SET` clauses to perform attribute set assignment, as in:
```
MATCH (a {v: 1}), (b {v: 2}) SET a = b
```
Resolves #2045 