### PR TITLE
Add "dsl" field for query arguments of commands

### DIFF
--- a/commands.json
+++ b/commands.json
@@ -8,7 +8,8 @@
 			},
 			{
 				"name": "query",
-				"type": "string"
+				"type": "string",
+				"dsl": "cypher"
 			}
 		],
 		"since": "1.0.0",
@@ -23,7 +24,8 @@
 			},
 			{
 				"name": "query",
-				"type": "string"
+				"type": "string",
+				"dsl": "cypher"
 			}
 		],
 		"since": "2.2.8",
@@ -49,7 +51,8 @@
 			},
 			{
 				"name": "query",
-				"type": "string"
+				"type": "string",
+				"dsl": "cypher"
 			}
 		],
 		"since": "2.0.0",
@@ -64,7 +67,8 @@
 			},
 			{
 				"name": "query",
-				"type": "string"
+				"type": "string",
+				"dsl": "cypher"
 			}
 		],
 		"since": "2.0.0",


### PR DESCRIPTION
In [Redisinsight](https://github.com/RedisInsight/RedisInsight) we planning to support different syntaxes for code editor.
![Redisinsight Code Editor](https://i.ibb.co/yRy8n1N/Redisinsight-code-editor.png)
And in order to achieve this, we need to understand exactly where the other syntax is used