### PR TITLE
return NULL when trying to retrieve an out of bounds item

### DIFF
--- a/src/util/datablock/datablock.c
+++ b/src/util/datablock/datablock.c
@@ -150,7 +150,8 @@ void DataBlock_Ensure(DataBlock *dataBlock, uint64_t idx) {
 void *DataBlock_GetItem(const DataBlock *dataBlock, uint64_t idx) {
 	ASSERT(dataBlock != NULL);
 
-	ASSERT(!_DataBlock_IndexOutOfBounds(dataBlock, idx));
+	// return NULL if idx is out of bounds
+	if(_DataBlock_IndexOutOfBounds(dataBlock, idx)) return NULL;
 
 	DataBlockItemHeader *item_header = DataBlock_GetItemHeader(dataBlock, idx);
 

--- a/tests/flow/test_node_by_id.py
+++ b/tests/flow/test_node_by_id.py
@@ -239,3 +239,4 @@ class testNodeByIDFlow(FlowTestsBase):
             resultset = redis_graph.query(query).result_set        
             self.env.assertEquals(len(resultset), 0)    # Expecting no results.
             self.env.assertIn("Node By Label and ID Scan", redis_graph.execution_plan(query))
+


### PR DESCRIPTION
Resolves #2119
Covered by: `tests/flow/test_node_by_id.py : test_for_none_existing_entity_ids`