### PR TITLE
Add support for keys() function

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -641,6 +641,7 @@ This section contains information on all supported functions from the Cypher que
 | endNode()           | Returns the destination node of a relationship.                             |
 | id()                | Returns the internal ID of a relationship or node (which is not immutable.) |
 | hasLabels()         | Returns true if input node contains all specified labels, otherwise false.  |
+| keys()              | Returns the array of keys contained in the given map, node, or edge.        |
 | labels()            | Returns a string representation of the label of a node.                     |
 | startNode()         | Returns the source node of a relationship.                                  |
 | timestamp()         | Returns the the amount of milliseconds since epoch.                         |

--- a/src/arithmetic/map_funcs/map_funcs.c
+++ b/src/arithmetic/map_funcs/map_funcs.c
@@ -10,6 +10,7 @@
 #include "../../errors.h"
 #include "../../util/arr.h"
 #include "../../datatypes/map.h"
+#include "../../graph/entities/graph_entity.h"
 
 SIValue AR_TOMAP(SIValue *argv, int argc) {
 	/* create a new SIMap object
@@ -40,6 +41,22 @@ SIValue AR_TOMAP(SIValue *argv, int argc) {
 	return map;
 }
 
+SIValue AR_KEYS(SIValue *argv, int argc) {
+	ASSERT(argc == 1);
+	switch(SI_TYPE(argv[0])) {
+		case T_NULL:
+			return SI_NullVal();
+		case T_NODE:
+		case T_EDGE:
+			return GraphEntity_Keys(argv[0].ptrval);
+		case T_MAP:
+			return Map_Keys(argv[0]);
+		default:
+			ASSERT(false);
+	}
+	return SI_NullVal();
+}
+
 void Register_MapFuncs() {
 	SIType *types;
 	AR_FuncDesc *func_desc;
@@ -47,6 +64,11 @@ void Register_MapFuncs() {
 	types = array_new(SIType, 1);
 	array_append(types, SI_ALL);
 	func_desc = AR_FuncDescNew("tomap", AR_TOMAP, 0, VAR_ARG_LEN, types, true, false);
+	AR_RegFunc(func_desc);
+
+	types = array_new(SIType, 1);
+	array_append(types, T_NULL | T_MAP | T_NODE | T_EDGE);
+	func_desc = AR_FuncDescNew("keys", AR_KEYS, 1, 1, types, true, false);
 	AR_RegFunc(func_desc);
 }
 

--- a/src/datatypes/map.c
+++ b/src/datatypes/map.c
@@ -5,6 +5,7 @@
 */
 
 #include "map.h"
+#include "array.h"
 #include "../util/arr.h"
 #include "../util/qsort.h"
 #include "../util/strcmp.h"
@@ -187,18 +188,18 @@ uint Map_KeyCount
 	return array_len(map.map);
 }
 
-SIValue *Map_Keys
+SIValue Map_Keys
 (
 	SIValue map
 ) {
 	ASSERT(SI_TYPE(map) & T_MAP);
 
 	uint key_count = Map_KeyCount(map);
-	SIValue *keys = array_new(SIValue, key_count);
+	SIValue keys = SIArray_New(key_count);
 
 	for(uint i = 0; i < key_count; i++) {
 		Pair p = map.map[i];
-		array_append(keys, p.key);
+		SIArray_Append(&keys, p.key);
 	}
 
 	return keys;

--- a/src/datatypes/map.h
+++ b/src/datatypes/map.h
@@ -81,9 +81,9 @@ uint Map_KeyCount
 	SIValue map  // map to count number of keys in
 );
 
-// return all keys in map
-// caller should free returned array with array_free
-SIValue *Map_Keys
+// return an SIArray of all keys in map
+// caller should free returned array with SIArray_Free
+SIValue Map_Keys
 (
 	SIValue map  // map to extract keys from
 );

--- a/src/graph/entities/graph_entity.c
+++ b/src/graph/entities/graph_entity.c
@@ -12,6 +12,7 @@
 #include "../../query_ctx.h"
 #include "../graphcontext.h"
 #include "../../util/rmalloc.h"
