### PR TITLE
Fix leak when MAX_QUEUED_QUERIES is used.

### DIFF
--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -275,7 +275,7 @@ static void _DelegateWriter(GraphQueryCtx *gq_ctx) {
 	gq_ctx->command_ctx->thread = EXEC_THREAD_WRITER;
 
 	// dispatch work to the writer thread
-	int res = ThreadPools_AddWorkWriter(_ExecuteQuery, gq_ctx);
+	int res = ThreadPools_AddWorkWriter(_ExecuteQuery, gq_ctx, 0);
 	ASSERT(res == 0);
 }
 

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -39,6 +39,8 @@ static inline void _GraphContext_DecreaseRefCount(GraphContext *gc) {
 
 		if(async_delete) {
 			// Async delete
+			// add deletion task to pool using force mode
+			// we can't lose this task in-case pool's queue is full
 			ThreadPools_AddWorkWriter(_GraphContext_Free, gc, 1);
 		} else {
 			// Sync delete

--- a/src/graph/graphcontext.c
+++ b/src/graph/graphcontext.c
@@ -39,7 +39,7 @@ static inline void _GraphContext_DecreaseRefCount(GraphContext *gc) {
 
 		if(async_delete) {
 			// Async delete
-			ThreadPools_AddWorkWriter(_GraphContext_Free, gc);
+			ThreadPools_AddWorkWriter(_GraphContext_Free, gc, 1);
 		} else {
 			// Sync delete
 			_GraphContext_Free(gc);

--- a/src/util/thpool/pools.c
+++ b/src/util/thpool/pools.c
@@ -153,12 +153,13 @@ int ThreadPools_AddWorkReader
 int ThreadPools_AddWorkWriter
 (
 	void (*function_p)(void *),
-	void *arg_p
+	void *arg_p,
+	int force
 ) {
 	ASSERT(_writers_thpool != NULL);
 
 	// make sure there's enough room in thread pool queue
-	if(thpool_queue_full(_writers_thpool)) return THPOOL_QUEUE_FULL;
+	if(thpool_queue_full(_writers_thpool) && !force) return THPOOL_QUEUE_FULL;
 
 	return thpool_add_work(_writers_thpool, function_p, arg_p);
 }

--- a/src/util/thpool/pools.h
+++ b/src/util/thpool/pools.h
@@ -68,7 +68,8 @@ int ThreadPools_AddWorkReader
 int ThreadPools_AddWorkWriter
 (
 	void (*function_p)(void *),
-	void *arg_p
+	void *arg_p,
+	int force
 );
 
 // sets the limit on max queued queries in each thread pool

--- a/src/util/thpool/pools.h
+++ b/src/util/thpool/pools.h
@@ -67,9 +67,9 @@ int ThreadPools_AddWorkReader
 // add a write task
 int ThreadPools_AddWorkWriter
 (
-	void (*function_p)(void *),
-	void *arg_p,
-	int force
+	void (*function_p)(void *),  // function to run
+	void *arg_p,                 // function arguments
+	int force                    // true will add task even if internal queue is full
 );
 
 // sets the limit on max queued queries in each thread pool

--- a/tests/unit/test_thread_pools.cpp
+++ b/tests/unit/test_thread_pools.cpp
@@ -58,7 +58,7 @@ TEST_F(ThreadPoolsTest, ThreadPools_ThreadID) {
 		int offset = i + READER_COUNT + 1;
 		ASSERT_EQ(0,
 				ThreadPools_AddWorkWriter(get_thread_friendly_id,
-					thread_ids + offset));
+					thread_ids + offset, 0));
 	}
 
 	// wait for all threads


### PR DESCRIPTION
When trying to add an async graph free job to the writers queue, the queue might be full (because of MAX_QUEUED_QUERIES configuration). This will cause the free job to be lost which will cause the graph to leak.

Added a force option to ThreadPools_AddWorkWriter so that the free jobs will not be lost.

@swilly22 I am not sure if this is the correct fix and if there are any other things to consider, please let me know what you think.