### PR TITLE
Fixed nightly perf CI module path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,7 +257,7 @@ commands:
             export BENCHMARK_GLOB=<< parameters.benchmark_glob >>
             export PERF_CALLGRAPH_MODE="fp"
             redisbench-admin run-remote \
-              --module_path $ROOT/<< parameters.module_path >> \
+              --module_path << parameters.module_path >> \
               --github_actor << parameters.github_actor >> \
               --github_repo $CIRCLE_PROJECT_REPONAME \
               --github_org $CIRCLE_PROJECT_USERNAME \


### PR DESCRIPTION
Fixes for https://app.circleci.com/pipelines/github/RedisGraph/RedisGraph/6003/workflows/8418fc08-87f2-4d1a-a53a-643e5ea94d0d/jobs/23776
due to:
```
redisbench-admin run-remote \
  --module_path $ROOT//root/project/src/$PACKAGE_NAME.so \
```