### PR TITLE
Support for Debian Bullseye

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -571,7 +571,7 @@ workflows:
           context: common
           matrix:
             parameters:
-              platform: [focal, bionic, xenial, centos7, rocky8, jammy]
+              platform: [focal, bionic, xenial, centos7, rocky8, bullseye]
       - build-arm-platforms:
           <<: *on-integ-and-version-tags
           context: common


### PR DESCRIPTION
RedisGraph is the last of the modules to not build on Debian bullseye. This PR adds support via Circle - where we just add a new platform.