### PR TITLE
Fix crash on parser errors in queries with RETURN *

### DIFF
--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -571,7 +571,7 @@ cypher_parse_result_t *parse_query(const char *query) {
 		return NULL;
 	}
 
-	AST_RewriteStarProjections(result);
+	if(!AST_ContainsErrors(result)) AST_RewriteStarProjections(result);
 
 	if(AST_Validate_Query(result) != AST_VALID) {
 		parse_result_free(result);

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -571,7 +571,14 @@ cypher_parse_result_t *parse_query(const char *query) {
 		return NULL;
 	}
 
-	if(!AST_ContainsErrors(result)) AST_RewriteStarProjections(result);
+	// in case ast contains any errors, report them and return
+	if(AST_ContainsErrors(result)) {
+		AST_ReportErrors(result);
+		parse_result_free(result);
+		return NULL;
+	}
+
+	AST_RewriteStarProjections(result);
 
 	if(AST_Validate_Query(result) != AST_VALID) {
 		parse_result_free(result);

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -587,10 +587,10 @@ cypher_parse_result_t *parse_query(const char *query) {
 	// e.g. MATCH (a), (b) RETURN *
 	// will be rewritten as:
 	//  MATCH (a), (b) RETURN a, b
-	AST_RewriteStarProjections(result);
+	bool rerun_validation = AST_RewriteStarProjections(result);
 
-	// TODO: only perform additional validations if there's been a rewrite!
-	if(AST_Validate_Query(result) != AST_VALID) {
+	// only perform validations again if there's been a rewrite
+	if(rerun_validation && AST_Validate_Query(result) != AST_VALID) {
 		parse_result_free(result);
 		return NULL;
 	}

--- a/src/ast/ast.c
+++ b/src/ast/ast.c
@@ -7,7 +7,7 @@
 #include "ast.h"
 #include <pthread.h>
 
-#include "../RG.h"
+#include "RG.h"
 #include "../errors.h"
 #include "../util/arr.h"
 #include "../query_ctx.h"
@@ -578,8 +578,18 @@ cypher_parse_result_t *parse_query(const char *query) {
 		return NULL;
 	}
 
+	if(AST_Validate_Query(result) != AST_VALID) {
+		parse_result_free(result);
+		return NULL;
+	}
+
+	// rewrite '*' projections
+	// e.g. MATCH (a), (b) RETURN *
+	// will be rewritten as:
+	//  MATCH (a), (b) RETURN a, b
 	AST_RewriteStarProjections(result);
 
+	// TODO: only perform additional validations if there's been a rewrite!
 	if(AST_Validate_Query(result) != AST_VALID) {
 		parse_result_free(result);
 		return NULL;

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -33,6 +33,10 @@ typedef struct {
 // Checks to see if libcypher-parser reported any errors.
 bool AST_ContainsErrors(const cypher_parse_result_t *result);
 
+// reports first encountered error
+// asserts if there are no errors!
+void AST_ReportErrors(const cypher_parse_result_t *result);
+
 // Make sure the parse result and the AST tree pass all validations.
 AST_Validation AST_Validate_Query(const cypher_parse_result_t *result);
 

--- a/src/ast/ast_rewrite_star_projections.c
+++ b/src/ast/ast_rewrite_star_projections.c
@@ -171,15 +171,6 @@ static void replace_clause
 	cypher_astnode_type_t t = cypher_astnode_type(clause);
 
 	//--------------------------------------------------------------------------
-	// return early in the case of a parse error
-	//--------------------------------------------------------------------------
-	uint child_count = cypher_astnode_nchildren(root);
-	for(uint i = 0; i < child_count; i++) {
-		const cypher_astnode_t *to = cypher_astnode_get_child(root, i);
-		if(cypher_astnode_type(to) == CYPHER_AST_ERROR) return;
-	}
-
-	//--------------------------------------------------------------------------
 	// collect identifiers
 	//--------------------------------------------------------------------------
 	rax *identifiers = raxNew();

--- a/src/ast/ast_rewrite_star_projections.c
+++ b/src/ast/ast_rewrite_star_projections.c
@@ -171,6 +171,15 @@ static void replace_clause
 	cypher_astnode_type_t t = cypher_astnode_type(clause);
 
 	//--------------------------------------------------------------------------
+	// return early in the case of a parse error
+	//--------------------------------------------------------------------------
+	uint child_count = cypher_astnode_nchildren(root);
+	for(uint i = 0; i < child_count; i++) {
+		const cypher_astnode_t *to = cypher_astnode_get_child(root, i);
+		if(cypher_astnode_type(to) == CYPHER_AST_ERROR) return;
+	}
+
+	//--------------------------------------------------------------------------
 	// collect identifiers
 	//--------------------------------------------------------------------------
 	rax *identifiers = raxNew();

--- a/src/ast/ast_rewrite_star_projections.c
+++ b/src/ast/ast_rewrite_star_projections.c
@@ -80,6 +80,10 @@ static void _collect_with_projections
 			// so the projection itself must be an identifier
 			identifier_node = cypher_ast_projection_get_expression(projection);
 			ASSERT(cypher_astnode_type(identifier_node) == CYPHER_AST_IDENTIFIER);
+		} else {
+			// do not include empty projections, which may have been made to
+			// handle the MATCH () WITH * case
+			if(!strcmp(cypher_ast_identifier_get_name(identifier_node), "")) continue;
 		}
 		const char *identifier = cypher_ast_identifier_get_name(identifier_node);
 		raxTryInsert(identifiers, (unsigned char *)identifier,

--- a/src/ast/ast_rewrite_star_projections.c
+++ b/src/ast/ast_rewrite_star_projections.c
@@ -363,17 +363,18 @@ static void replace_clause
 	cypher_ast_query_set_clause(root, new_clause, scope_end);
 }
 
-void AST_RewriteStarProjections
+bool AST_RewriteStarProjections
 (
 	cypher_parse_result_t *result
 ) {
+	bool rewritten = false;
 	// retrieve the statement node
 	const cypher_astnode_t *statement = cypher_parse_result_get_root(result, 0);
-	if(cypher_astnode_type(statement) != CYPHER_AST_STATEMENT) return;
+	if(cypher_astnode_type(statement) != CYPHER_AST_STATEMENT) return rewritten;
 
 	// retrieve the root query node from the statement
 	const cypher_astnode_t *root = cypher_ast_statement_get_body(statement);
-	if(cypher_astnode_type(root) != CYPHER_AST_QUERY) return;
+	if(cypher_astnode_type(root) != CYPHER_AST_QUERY) return rewritten;
 
 	// rewrite all WITH * / RETURN * clauses to include all aliases
 	uint  scope_start   =  0;
@@ -392,10 +393,13 @@ void AST_RewriteStarProjections
 			// clause contains a star projection, replace it
 			replace_clause((cypher_astnode_t *)root, (cypher_astnode_t *)clause,
 						   scope_start, i);
+			rewritten = true;
 		}
 
 		// update scope start
 		scope_start = i;
 	}
+
+	return rewritten;
 }
 

--- a/src/ast/ast_rewrite_star_projections.h
+++ b/src/ast/ast_rewrite_star_projections.h
@@ -8,5 +8,7 @@
 
 #include "ast.h"
 
-void AST_RewriteStarProjections(cypher_parse_result_t *result);
+// rewrite WITH/RETURN * clauses in query to project explicit identifiers,
+// returning true if a rewrite has been performed
+bool AST_RewriteStarProjections(cypher_parse_result_t *result);
 

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1354,33 +1354,32 @@ static AST_Validation _Validate_Aliases_Defined(const AST *ast) {
 }
 
 // Report encountered errors by libcypher-parser.
-static void _AST_ReportErrors(const cypher_parse_result_t *result) {
-	uint nerrors = cypher_parse_result_nerrors(result);
-	// We are currently only reporting the first error to simplify the response.
-	if(nerrors > 1) nerrors = 1;
-	for(uint i = 0; i < nerrors; i++) {
-		const cypher_parse_error_t *error = cypher_parse_result_get_error(result, i);
+void AST_ReportErrors(const cypher_parse_result_t *result) {
+	ASSERT(cypher_parse_result_nerrors(result) > 0);
 
-		// Get the position of an error.
-		struct cypher_input_position errPos = cypher_parse_error_position(error);
+	// report first encountered error
+	const cypher_parse_error_t *error =
+		cypher_parse_result_get_error(result, 0);
 
-		// Get the error message of an error.
-		const char *errMsg = cypher_parse_error_message(error);
+	// Get the position of an error.
+	struct cypher_input_position errPos = cypher_parse_error_position(error);
 
-		// Get the error context of an error.
-		// This returns a pointer to a null-terminated string, which contains a
-		// section of the input around where the error occurred, that is limited
-		// in length and suitable for presentation to a user.
-		const char *errCtx = cypher_parse_error_context(error);
+	// Get the error message of an error.
+	const char *errMsg = cypher_parse_error_message(error);
 
-		// Get the offset into the context of an error.
-		// Identifies the point of the error within the context string, allowing
-		// this to be reported to the user, typically with an arrow pointing to the
-		// invalid character.
-		size_t errCtxOffset = cypher_parse_error_context_offset(error);
-		ErrorCtx_SetError("errMsg: %s line: %u, column: %u, offset: %zu errCtx: %s errCtxOffset: %zu",
-						  errMsg, errPos.line, errPos.column, errPos.offset, errCtx, errCtxOffset);
-	}
+	// Get the error context of an error.
+	// This returns a pointer to a null-terminated string, which contains a
+	// section of the input around where the error occurred, that is limited
+	// in length and suitable for presentation to a user.
+	const char *errCtx = cypher_parse_error_context(error);
+
+	// Get the offset into the context of an error.
+	// Identifies the point of the error within the context string, allowing
+	// this to be reported to the user, typically with an arrow pointing to the
+	// invalid character.
+	size_t errCtxOffset = cypher_parse_error_context_offset(error);
+	ErrorCtx_SetError("errMsg: %s line: %u, column: %u, offset: %zu errCtx: %s errCtxOffset: %zu",
+					  errMsg, errPos.line, errPos.column, errPos.offset, errCtx, errCtxOffset);
 }
 
 // checks if set items contains non-alias referenes in lhs
@@ -1646,10 +1645,7 @@ bool AST_ContainsErrors(const cypher_parse_result_t *result) {
 static AST_Validation _AST_Validate_ParseResultRoot(const cypher_parse_result_t *result,
 													int *index) {
 	// Check for failures in libcypher-parser
-	if(AST_ContainsErrors(result)) {
-		_AST_ReportErrors(result);
-		return AST_INVALID;
-	}
+	ASSERT(AST_ContainsErrors(result) == false);
 
 	uint nroots = cypher_parse_result_nroots(result);
 	for(uint i = 0; i < nroots; i++) {

--- a/src/commands/execution_ctx.c
+++ b/src/commands/execution_ctx.c
@@ -50,7 +50,8 @@ static AST *_ExecutionCtx_ParseAST(const char *query_string,
 								   cypher_parse_result_t *params_parse_result) {
 	cypher_parse_result_t *query_parse_result = parse_query(query_string);
 	// If no output from the parser, the query is not valid.
-	if(!query_parse_result) {
+	if(query_parse_result == NULL ||
+			ErrorCtx_EncounteredError()) {
 		parse_result_free(params_parse_result);
 		return NULL;
 	}

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -596,39 +596,26 @@ class testQueryValidationFlow(FlowTestsBase):
     def test40_compile_time_errors_in_star_projections(self):
         # validate that parser errors are handled correctly
         # in queries containing star projections
-        try:
-            query = """MATCH (a)-[r:]->(b) RETURN *"""
-            redis_graph.query(query)
-            self.env.assertTrue(False)
-        except redis.exceptions.ResponseError:
-            pass
-
-        try:
-            query = """MATCH (a)-[r:]->(b) WITH b RETURN *"""
-            redis_graph.query(query)
-            self.env.assertTrue(False)
-        except redis.exceptions.ResponseError:
-            pass
+        queries = ["MATCH (a)-[r:]->(b) RETURN *",
+                   "MATCH (a)-[r:]->(b) WITH b RETURN *"]
+        for query in queries:
+            try:
+                redis_graph.query(query)
+                self.env.assertTrue(False)
+            except redis.exceptions.ResponseError:
+                pass
 
         # check that AST validation errors are handled correctly
         # in queries containing star projections
-        try:
-            query = """WITH 1 RETURN *"""
-            redis_graph.query(query)
-            self.env.assertTrue(False)
-        except redis.exceptions.ResponseError:
-            pass
-
-        try:
-            query = """RETURN *"""
-            redis_graph.query(query)
-            self.env.assertTrue(False)
-        except redis.exceptions.ResponseError:
-            pass
-
-        try:
-            query = """CREATE () RETURN DISTINCT *"""
-            redis_graph.query(query)
-            self.env.assertTrue(False)
-        except redis.exceptions.ResponseError:
-            pass
+        queries = ["WITH 1 RETURN *",
+                   "RETURN *",
+                   "CREATE () RETURN DISTINCT *",
+                   "MATCH () WITH * RETURN z",
+                   "MATCH () WITH * RETURN *",
+                   "MATCH () WITH * WHERE n.v > 1 RETURN *"]
+        for query in queries:
+            try:
+                redis_graph.query(query)
+                self.env.assertTrue(False)
+            except redis.exceptions.ResponseError:
+                pass

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -593,7 +593,7 @@ class testQueryValidationFlow(FlowTestsBase):
             except redis.exceptions.ResponseError as e:
                 self.env.assertContains("query with more than one statement is not supported", str(e))
 
-    def test40_parser_errors_in_star_projections(self):
+    def test40_compile_time_errors_in_star_projections(self):
         # validate that parser errors are handled correctly
         # in queries containing star projections
         try:
@@ -605,6 +605,29 @@ class testQueryValidationFlow(FlowTestsBase):
 
         try:
             query = """MATCH (a)-[r:]->(b) WITH b RETURN *"""
+            redis_graph.query(query)
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError:
+            pass
+
+        # check that AST validation errors are handled correctly
+        # in queries containing star projections
+        try:
+            query = """WITH 1 RETURN *"""
+            redis_graph.query(query)
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError:
+            pass
+
+        try:
+            query = """RETURN *"""
+            redis_graph.query(query)
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError:
+            pass
+
+        try:
+            query = """CREATE () RETURN DISTINCT *"""
             redis_graph.query(query)
             self.env.assertTrue(False)
         except redis.exceptions.ResponseError:

--- a/tests/flow/test_query_validation.py
+++ b/tests/flow/test_query_validation.py
@@ -592,3 +592,20 @@ class testQueryValidationFlow(FlowTestsBase):
                 assert(False)
             except redis.exceptions.ResponseError as e:
                 self.env.assertContains("query with more than one statement is not supported", str(e))
+
+    def test40_parser_errors_in_star_projections(self):
+        # validate that parser errors are handled correctly
+        # in queries containing star projections
+        try:
+            query = """MATCH (a)-[r:]->(b) RETURN *"""
+            redis_graph.query(query)
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError:
+            pass
+
+        try:
+            query = """MATCH (a)-[r:]->(b) WITH b RETURN *"""
+            redis_graph.query(query)
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError:
+            pass

--- a/tests/flow/test_star_projections.py
+++ b/tests/flow/test_star_projections.py
@@ -145,19 +145,3 @@ class testStarProjections():
         query = """MATCH (a)-[]->(a) RETURN *, a"""
         actual_result = redis_graph.query(query)
         self.env.assertEqual(actual_result.result_set, expected)
-
-    # verify that parser errors are handled gracefully
-    def test05_invalid_query(self):
-        try:
-            query = """MATCH (a)-[r:]->(b) RETURN *"""
-            redis_graph.query(query)
-            self.env.assertTrue(False)
-        except redis.exceptions.ResponseError:
-            pass
-
-        try:
-            query = """MATCH (a)-[r:]->(b) WITH b RETURN *"""
-            redis_graph.query(query)
-            self.env.assertTrue(False)
-        except redis.exceptions.ResponseError:
-            pass

--- a/tests/flow/test_star_projections.py
+++ b/tests/flow/test_star_projections.py
@@ -145,3 +145,19 @@ class testStarProjections():
         query = """MATCH (a)-[]->(a) RETURN *, a"""
         actual_result = redis_graph.query(query)
         self.env.assertEqual(actual_result.result_set, expected)
+
+    # verify that parser errors are handled gracefully
+    def test05_invalid_query(self):
+        try:
+            query = """MATCH (a)-[r:]->(b) RETURN *"""
+            redis_graph.query(query)
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError:
+            pass
+
+        try:
+            query = """MATCH (a)-[r:]->(b) WITH b RETURN *"""
+            redis_graph.query(query)
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError:
+            pass


### PR DESCRIPTION
Error nodes exist at the clause level in libcypher-parser, which can make the clause index utilized by the `RETURN *` rewrite inaccurate.

This can simply be resolved by returning early if the clause index corresponds to an error node, as the query will immediately fail validation afterwards.

This issue can be seen in the sample query:
`MATCH (a)-[r:]->(b) RETURN *`