### PR TITLE
Fix transfer of SIValue ownership in DISTINCT function

### DIFF
--- a/src/arithmetic/conditional_funcs/conditional_funcs.c
+++ b/src/arithmetic/conditional_funcs/conditional_funcs.c
@@ -80,7 +80,7 @@ SIValue AR_COALESCE(SIValue *argv, int argc) {
 // otherwise `X` is returned and added to to the set.
 SIValue AR_DISTINCT(SIValue *argv, int argc) {
 	set *set = argv[1].ptrval;
-	if(Set_Add(set, argv[0])) return SI_ConstValue(argv);
+	if(Set_Add(set, argv[0])) return SI_TransferOwnership(argv);
 	return SI_NullVal();
 }
 

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -474,3 +474,10 @@ class testFunctionCallsFlow(FlowTestsBase):
         # Test trying to retrieve keys of an invalid type
         query = """WITH 10 AS map RETURN keys(map)"""
         self.expect_type_error(query)
+
+    def test21_distinct_memory_management(self):
+        # validate behavior of the DISTINCT function with allocated values
+        query = """MATCH (a {val: 0}) RETURN collect(DISTINCT a { .name })"""
+        actual_result = graph.query(query)
+        expected_result = [[[{'name': 'Roi'}]]]
+        self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
This PR fixes an invalid assumption about SIValue memory scope in the `Distinct` function.

Resolves #2171