### PR TITLE
Fix invalid memory access after free.

### DIFF
--- a/src/module_event_handlers.c
+++ b/src/module_event_handlers.c
@@ -185,10 +185,6 @@ static void _FlushDBHandler(RedisModuleCtx *ctx, RedisModuleEvent eid, uint64_t 
 	if(eid.id == REDISMODULE_EVENT_FLUSHDB &&
 	   subevent == REDISMODULE_SUBEVENT_FLUSHDB_START) {
 		aux_field_counter = 0;
-		uint count = array_len(graphs_in_keyspace);
-		for (size_t i = 0; i < count; i++) {
-			GraphContext_Delete(graphs_in_keyspace[i]);
-		}
 	}
 }
 


### PR DESCRIPTION
On flushall, Graphs were freed twice:
1. On flush events handler
2. When the graph key was deleted by Redis

This caused invalid memory accesses on the second free, and on rare cases it caused crashes.

Avoid free the graphs on the flush event, free it only when the key is deleted by Redis.