### PR TITLE
Use bulk string API for replying with strings

### DIFF
--- a/src/commands/cmd_list.c
+++ b/src/commands/cmd_list.c
@@ -22,7 +22,7 @@ int Graph_List(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 	for(uint i = 0; i < count; i ++) {
 		GraphContext *gc = graphs_in_keyspace[i];
 		const char *name = GraphContext_GetName(gc);
-		RedisModule_ReplyWithSimpleString(ctx, name);
+		RedisModule_ReplyWithStringBuffer(ctx, name, strlen(name));
 	}
 
 	return REDISMODULE_OK;

--- a/src/resultset/formatters/resultset_replycompact.c
+++ b/src/resultset/formatters/resultset_replycompact.c
@@ -57,7 +57,7 @@ static void _ResultSet_CompactReplyWithSIValue(RedisModuleCtx *ctx, GraphContext
 
 	switch(SI_TYPE(v)) {
 	case T_STRING:
-		RedisModule_ReplyWithSimpleString(ctx, v.stringval);
+		RedisModule_ReplyWithStringBuffer(ctx, v.stringval, strlen(v.stringval));
 		return;
 	case T_INT64:
 		RedisModule_ReplyWithLongLong(ctx, v.longval);
@@ -299,6 +299,6 @@ void ResultSet_ReplyWithCompactHeader(RedisModuleCtx *ctx, const char **columns,
 		RedisModule_ReplyWithLongLong(ctx, t);
 
 		// Second, emit the identifier string associated with the column
-		RedisModule_ReplyWithSimpleString(ctx, columns[i]);
+		RedisModule_ReplyWithStringBuffer(ctx, columns[i], strlen(columns[i]));
 	}
 }

--- a/src/resultset/formatters/resultset_replyverbose.c
+++ b/src/resultset/formatters/resultset_replyverbose.c
@@ -23,7 +23,7 @@ static void _ResultSet_VerboseReplyWithSIValue(RedisModuleCtx *ctx, GraphContext
 											   const SIValue v) {
 	switch(SI_TYPE(v)) {
 	case T_STRING:
-		RedisModule_ReplyWithSimpleString(ctx, v.stringval);
+		RedisModule_ReplyWithStringBuffer(ctx, v.stringval, strlen(v.stringval));
 		return;
 	case T_INT64:
 		RedisModule_ReplyWithLongLong(ctx, v.longval);
@@ -71,7 +71,7 @@ static void _ResultSet_VerboseReplyWithProperties(RedisModuleCtx *ctx, GraphCont
 		EntityProperty prop = ENTITY_PROPS(e)[i];
 		// Emit the actual string
 		const char *prop_str = GraphContext_GetAttributeString(gc, prop.id);
-		RedisModule_ReplyWithSimpleString(ctx, prop_str);
+		RedisModule_ReplyWithStringBuffer(ctx, prop_str, strlen(prop_str));
 		// Emit the value
 		_ResultSet_VerboseReplyWithSIValue(ctx, gc, prop.value);
 	}
@@ -104,7 +104,7 @@ static void _ResultSet_VerboseReplyWithNode(RedisModuleCtx *ctx, GraphContext *g
 	for(int i = 0; i < lbls_count; i++) {
 		Schema *s = GraphContext_GetSchemaByID(gc, labels[i], SCHEMA_NODE);
 		const char *lbl_name = Schema_GetName(s);
-		RedisModule_ReplyWithSimpleString(ctx, lbl_name);
+		RedisModule_ReplyWithStringBuffer(ctx, lbl_name, strlen(lbl_name));
 	}
 
 	// [properties, [properties]]
@@ -206,6 +206,6 @@ void ResultSet_ReplyWithVerboseHeader(RedisModuleCtx *ctx, const char **columns,
 	RedisModule_ReplyWithArray(ctx, columns_len);
 	for(uint i = 0; i < columns_len; i++) {
 		// Emit the identifier string associated with the column
-		RedisModule_ReplyWithSimpleString(ctx, columns[i]);
+		RedisModule_ReplyWithStringBuffer(ctx, columns[i], strlen(columns[i]));
 	}
 }

--- a/tests/flow/test_results.py
+++ b/tests/flow/test_results.py
@@ -196,3 +196,7 @@ class testResultSetFlow(FlowTestsBase):
         unlimited_record_count = len(result.result_set)
         assert(unlimited_record_count == record_count)
 
+    def test10_carriage_return_in_result(self):
+        query = """RETURN 'Foo\r\nBar'"""
+        result = graph.query(query)
+        self.env.assertEqual(result.result_set[0][0], 'Foo\r\nBar')


### PR DESCRIPTION
This PR replaces most instances of `RedisModule_ReplyWithSimpleString` calls with `RedisModule_ReplyWithStringBuffer` calls.

The former returns values of type `REDIS_REPLY_STATUS`, which cannot process the CRLF sequence (`\r\n`) and is generally meant for short status messages.

The latter returns `REDIS_REPLY_STRING` objects, which are binary-safe and can be up to 512 MBs.

Resolves #2072