### PR TITLE
Enabled CI profilers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,18 @@ commands:
       module_path:
         type: string
         default: /workspace/$MODULE_ARTIFACT
+      profile_env:
+        type: string
+        default: "0"
+      benchmark_glob:
+        type: string
+        default: "*.yml"
+      triggering_env:
+        type: string
+        default: "circleci"
+      allowed_envs:
+        type: string
+        default: "oss-standalone"
     steps:
       - run:
           name: Install remote benchmark tool dependencies
@@ -113,7 +125,9 @@ commands:
             export AWS_SECRET_ACCESS_KEY=$PERFORMANCE_EC2_SECRET_KEY
             export AWS_DEFAULT_REGION=$PERFORMANCE_EC2_REGION
             export EC2_PRIVATE_PEM=$PERFORMANCE_EC2_PRIVATE_PEM
-
+            export PROFILE=<< parameters.profile_env >>
+            export BENCHMARK_GLOB=<< parameters.benchmark_glob >>
+            export PERF_CALLGRAPH_MODE="dwarf"
             redisbench-admin run-remote \
               --module_path << parameters.module_path >> \
               --github_actor << parameters.github_actor >> \
@@ -124,7 +138,11 @@ commands:
               --upload_results_s3 \
               --triggering_env circleci \
               --required-module graph \
-              --push_results_redistimeseries
+              --upload_results_s3 \
+              --triggering_env << parameters.triggering_env >> \
+              --fail_fast \
+              --push_results_redistimeseries \
+              --allowed-envs << parameters.allowed_envs >>
 
   platform-build-steps:
     parameters:
@@ -405,17 +423,6 @@ jobs:
           shell: /bin/bash -l -eo pipefail
           command: FUZZ_TIMEOUT=600 make fuzz
 
-  performance_ci_automation_not_integ:
-    docker:
-      - image: redisfab/rmbuilder:6.2.5-x64-bionic
-    steps:
-      - early-returns
-      - checkout
-      - install-prerequisites
-      - attach_workspace:
-          at: /workspace
-      - benchmark-automation
-
   performance_ci_automation:
     docker:
       - image: redisfab/rmbuilder:6.2.5-x64-bionic
@@ -430,6 +437,24 @@ jobs:
           command: |
             unzip `ls /workspace/$PACKAGE_NAME.Linux-ubuntu18.04-x86_64.*.zip |grep -v rce` -d /workspace/
       - benchmark-automation
+
+  performance_ci_automation_profiler:
+    docker:
+      - image: redisfab/rmbuilder:6.2.5-x64-bionic
+    steps:
+      - early-returns
+      - checkout
+      - install-prerequisites
+      - attach_workspace:
+          at: /workspace
+      - run:
+          name: Unzip module artifact
+          command: |
+            unzip `ls /workspace/$PACKAGE_NAME.Linux-ubuntu18.04-x86_64.*.zip |grep -v rce` -d /workspace/
+      - benchmark-automation:
+          profile_env: "1"
+          triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it
+
 
   nightly_performance_automation:
     docker:
@@ -447,6 +472,25 @@ jobs:
       - benchmark-automation:
           github_actor: "ci.nightly"
           module_path: "/root/project/src/$PACKAGE_NAME.so"
+
+  nightly_performance_automation_profiler:
+    docker:
+      - image: redisfab/rmbuilder:6.2.5-x64-bionic
+    steps:
+      - early-returns
+      - checkout-all
+      - install-prerequisites
+      - attach_workspace:
+          at: /workspace
+      - run:
+          name: Build artifact
+          shell: /bin/bash -l -eo pipefail
+          command: make
+      - benchmark-automation:
+          github_actor: "ci.nightly"
+          module_path: "/root/project/src/$PACKAGE_NAME.so"
+          profile_env: "1"
+          triggering_env: "circleci.profilers" # results generated with profilers attached are not mixed with the ones without it
 
 #----------------------------------------------------------------------------------------------------------------------------------
 
@@ -505,6 +549,15 @@ on-integ-and-version-tags: &on-integ-and-version-tags
         - master
         - /^\d+\.\d+.*$/
         - /^feature-.*$/
+    tags:
+      only: /^v[0-9].*/
+
+on-perf-tags: &on-perf-tags
+  filters:
+    branches:
+      only:
+        - master
+        - /^\d+\.\d+.*$/
         - /^perf-.*$/
     tags:
       only: /^v[0-9].*/
@@ -570,7 +623,12 @@ workflows:
             - build_macos
       - performance_ci_automation:
           <<: *context
-          <<: *on-integ-and-version-tags
+          <<: *on-perf-tags
+          requires:
+            - platform_build
+      - performance_ci_automation_profiler:
+          <<: *context
+          <<: *on-perf-tags
           requires:
             - platform_build
 
@@ -583,4 +641,6 @@ workflows:
               only: master
     jobs:
       - nightly_performance_automation:
+          <<: *context
+      - nightly_performance_automation_profiler:
           <<: *context


### PR DESCRIPTION
This PR enables a CI profiler setup with the same specs as the default benchmark setups. 
It attaches a profiler for 60 seconds to each benchmark run and produces a set of outputs by default that can be consulted at 
[CI profiler viewer Grafana dashboard](https://benchmarksrediscom.grafana.net/d/uRPZar57k/ci-profiler-viewer?orgId=1):


- Flame Graph
- Main THREAD Flame Graph
- perf report per dso
- perf report per dso,sym
- perf report per dso,sym with callgraph
- perf report per dso,sym,srcline
- perf report per dso,sym,srcline with callgraph
- perf report top self-cpu
- perf report top self-cpu (dso=)
- Identical stacks collapsed

Note: the results produced with a profiler attached are not used on the visualizations/regression analysis due to the profiler overhead impact.