### PR TITLE
improve the perf of matrix label population

### DIFF
--- a/src/serializers/decoders/current/v11/decode_graph.c
+++ b/src/serializers/decoders/current/v11/decode_graph.c
@@ -197,7 +197,7 @@ GraphContext *RdbLoadGraphContext_v11
 		Graph *g = gc->g;
 
 		// set the node label matrix
-		Serializer_Graph_SetNodeLabels(gc->g);
+		Serializer_Graph_SetNodeLabels(g);
 
 		// revert to default synchronization behavior
 		Graph_SetMatrixPolicy(g, SYNC_POLICY_FLUSH_RESIZE);

--- a/src/serializers/decoders/current/v11/decode_graph.c
+++ b/src/serializers/decoders/current/v11/decode_graph.c
@@ -196,6 +196,9 @@ GraphContext *RdbLoadGraphContext_v11
 	if(GraphDecodeContext_Finished(gc->decoding_context)) {
 		Graph *g = gc->g;
 
+		// set the node label matrix
+		Serializer_Graph_SetNodeLabels(gc->g);
+
 		// revert to default synchronization behavior
 		Graph_SetMatrixPolicy(g, SYNC_POLICY_FLUSH_RESIZE);
 		Graph_ApplyAllPending(g, true);

--- a/src/serializers/decoders/current/v11/decode_graph_entities.c
+++ b/src/serializers/decoders/current/v11/decode_graph_entities.c
@@ -128,8 +128,6 @@ void RdbLoadNodes_v11
 			if(s->fulltextIdx) Index_IndexNode(s->fulltextIdx, &n);
 		}
 	}
-
-	Serializer_Graph_SetNodeLabels(gc->g);
 }
 
 void RdbLoadDeletedNodes_v11

--- a/src/serializers/graph_extensions.c
+++ b/src/serializers/graph_extensions.c
@@ -62,6 +62,7 @@ void Serializer_Graph_SetNode
 
 // computes NodeLabelMarix out of label matrices
 // NodeLabelMatrix[:i] = diag(LabelMatrix[i])
+// must be called once after all virtual keys loaded for perf
 void Serializer_Graph_SetNodeLabels
 (
 	Graph *g
@@ -82,8 +83,10 @@ void Serializer_Graph_SetNodeLabels
 
 		GxB_Vector_diag(v, m, 0, NULL);
 
-		GxB_Col_subassign(node_labels_m, NULL, NULL, v, GrB_ALL, 0, i, NULL);
+		GxB_Row_subassign(node_labels_m, NULL, NULL, v, i, GrB_ALL, 0, NULL);
 	}
+
+	GrB_transpose(node_labels_m, NULL, NULL, node_labels_m, NULL);
 
 	GrB_Vector_free(&v);
 }

--- a/src/serializers/graph_extensions.c
+++ b/src/serializers/graph_extensions.c
@@ -75,6 +75,12 @@ void Serializer_Graph_SetNodeLabels
 	RG_Matrix node_labels   = Graph_GetNodeLabelMatrix(g);
 	GrB_Matrix node_labels_m = RG_MATRIX_M(node_labels);
 
+#if RG_DEBUG
+	GrB_Index nvals;
+	GrB_Matrix_nvals(&nvals, node_labels_m);
+	ASSERT(nvals == 0);
+#endif
+
 	GrB_Vector_new(&v, GrB_BOOL, node_count);
 
 	for(int i = 0; i < label_count; i++) {


### PR DESCRIPTION
this fix improve perf of loading an rdb of graph created with the below query
GRAPH.QUERY x "UNWIND range(1, 1000000) AS x CREATE (:N1), (:N2), (:N3), (:N4), (:N5)"
master: 22.541 seconds
this fix: 3.536 seconds