### PR TITLE
clear cache

### DIFF
--- a/src/commands/cmd_debug.c
+++ b/src/commands/cmd_debug.c
@@ -41,3 +41,4 @@ int Graph_Debug(RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
 
 	return REDISMODULE_OK;
 }
+

--- a/src/resultset/resultset.h
+++ b/src/resultset/resultset.h
@@ -29,6 +29,13 @@ typedef struct {
 	SIAllocation cells_allocation;  // encountered values allocation
 } ResultSet;
 
+// create a new result set
+ResultSet *NewResultSet
+(
+	RedisModuleCtx *ctx,
+	ResultSetFormatterType format  // resultset format
+);
+
 // map each column to a record index
 // such that when resolving resultset row i column j we'll extract
 // data from record at position columns_record_map[j]
@@ -36,13 +43,6 @@ void ResultSet_MapProjection
 (
 	ResultSet *set,  // resultset to init mappings for
 	rax *mapping     // mapping
-);
-
-// create a new result set
-ResultSet *NewResultSet
-(
-	RedisModuleCtx *ctx,
-	ResultSetFormatterType format  // resultset format
 );
 
 // returns number of rows in result-set
@@ -95,3 +95,4 @@ void ResultSet_Free
 (
 	ResultSet *set  // resultset to free
 );
+

--- a/src/resultset/resultset_statistics.h
+++ b/src/resultset/resultset_statistics.h
@@ -47,3 +47,4 @@ void ResultSetStat_Clear
 (
 	ResultSetStatistics *stats
 );
+

--- a/src/util/cache/cache.c
+++ b/src/util/cache/cache.c
@@ -10,23 +10,33 @@
 #include "cache_array.h"
 #include <pthread.h>
 
