### PR TITLE
Allow backtick-escaping of parameter names

### DIFF
--- a/tests/flow/test_params.py
+++ b/tests/flow/test_params.py
@@ -21,7 +21,7 @@ class testParams(FlowTestsBase):
 
     def setUp(self):
         self.env.flush()
-    
+
     def test_simple_params(self):
         params = [1, 2.3, -1, -2.3, "str", True, False, None, [0, 1, 2]]
         query = "RETURN $param"
@@ -63,7 +63,7 @@ class testParams(FlowTestsBase):
         params = {'param': 1}
         query = "RETURN $param + 1"
         expected_results = [[2]]
-            
+
         query_info = QueryInfo(query = query, description="Tests expression on param", expected_result = expected_results)
         self._assert_resultset_equals_expected(redis_graph.query(query, params), query_info)
 
@@ -79,7 +79,7 @@ class testParams(FlowTestsBase):
         params = {'name': 'a'}
         query = "MATCH (n :Person {name:$name}) RETURN n"
         expected_results = [[p0]]
-            
+
         query_info = QueryInfo(query = query, description="Tests expression on param", expected_result = expected_results)
         self._assert_resultset_equals_expected(redis_graph.query(query, params), query_info)
 
@@ -87,7 +87,7 @@ class testParams(FlowTestsBase):
         params = {'skip': 1, 'limit': 1}
         query = "UNWIND [1,2,3] AS X RETURN X SKIP $skip LIMIT $limit"
         expected_results = [[2]]
-            
+
         query_info = QueryInfo(query = query, description="Tests skip limit as params", expected_result = expected_results)
         self._assert_resultset_equals_expected(redis_graph.query(query, params), query_info)
 
@@ -149,3 +149,9 @@ class testParams(FlowTestsBase):
         plan = redis_graph.execution_plan(query, params=params)
         self.env.assertIn('NodeByIdSeek', plan)
 
+    def test_escaped_parameter_name(self):
+        params = {'`escaped:param`': 5}
+        query = "RETURN $`escaped:param`"
+        actual_result = redis_graph.query(query, params)
+        expected_result = [[5]]
+        self.env.assertEqual(actual_result.result_set, expected_result)

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -564,3 +564,12 @@ class testQueryValidationFlow(FlowTestsBase):
             except redis.exceptions.ResponseError as e:
                 pass
 
+    def test38_backtick_escaping(self):
+        # Strings interpolated in backticks should be able to include special characters
+        queries = ["WITH 'str' AS `backtick:string` RETURN `backtick:string`",
+                   "CYPHER `backtick:string`='str' RETURN $`backtick:string`"]
+
+        expected_result = [['str']]
+        for q in queries:
+            actual_result = redis_graph.query(q)
+            self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
This PR resolves https://github.com/RedisGraph/redisgraph-py/issues/66#issuecomment-1007189917