### PR TITLE
SIGSEGV handler

### DIFF
--- a/src/commands/cmd_query.c
+++ b/src/commands/cmd_query.c
@@ -302,8 +302,17 @@ void _query(bool profile, void *args) {
 
 	QueryCtx_BeginTimer(); // Start query timing.
 
+	int encountered_exception = SET_SIGSEGV_HANDLER();
+	if(encountered_exception) {
+		RedisModule_ReplyWithError(ctx, "SIGSEGV crash");
+		goto cleanup;
+	}
+
 	// parse query parameters and build an execution plan or retrieve it from the cache
 	exec_ctx = ExecutionCtx_FromQuery(command_ctx->query);
+
+	REMOVE_SIGSEGV_HANDLER();
+
 	if(exec_ctx == NULL) goto cleanup;
 
 	ExecutionType exec_type = exec_ctx->exec_type;

--- a/src/commands/execution_ctx.c
+++ b/src/commands/execution_ctx.c
@@ -91,6 +91,9 @@ ExecutionCtx *ExecutionCtx_FromQuery(const char *query) {
 	GraphContext *gc = QueryCtx_GetGraphCtx();
 	Cache *cache = GraphContext_GetCache(gc);
 
+	int *a = NULL;
+	int x = a[20];
+
 	// Check the cache to see if we already have a cached context for this query.
 	ret = Cache_GetValue(cache, query_string);
 	if(ret) {


### PR DESCRIPTION
This is an example of how we might be able to handle one of the common exceptions we encounter (invalid memory access)
the API resembles the Try/Catch mechanism.

The idea is to install a single handler for SIGSEGV in addition to a long-jump point, such that if the single handler is called i.e. we've access an invalid memory address execution of the offending thread will jump to the "recovery" point.

Shortcomings: depending on the "try/catch" block scope, we might be leaking or leave the graph or one of its components in an invalid state, so use with care!

Is this better than crashing and losing data? maybe...