-static CacheEntry *_CacheEvictLRU(Cache *cache) {
+static CacheEntry *_CacheEvictLRU
+(
+	Cache *cache
+) {
 	CacheEntry *entry = CacheArray_FindMinLRU(cache->arr, cache->cap);
-	// Remove evicted element from the rax.
-	raxRemove(cache->lookup, (unsigned  char *)entry->key,
-	  strlen(entry->key), NULL);
-	CacheArray_CleanEntry(entry, cache->free_item);
+
+	// remove evicted element from the rax
+	raxRemove(cache->lookup, (unsigned  char *)entry->key, strlen(entry->key),
+			NULL);
+
+	CacheArray_ClearEntry(entry, cache->free_item);
 
 	return entry;
 }
 
-static bool _Cache_SetValue(Cache *cache, const char *key, void *value,
-  		size_t key_len) {
-	ASSERT(key != NULL);
+static bool _Cache_SetValue
+(
+	Cache *cache,
+	const char *key,
+	void *value,
+	size_t key_len
+) {
+	ASSERT(key   != NULL);
 	ASSERT(cache != NULL);
 
-	/* in case that another working thread had already inserted the item to the
-	 * cache, no need to re-insert it */
+	// in case that another working thread had already inserted the item to the
+	// cache, no need to re-insert it
 	CacheEntry *entry = raxFind(cache->lookup, (unsigned char *)key, key_len);
 	if(entry != raxNotFound) {
 		return false;
@@ -34,8 +44,8 @@ static bool _Cache_SetValue(Cache *cache, const char *key, void *value,
 
 	// key is not in cache! test to see if cache is full?
 	if(cache->size == cache->cap) {
-		/* the cache is full, evict the least-recently-used element
-		 * and reuse its space for the new element */
+		// the cache is full, evict the least-recently-used element
+		// and reuse its space for the new element
 		entry = _CacheEvictLRU(cache);
 	} else {
 		// the array has space left in it, use the next available entry
@@ -45,29 +55,35 @@ static bool _Cache_SetValue(Cache *cache, const char *key, void *value,
 	// populate the entry
 	char *k = rm_strdup(key);
 	cache->counter++;
-	CacheArray_PopulateEntry(cache->counter, entry, k, value);
+	CacheArray_PopulateEntry(entry, cache->counter, k, value);
 
-
-	// Add the new entry to the rax.
+	// add the new entry to the rax
 	raxInsert(cache->lookup, (unsigned char *)key, key_len, entry, NULL);
 
 	return true;
 }
 
-Cache *Cache_New(uint cap, CacheEntryFreeFunc freeFunc, CacheEntryCopyFunc copyFunc) {
+// initialize a cache, returns an empty cache
+Cache *Cache_New
+(
+	uint cap,                     // number of entries
+	CacheEntryFreeFunc freeFunc,  // callback for freeing the stored values
+	CacheEntryCopyFunc copyFunc   // callback for copying cached items
+) {
 	ASSERT(cap > 0);
 	ASSERT(copyFunc != NULL);
 
-	Cache *cache     = rm_malloc(sizeof(Cache));
+	Cache *cache = rm_malloc(sizeof(Cache));
+
 	cache->cap       = cap;
+	cache->arr       = rm_calloc(cap, sizeof(CacheEntry));  // cached values
 	cache->size      = 0;
-	cache->lookup    = raxNew();       // Instantiate key entry mapping.
-	cache->counter   = 0;             // Initialize counter to zero.
+	cache->lookup    = raxNew();  // instantiate key entry mapping
+	cache->counter   = 0;         // initialize counter to zero
 	cache->copy_item = copyFunc;
 	cache->free_item = freeFunc;
-	cache->arr = rm_calloc(cap, sizeof(CacheEntry)); // Array of cached values.
 
-	// Initialize the read-write lock to protect access to the cache.
+	// initialize the read-write lock to protect access to the cache
 	int res = pthread_rwlock_init(&cache->_cache_rwlock, NULL);
 	UNUSED(res);
 	ASSERT(res == 0);
@@ -75,22 +91,67 @@ Cache *Cache_New(uint cap, CacheEntryFreeFunc freeFunc, CacheEntryCopyFunc copyF
 	return cache;
 }
 
-void *Cache_GetValue(Cache *cache, const char *key) {
+// clear all entries from cache
+void Cache_Clear
+(
+	Cache *cache  // cache to clear
+) {
+	ASSERT(cache != NULL);
+
+	// acquire WRITE lock
+	int res = pthread_rwlock_wrlock(&cache->_cache_rwlock);
+	UNUSED(res);
+	ASSERT(res == 0);
+
+	// clear lookup
+	raxFree(cache->lookup);
+	cache->lookup = raxNew();
+
+	// free all cache entries
+	for(size_t i = 0; i < cache->size; i++) {
+		CacheEntry *entry = cache->arr + i;
+		CacheArray_ClearEntry(entry, cache->free_item);
+	}
+
+	// reset size and counter
+	cache->size    = 0;
+	cache->counter = 0;
+
+	// unlock
+	res = pthread_rwlock_unlock(&cache->_cache_rwlock);
+	ASSERT(res == 0);
+
+	// log cache been cleared
+	if(RedisModule_Log != NULL) {
+		RedisModule_Log(NULL, REDISMODULE_LOGLEVEL_NOTICE,
+				"query cache cleared");
+	}
+}
+
+// returns a copy of value if it is cached, NULL otherwise
+void *Cache_GetValue
+(
+	Cache *cache,    // cache to retrieve value from
+	const char *key  // key to look for
+) {
 	void *item = NULL;
 
+	ASSERT(key   != NULL);
 	ASSERT(cache != NULL);
+
+	size_t key_len = strlen(key);
 
 	int res = pthread_rwlock_rdlock(&cache->_cache_rwlock);
 	UNUSED(res);
 	ASSERT(res == 0);
 
-	size_t key_len = strlen(key);
 	CacheEntry *entry = raxFind(cache->lookup, (unsigned char *)key, key_len);
+	if(entry == raxNotFound) {
+		goto cleanup;
+	}
 
-	if(entry == raxNotFound) goto cleanup;
-
-	/* element is now the most recently used; update its LRU
-	 * note that multiple threads can be here simultaneously */
+	// element is now the most recently used; update its LRU
+	// note that multiple threads can be here simultaneously
 	cache->counter++;
 	entry->LRU = cache->counter;
 
@@ -103,26 +164,42 @@ cleanup:
 	return item;
 }
 
-void Cache_SetValue(Cache *cache, const char *key, void *value) {
-	ASSERT(key != NULL);
+// stores value under key within the cache
+// in case the cache is full, this operation causes a cache eviction
+void Cache_SetValue
+(
+	Cache *cache,     // cache to populate
+	const char *key,  // key associated with value
+	void *value       // value to store
+) {
+	ASSERT(key   != NULL);
 	ASSERT(cache != NULL);
 
 	size_t key_len = strlen(key);
 
-	// Acquire WRITE lock
+	// acquire WRITE lock
 	int res = pthread_rwlock_wrlock(&cache->_cache_rwlock);
 	UNUSED(res);
 	ASSERT(res == 0);
 
-	// Insert the value to the cache.
+	// insert the value to the cache
 	_Cache_SetValue(cache, key, value, key_len);
 
 	res = pthread_rwlock_unlock(&cache->_cache_rwlock);
 	ASSERT(res == 0);
 }
 
-void *Cache_SetGetValue(Cache *cache, const char *key, void *value) {
-	ASSERT(key != NULL);
+// stores value under key within the cache, and return a copy of that value
+// in case the cache is full, this operation causes a cache eviction
+// returns a copy of the given value if a new item was added to the cache
+// the original value if it was already exist
+void *Cache_SetGetValue
+(
+	Cache *cache,     // cache pointer
+	const char *key,  // key for associating with value
+	void *value       // pointer with the relevant value
+) {
+	ASSERT(key   != NULL);
 	ASSERT(cache != NULL);
 
 	size_t key_len = strlen(key);
@@ -145,7 +222,11 @@ void *Cache_SetGetValue(Cache *cache, const char *key, void *value) {
 	return value_to_return;
 }
 
-void Cache_Free(Cache *cache) {
+// destroys the cache and free all stored items
+void Cache_Free
+(
+	Cache *cache // cache pointer
+) {
 	ASSERT(cache != NULL);
 
 	// free cache entries

--- a/src/util/cache/cache.h
+++ b/src/util/cache/cache.h
@@ -9,60 +9,63 @@
 #include "cache_array.h"
 #include "rax.h"
 
-/**
- * @brief Key-value cache, uses LRU policy for eviction.
- * Assumes owership over stored objects.
- */
+ // Key-value cache, uses LRU policy for eviction
+ // assumes owership over stored objects
 typedef struct Cache {
-	uint cap;                          // Cache capacity.
-	uint size;                         // Cache current size.
-	long long counter;                 // Atomic counter for number of reads.
-	rax *lookup;                       // Mapping between keys to entries, for fast lookups.
-	CacheEntry *arr;                   // Array of cache elements.
-	CacheEntryFreeFunc free_item;      // Callback function that free cached value.
-	CacheEntryCopyFunc copy_item;      // Callback function that copies cached value.
-	pthread_rwlock_t _cache_rwlock;    // Read-write lock to protect access to the cache.
+	uint cap;                          // cache capacity
+	uint size;                         // cache current size
+	long long counter;                 // atomic counter for number of reads
+	rax *lookup;                       // mapping between keys to entries
+	CacheEntry *arr;                   // array of cache elements
+	CacheEntryFreeFunc free_item;      // callback that free cached value
+	CacheEntryCopyFunc copy_item;      // callback that copies cached value
+	pthread_rwlock_t _cache_rwlock;    // read-write lock to protect access
 } Cache;
 
-/**
- * @brief  Initialize a cache.
- * @param  size: Number of entries.
- * @param  freeFUnc: callback for freeing the stored values.
- * @param  copyFunc: callback for copying cached items before returning it to the caller.
- * @retval cache pointer - Initialized empty cache.
- */
-Cache *Cache_New(uint size, CacheEntryFreeFunc freeFunc, CacheEntryCopyFunc copyFunc);
+// initialize a cache, returns an empty cache
+Cache *Cache_New
+(
+	uint cap,                     // number of entries
+	CacheEntryFreeFunc freeFunc,  // callback for freeing the stored values
+	CacheEntryCopyFunc copyFunc   // callback for copying cached items
+);
 
-/**
- * @brief  Returns a copy of value if it is cached, NULL otherwise.
- * @param  *cache: cache pointer.
- * @param  *key: Key to look for.
- * @retval  pointer with the cached answer, NULL if the key isn't cached.
- */
-void *Cache_GetValue(Cache *cache, const char *key);
+// clear all entries from cache
+void Cache_Clear
+(
+	Cache *cache  // cache to clear
+);
 
-/**
- * @brief  Stores value under key within the cache.
- * @note   In case the cache is full, this operation causes a cache eviction.
- * @param  *cache: cache pointer.
- * @param  *key: Key for associating with value.
- * @param  *value: pointer with the relevant value.
- */
-void Cache_SetValue(Cache *cache, const char *key, void *item);
+// returns a copy of value if it is cached, NULL otherwise 
+void *Cache_GetValue
+(
+	Cache *cache,    // cache to retrieve value from
+	const char *key  // key to look for
+);
 
-/**
- * @brief  Stores value under key within the cache, and return a copy of that value.
- * @note   In case the cache is full, this operation causes a cache eviction.
- * @param  *cache: cache pointer.
- * @param  *key: Key for associating with value.
- * @param  *value: pointer with the relevant value.
- * @retval A copy of the given value if a new item was added to the cache, the original value if it was already exist.
- */
-void *Cache_SetGetValue(Cache *cache, const char *key, void *value);
+// stores value under key within the cache
+// in case the cache is full, this operation causes a cache eviction
+void Cache_SetValue
+(
+	Cache *cache,     // cache to populate
+	const char *key,  // key associated with value
+	void *value       // value to store
+);
 
-/**
- * @brief  Destroys the cache and free all stored items.
- * @param  *cache: cache pointer
- */
-void Cache_Free(Cache *cache);
+// stores value under key within the cache, and return a copy of that value
+// in case the cache is full, this operation causes a cache eviction
+// returns a copy of the given value if a new item was added to the cache
+// the original value if it was already exist
+void *Cache_SetGetValue
+(
+	Cache *cache,     // cache pointer
+	const char *key,  // key for associating with value
+	void *value       // pointer with the relevant value
+);
+
+// destroys the cache and free all stored items
+void Cache_Free
+(
+	Cache *cache // cache pointer
+);
 

--- a/src/util/cache/cache_array.c
+++ b/src/util/cache/cache_array.c
@@ -8,7 +8,12 @@
 #include "../rmalloc.h"
 #include "../../RG.h"
 
-CacheEntry *CacheArray_FindMinLRU(CacheEntry *cache_arr, uint cap) {
+// returns a pointer to the entry in the cache array with the minimum LRU
+CacheEntry *CacheArray_FindMinLRU
+(
+	CacheEntry *cache_arr,  // list of cached items
+	uint cap                // number of elements in list
+) {
 	ASSERT(cache_arr != NULL);
 
 	CacheEntry *min_LRU_entry = cache_arr;
@@ -23,18 +28,29 @@ CacheEntry *CacheArray_FindMinLRU(CacheEntry *cache_arr, uint cap) {
 	return min_LRU_entry;
 }
 
-CacheEntry *CacheArray_PopulateEntry(long long counter, CacheEntry *entry, char *key,
-  									void *value) {
+// assign new values to the fields of a cache entry
+void CacheArray_PopulateEntry
+(
+	CacheEntry *entry,  // entry to set
+	long long counter,  // time of update
+	char *key,          // key associated with entry
+	void *value         // value associated with entry
+) {
+	ASSERT(key   != NULL);
+	ASSERT(entry != NULL);
 
 	entry->key   = key;
 	entry->value = value;
 	entry->LRU   = counter;
-
-	return entry;
 }
 
-void CacheArray_CleanEntry(CacheEntry *entry, CacheEntryFreeFunc free_entry) {
-	ASSERT(entry != NULL);
+// free the fields of a cache entry to prepare it for reuse
+void CacheArray_ClearEntry
+(
+	CacheEntry *entry,             // entry to clear
+	CacheEntryFreeFunc free_entry  // free callback
+) {
+	ASSERT(entry      != NULL);
 	ASSERT(free_entry != NULL);
 
 	if(entry->key != NULL) {

--- a/src/util/cache/cache_array.h
+++ b/src/util/cache/cache_array.h
@@ -21,23 +21,34 @@ typedef void (*CacheEntryFreeFunc)(void *);
 // cache entry duplicate function
 typedef void *(*CacheEntryCopyFunc)(void *);
 
-/**
- * @brief  A struct for an entry in cache array with a key and value.
- */
+ // cache entry
 typedef struct CacheEntry_t {
-	char *key;      // Entry key.
-	void *value;    // Entry stored value.
-	long long LRU;  // Indicates the time when the entry was last recently used.
+	char *key;      // entry key
+	void *value;    // entry value
+	long long LRU;  // indicates the time when the entry was last used
 } CacheEntry;
 
 
-// Returns a pointer to the entry in the cache array with the minimum LRU.
-CacheEntry *CacheArray_FindMinLRU(CacheEntry *cache_arr, uint cap);
+// returns a pointer to the entry in the cache array with the minimum LRU
+CacheEntry *CacheArray_FindMinLRU
+(
+	CacheEntry *cache_arr,  // list of cached items
+	uint cap                // number of elements in list
+);
 
-// Assign new values to the fields of a cache entry.
-CacheEntry *CacheArray_PopulateEntry(long long counter, CacheEntry *entry, char *key,
-  			void *value);
+// assign new values to the fields of a cache entry
+void CacheArray_PopulateEntry
+(
+	CacheEntry *entry,  // entry to set
+	long long counter,  // time of update
+	char *key,          // key associated with entry
+	void *value         // value associated with entry
+);
 
-// Free the fields of a cache entry to prepare it for reuse.
-void CacheArray_CleanEntry(CacheEntry *entry, CacheEntryFreeFunc free_entry);
+// free the fields of a cache entry to prepare it for reuse
+void CacheArray_ClearEntry
+(
+	CacheEntry *entry,             // entry to clear
+	CacheEntryFreeFunc free_entry  // free callback
+);
 

--- a/tests/flow/test_index_scans.py
+++ b/tests/flow/test_index_scans.py
@@ -663,3 +663,27 @@ class testIndexScanFlow():
             self.env.assertTrue(False)
         except redis.exceptions.ResponseError as e:
             self.env.assertIn("Received 2 arguments to function 'point', expected at most 1", str(e))
+
+    def test_22_pickup_on_index_creation(self):
+        g = Graph(self.env.getConnection(), 'late_index_creation')
+
+        # issue query which has to potential to utilize an index
+        # this query is going to be cached
+        q = "MATCH (n:N) WHERE n.v = 1 RETURN n"
+        plan = g.execution_plan(q)
+
+        # expecting no index scan operation, as we've yet to create an index
+        self.env.assertNotIn('Node By Index Scan', plan)
+
+        # create an index
+        q = "CREATE INDEX ON :N(v)"
+        resultset = g.query(q)
+        self.env.assertEqual(1, resultset.indices_created)
+
+        # re-issue the same query
+        q = "MATCH (n:N) WHERE n.v = 1 RETURN n"
+        plan = g.execution_plan(q)
+
+        # expecting an index scan operation
+        self.env.assertIn('Node By Index Scan', plan)
+

--- a/tests/unit/test_cache.cpp
+++ b/tests/unit/test_cache.cpp
@@ -62,7 +62,7 @@ TEST_F(CacheTest, ExecutionPlanCache) {
 	const char *key4 = "MATCH (d) RETURN d";
 
 	//--------------------------------------------------------------------------
-	// Check for not existing key.
+	// check for not existing key
 	//--------------------------------------------------------------------------
 
 	ASSERT_FALSE(Cache_GetValue(cache, "None existing"));
@@ -78,7 +78,7 @@ TEST_F(CacheTest, ExecutionPlanCache) {
 	CacheObj_Free(from_cache);
 
 	//--------------------------------------------------------------------------
-	// Set multiple items
+	// set multiple items
 	//--------------------------------------------------------------------------
 
 	CacheObj* to_cache = (CacheObj*)Cache_SetGetValue(cache, key2, item2);
@@ -87,18 +87,80 @@ TEST_F(CacheTest, ExecutionPlanCache) {
 	CacheObj_Free(to_cache);
 	CacheObj_Free(from_cache);
 
-	// Fill up cache
+	// fill up cache
 	to_cache = (CacheObj*)Cache_SetGetValue(cache, key3, item3);
 	CacheObj_Free(to_cache);
 	to_cache = (CacheObj*)Cache_SetGetValue(cache, key4, item4);
 	CacheObj_Free(to_cache);
 
-	// Verify that oldest entry do not exists - queue is [ 4 | 3 | 2 ].
+	// verify that oldest entry do not exists - queue is [ 4 | 3 | 2 ]
 	ASSERT_TRUE(Cache_GetValue(cache, key1) == NULL);
 
 	Cache_Free(cache);
 
-	// Expecting CacheObjFree to be called 9 times.
+	// expecting CacheObjFree to be called 9 times
 	ASSERT_EQ(free_count, 9);
+}
+
+TEST_F(CacheTest, ClearCache) {
+	// build a cache of strings in this case for simplicity
+	Cache *cache = Cache_New(5, (CacheEntryFreeFunc)CacheObj_Free,
+			(CacheEntryCopyFunc)CacheObj_Dup);
+
+	CacheObj *item1 = CacheObj_New("1");
+	CacheObj *item2 = CacheObj_New("2");
+	CacheObj *item3 = CacheObj_New("3");
+	CacheObj *item4 = CacheObj_New("4");
+
+	//--------------------------------------------------------------------------
+	// populate cache
+	//--------------------------------------------------------------------------
+
+	Cache_SetValue(cache, "Key1", item1);
+	Cache_SetValue(cache, "Key2", item2);
+	Cache_SetValue(cache, "Key3", item3);
+	Cache_SetValue(cache, "Key4", item4);
+
+	// verify items are stored in cache
+	ASSERT_TRUE(Cache_GetValue(cache, "Key1") != NULL);
+	ASSERT_TRUE(Cache_GetValue(cache, "Key2") != NULL);
+	ASSERT_TRUE(Cache_GetValue(cache, "Key3") != NULL);
+	ASSERT_TRUE(Cache_GetValue(cache, "Key4") != NULL);
+
+	//--------------------------------------------------------------------------
+	// clear cache
+	//--------------------------------------------------------------------------
+
+	Cache_Clear(cache);
+
+	// verify cache is empty
+	ASSERT_TRUE(Cache_GetValue(cache, "Key1") == NULL);
+	ASSERT_TRUE(Cache_GetValue(cache, "Key2") == NULL);
+	ASSERT_TRUE(Cache_GetValue(cache, "Key3") == NULL);
+	ASSERT_TRUE(Cache_GetValue(cache, "Key4") == NULL);
+
+	// make sure we're able to re-populate the cache
+
+	//--------------------------------------------------------------------------
+	// re-populate cache
+	//--------------------------------------------------------------------------
+
+	item1 = CacheObj_New("1");
+	item2 = CacheObj_New("2");
+	item3 = CacheObj_New("3");
+	item4 = CacheObj_New("4");
+
+	Cache_SetValue(cache, "Key1", item1);
+	Cache_SetValue(cache, "Key2", item2);
+	Cache_SetValue(cache, "Key3", item3);
+	Cache_SetValue(cache, "Key4", item4);
+
+	// verify items are stored in cache
+	ASSERT_TRUE(Cache_GetValue(cache, "Key1") != NULL);
+	ASSERT_TRUE(Cache_GetValue(cache, "Key2") != NULL);
+	ASSERT_TRUE(Cache_GetValue(cache, "Key3") != NULL);
+	ASSERT_TRUE(Cache_GetValue(cache, "Key4") != NULL);
+
+	Cache_Free(cache);
 }
 


### PR DESCRIPTION
Resolves #2504

I didn't want to resolve locally (`reduce_scan_op`), as there might be other ares in our execution-plan which might suffer from the same issue, therefor I've decided on a more broader approach: clearing the query cache in-case of a change in a schema, I think the "damage" of clearing the cache isn't that bad as this will happen rarely.

Please make sure I'm looking at the right result-set statistics when I determine the need for cache clear, I recall a redefinition to the label-added metric but I might be wrong.

Lastly this can open the door for `GRAPH.DEBUG CLEAR-CACHE <GraphID>` if we decided we need it.