+#include "../../datatypes/array.h"
 
 SIValue *PROPERTY_NOTFOUND = &(SIValue) {
 	.longval = 0, .type = T_NULL
@@ -123,6 +124,16 @@ bool GraphEntity_SetProperty(const GraphEntity *e, Attribute_ID attr_id, SIValue
 	SIValue_Free(*current);
 	*current = SI_CloneValue(value);
 	return true;
+}
+
+SIValue GraphEntity_Keys(const GraphEntity *e) {
+	GraphContext *gc = QueryCtx_GetGraphCtx();
+	SIValue keys = SIArray_New(ENTITY_PROP_COUNT(e));
+	for(int i = 0; i < e->entity->prop_count; i++) {
+		const char *key = GraphContext_GetAttributeString(gc, ENTITY_PROPS(e)[i].id);
+		SIArray_Append(&keys, SI_ConstStringVal(key));
+	}
+	return keys;
 }
 
 size_t GraphEntity_PropertiesToString(const GraphEntity *e, char **buffer, size_t *bufferLen,

--- a/src/graph/entities/graph_entity.h
+++ b/src/graph/entities/graph_entity.h
@@ -78,6 +78,9 @@ SIValue *GraphEntity_GetProperty(const GraphEntity *e, Attribute_ID attr_id);
 /* Updates existing attribute value, return true if property been updated. */
 bool GraphEntity_SetProperty(const GraphEntity *e, Attribute_ID attr_id, SIValue value);
 
+// returns an SIArray of all keys in graph entity properties
+SIValue GraphEntity_Keys(const GraphEntity *e);
+
 /* Prints the graph entity into a buffer, returns what is the string length, buffer can be re-allocated at need. */
 void GraphEntity_ToString(const GraphEntity *e, char **buffer, size_t *bufferLen,
 						  size_t *bytesWritten,

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -158,7 +158,7 @@ class testFunctionCallsFlow(FlowTestsBase):
         actual_result = graph.query(query)
         expected_result = [[0, 1], [False, 1], ["false", 1], ['0', 1]]
         self.env.assertEquals(actual_result.result_set, expected_result)
-    
+
     def test09_static_aggregation(self):
         query = "RETURN count(*)"
         actual_result = graph.query(query)
@@ -404,25 +404,25 @@ class testFunctionCallsFlow(FlowTestsBase):
         self.env.assertEquals(actual_result.result_set, expected_result)
 
     def test19_has_labels(self):
-        # Test existing label 
+        # Test existing label
         query = """MATCH (n) WHERE n:person RETURN n.name"""
         actual_result = graph.query(query)
         expected_result = [['Roi'], ['Alon'], ['Ailon'], ['Boaz']]
         self.env.assertEquals(actual_result.result_set, expected_result)
 
-        # Test not existing label 
+        # Test not existing label
         query = """MATCH (n) WHERE n:L RETURN n.name"""
         actual_result = graph.query(query)
         expected_result = []
         self.env.assertEquals(actual_result.result_set, expected_result)
 
-        # Test multi label 
+        # Test multi label
         query = """MATCH (n) WHERE n:person:L RETURN n.name"""
         actual_result = graph.query(query)
         expected_result = []
         self.env.assertEquals(actual_result.result_set, expected_result)
 
-        # Test or between different labels label 
+        # Test or between different labels label
         query = """MATCH (n) WHERE n:person OR n:L RETURN n.name"""
         actual_result = graph.query(query)
         expected_result = [['Roi'], ['Alon'], ['Ailon'], ['Boaz']]
@@ -440,3 +440,37 @@ class testFunctionCallsFlow(FlowTestsBase):
             graph.query(query)
         except redis.ResponseError as e:
             self.env.assertContains("Type mismatch: expected String but was Integer", str(e))
+
+    def test20_keys(self):
+        # Test retrieving keys of a nested map
+        query = """RETURN keys({a: 5, b: 10})"""
+        actual_result = graph.query(query)
+        expected_result = [[['a', 'b']]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        # Test retrieving keys of a map reference
+        query = """WITH {a: 5, b: 10} AS map RETURN keys(map)"""
+        actual_result = graph.query(query)
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        # Test retrieving keys of a node
+        query = """MATCH (n:person {name: 'Roi'}) RETURN keys(n)"""
+        actual_result = graph.query(query)
+        expected_result = [[['name', 'val']]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        # Test retrieving keys of an (empty) edge
+        query = """MATCH (:person {name: 'Roi'})-[e:works_with]->(:person {name: 'Alon'}) RETURN keys(e)"""
+        actual_result = graph.query(query)
+        expected_result = [[[]]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        # Test a null input
+        query = """WITH NULL AS map RETURN keys(map)"""
+        actual_result = graph.query(query)
+        expected_result = [[None]]
+        self.env.assertEquals(actual_result.result_set, expected_result)
+
+        # Test trying to retrieve keys of an invalid type
+        query = """WITH 10 AS map RETURN keys(map)"""
+        self.expect_type_error(query)

--- a/tests/unit/test_map.cpp
+++ b/tests/unit/test_map.cpp
@@ -14,6 +14,7 @@ extern "C" {
 #include "../../src/util/arr.h"
 #include "../../src/util/rmalloc.h"
 #include "../../src/datatypes/map.h"
+#include "../../src/datatypes/array.h"
 
 #ifdef __cplusplus
 }
@@ -35,9 +36,9 @@ TEST_F(MapTest, empty_map) {
 
 	ASSERT_EQ(0, Map_KeyCount(map));
 
-	SIValue *keys = Map_Keys(map);
-	ASSERT_EQ(0, array_len(keys));
-	array_free(keys);
+	SIValue keys = Map_Keys(map);
+	ASSERT_EQ(0, SIArray_Length(keys));
+	SIArray_Free(keys);
 
 	//--------------------------------------------------------------------------
 	// try getting a key
@@ -97,14 +98,15 @@ TEST_F(MapTest, map_add) {
 	}
 
 	// verify keys
-	SIValue *stored_keys = Map_Keys(map);
-	ASSERT_EQ(array_len(stored_keys), 3);
+	SIValue stored_keys = Map_Keys(map);
+	ASSERT_EQ(SIArray_Length(stored_keys), 3);
 	for(int i = 0; i < 3; i++) {
-		ASSERT_TRUE(strcmp(keys[i].stringval, stored_keys[i].stringval) == 0);
+		SIValue key = SIArray_Get(stored_keys, i);
+		ASSERT_TRUE(strcmp(keys[i].stringval, key.stringval) == 0);
 	}
 
 	// clean up
-	array_free(stored_keys);
+	SIArray_Free(stored_keys);
 	Map_Free(map);
 }
 
@@ -147,11 +149,11 @@ TEST_F(MapTest, map_remove) {
 		ASSERT_FALSE(Map_Get(map, keys[0], &v));
 	}
 
-	SIValue *stored_keys = Map_Keys(map);
-	ASSERT_EQ(0, array_len(stored_keys));
+	SIValue stored_keys = Map_Keys(map);
+	ASSERT_EQ(0, SIArray_Length(stored_keys));
 
 	// clean up
-	array_free(stored_keys);
+	SIArray_Free(stored_keys);
 	Map_Free(map);
 }
 


### PR DESCRIPTION
This PR adds a `keys()` function that accepts map, node, and edge inputs and returns an array of all the keys the input contains.
Resolves #2098 