### PR TITLE
Fix Duplicate reports when matching relationship type :R|R

### DIFF
--- a/src/graph/query_graph.c
+++ b/src/graph/query_graph.c
@@ -88,7 +88,19 @@ static void _QueryGraphAddEdge
 			qg->unknown_reltype_ids = true;
 			continue;
 		}
-		array_append(edge->reltypeIDs, s->id);
+		// search if s-id exists in edge->reltypeIDs to don't insert duplicates ids
+		bool found = false;
+		int len = array_len(edge->reltypeIDs);
+		for (int i = 0; i < len; i++) {
+			if(edge->reltypeIDs[i] == s->id) {
+				found = true;
+				break;
+			}
+		}
+		if(!found) {
+			array_append(edge->reltypeIDs, s->id);
+		}
+
 	}
 
 	// incase of a variable length edge, set edge min/max hops

--- a/src/graph/query_graph.c
+++ b/src/graph/query_graph.c
@@ -80,27 +80,39 @@ static void _QueryGraphAddEdge
 	for(uint i = 0; i < nreltypes; i ++) {
 		const char *reltype = cypher_ast_reltype_get_name(cypher_ast_rel_pattern_get_reltype(ast_entity,
 														  i));
-		array_append(edge->reltypes, reltype);
+		bool found = false;
 		Schema *s = GraphContext_GetSchema(gc, reltype, SCHEMA_EDGE);
 		if(!s) {
 			// unknown relationship
-			array_append(edge->reltypeIDs, GRAPH_UNKNOWN_RELATION);
-			qg->unknown_reltype_ids = true;
+			// search if reltype exists in edge->reltypes to don't insert duplicated reltype
+			int len = array_len(edge->reltypes);
+			for (int j = 0; j < len; j++) {
+				if(edge->reltypeIDs[j] == GRAPH_UNKNOWN_RELATION) {
+					if(strcasecmp(edge->reltypes[j],reltype) == 0) {
+						found = true;
+						break;
+					}
+				}
+			}
+			if(!found) {
+				array_append(edge->reltypes, reltype);
+				array_append(edge->reltypeIDs, GRAPH_UNKNOWN_RELATION);
+				qg->unknown_reltype_ids = true;
+			}
 			continue;
 		}
-		// search if s-id exists in edge->reltypeIDs to don't insert duplicates ids
-		bool found = false;
+		// search if s-id exists in edge->reltypeIDs to don't insert duplicated ids
 		int len = array_len(edge->reltypeIDs);
-		for (int i = 0; i < len; i++) {
-			if(edge->reltypeIDs[i] == s->id) {
+		for (int j = 0; j < len; j++) {
+			if(edge->reltypeIDs[j] == s->id) {
 				found = true;
 				break;
 			}
 		}
 		if(!found) {
+			array_append(edge->reltypes, reltype);
 			array_append(edge->reltypeIDs, s->id);
 		}
-
 	}
 
 	// incase of a variable length edge, set edge min/max hops

--- a/tests/flow/test_graph_create.py
+++ b/tests/flow/test_graph_create.py
@@ -151,3 +151,46 @@ class testGraphCreationFlow(FlowTestsBase):
                 self.env.assertTrue(False)
             except redis.exceptions.ResponseError as e:
                 self.env.assertContains("The bound variable 'r' can't be redeclared in a CREATE clause", str(e))
+
+    # test creating queries with matching relationship type :R|R
+    # the results can't report duplicates
+    def test10_match_duplicated_reltype(self):
+        query = """CREATE (a:A)-[r1:R1]->(b:B), (a:A)-[r2:R2]->(b:B)"""
+        result = redis_graph.query(query)
+        self.env.assertEquals(result.nodes_created, 2)
+        self.env.assertEquals(result.relationships_created, 2)
+        self.env.assertEquals(result.labels_added, 2)
+
+        # search for same relationship multiple times, should report one relationship
+        queries = ["MATCH (a:A)-[r:R1]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R1|R1]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R1|R1|R1|R1]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R2]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R2|R2]->(b:B) RETURN count(r)",
+                   ]
+        for query in queries:
+            result = redis_graph.query(query)
+            expected_result = [[1]]
+            self.env.assertEquals(result.result_set, expected_result)
+
+        # search for two relationship multiple times, should report two relationships
+        queries = ["MATCH (a:A)-[r:R1|R2]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R1|R2|R1|R2]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R1|R1|R2|R2]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R1|R2|R2|R2]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R2|R1|R1|R1]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R2|R2|R1|R1]->(b:B) RETURN count(r)",
+                   ]
+        for query in queries:
+            result = redis_graph.query(query)
+            expected_result = [[2]]
+            self.env.assertEquals(result.result_set, expected_result)
+
+        # These queries should not report results
+        queries = ["MATCH (a:A)<-[r:R1|R2]-(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R3]->(b:B) RETURN count(r)",
+                   ]
+        for query in queries:
+            result = redis_graph.query(query)
+            expected_result = [[0]]
+            self.env.assertEquals(result.result_set, expected_result)

--- a/tests/flow/test_graph_create.py
+++ b/tests/flow/test_graph_create.py
@@ -167,6 +167,8 @@ class testGraphCreationFlow(FlowTestsBase):
                    "MATCH (a:A)-[r:R1|R1|R1|R1]->(b:B) RETURN count(r)",
                    "MATCH (a:A)-[r:R2]->(b:B) RETURN count(r)",
                    "MATCH (a:A)-[r:R2|R2]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R2|R2|R3]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R2|R2|R3|R4|R4]->(b:B) RETURN count(r)",
                    ]
         for query in queries:
             result = redis_graph.query(query)
@@ -189,6 +191,8 @@ class testGraphCreationFlow(FlowTestsBase):
         # These queries should not report results
         queries = ["MATCH (a:A)<-[r:R1|R2]-(b:B) RETURN count(r)",
                    "MATCH (a:A)-[r:R3]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R3|R3]->(b:B) RETURN count(r)",
+                   "MATCH (a:A)-[r:R3|R3|R4|R4]->(b:B) RETURN count(r)",
                    ]
         for query in queries:
             result = redis_graph.query(query)


### PR DESCRIPTION
Hi, this PR is to fix #2643

The function _QueryGraphAddEdge() was modified to prevent add duplicated ids to edge->reltypeIDs array.

Tests were added in test_graph_create.py, please check if it is the correct file to add them.
