### PR TITLE
Allow explicit variables to be returned after a WITH * projection

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1369,9 +1369,13 @@ static AST_Validation _Validate_Aliases_Defined(const AST *ast) {
 		res = _Validate_Aliases_DefinedInClause(clause, defined_aliases);
 		if(res != AST_VALID) break;
 		if(cypher_astnode_type(clause) == CYPHER_AST_WITH) {
-			// Each WITH clause marks the beginning of a new scope for defined aliases.
-			raxFree(defined_aliases);
-			defined_aliases = raxNew();
+			// each WITH clause marks the beginning of a new scope for defined aliases
+			// if the WITH clause contains a star projection, all variables from
+			// the previous scope are carried over
+			if(!cypher_ast_with_has_include_existing(clause)) {
+				raxFree(defined_aliases);
+				defined_aliases = raxNew();
+			}
 			_AST_GetDefinedIdentifiers(clause, defined_aliases);
 		}
 	}

--- a/tests/flow/test_star_projections.py
+++ b/tests/flow/test_star_projections.py
@@ -109,6 +109,12 @@ class testStarProjections():
         actual_result = redis_graph.query(query)
         self.env.assertEqual(actual_result.result_set, expected)
 
+        # test an explicit variable in the RETURN clause
+        # after a sequence of WITH * projections
+        query = """UNWIND range(1, 2) AS x UNWIND range(3, 4) AS y WITH * WITH * WITH * RETURN x, y"""
+        actual_result = redis_graph.query(query)
+        self.env.assertEqual(actual_result.result_set, expected)
+
         query = """UNWIND range(1, 2) AS x UNWIND range(3, 4) AS y WITH * SKIP 1 LIMIT 2 RETURN *"""
         actual_result = redis_graph.query(query)
         expected = [[1, 4],
@@ -126,6 +132,19 @@ class testStarProjections():
         query = """UNWIND range(1, 2) AS x WITH * WHERE false RETURN *"""
         actual_result = redis_graph.query(query)
         expected = []
+        self.env.assertEqual(actual_result.result_set, expected)
+
+        # test a WITH * projection that also introduces a new variable
+        query = """UNWIND range(1, 2) AS x WITH *, 3 AS y RETURN *"""
+        actual_result = redis_graph.query(query)
+        expected = [[1, 3],
+                    [2, 3]]
+        self.env.assertEqual(actual_result.result_set, expected)
+
+        # test a WITH * projection that also introduces a new variable
+        # and is explicitly returned
+        query = """UNWIND range(1, 2) AS x WITH *, 3 AS y RETURN x, y"""
+        actual_result = redis_graph.query(query)
         self.env.assertEqual(actual_result.result_set, expected)
 
     # verify that duplicate aliases only result in a single column


### PR DESCRIPTION
Resolves an error in which queries of the form:
`MATCH (a) WITH * RETURN a`
erroneously would report the variable `a` as being undefined.