### PR TITLE
Parameters list does not end with ; anymore

### DIFF
--- a/docs/docs/cypher_support.md
+++ b/docs/docs/cypher_support.md
@@ -188,7 +188,7 @@ We do not support any of these properties at the type level, meaning nodes and r
 ## Parameters
 Parameters may be specified to allow for more flexible query construction:
 ```sh
-CYPHER name_param = "Niccolò Machiavelli" birth_year_param = 1469; MATCH (p:Person {name: $name_param, birth_year: $birth_year_param}) RETURN p
+CYPHER name_param = "Niccolò Machiavelli" birth_year_param = 1469 MATCH (p:Person {name: $name_param, birth_year: $birth_year_param}) RETURN p
 ```
 The example above shows the syntax used by `redis-cli` to set parameters, but 
 each RedisGraph client introduces a language-appropriate method for setting parameters,


### PR DESCRIPTION
Parameters passed with a Cypher query were ended with a semicolon previously, see for instance https://github.com/RedisGraph/RedisGraph/issues/1078. Now this seems to return an error: 
```
127.0.0.1:6379> GRAPH.QUERY test "CYPHER name = \"opa\";  RETURN $name"
(error) Error: query with more than one statement is not supported.
```
This updates the documentation to reflect that. Or is this a code bug instead of a documentation being outdated bug, and the semicolon should still be accepted? I'm anxiously waiting for #1839, btw.