### PR TITLE
Enable running the tests by enabling debug command.

### DIFF
--- a/tests/flow/test_encode_decode.py
+++ b/tests/flow/test_encode_decode.py
@@ -18,7 +18,8 @@ def compare_nodes_result_set(env, result_set_a, result_set_b):
 class test_encode_decode(FlowTestsBase):
     def __init__(self):
         self.env = Env(decodeResponses=True,
-                       moduleArgs='VKEY_MAX_ENTITY_COUNT 10 NODE_CREATION_BUFFER 100')
+                       moduleArgs='VKEY_MAX_ENTITY_COUNT 10 NODE_CREATION_BUFFER 100',
+                       enableDebugCommand=True)
         global redis_con
         redis_con = self.env.getConnection()
 

--- a/tests/flow/test_persistency.py
+++ b/tests/flow/test_persistency.py
@@ -8,7 +8,7 @@ port = None
 
 class testGraphPersistency():
     def __init__(self):
-        self.env = Env(decodeResponses=True)
+        self.env = Env(decodeResponses=True, enableDebugCommand=True)
         global redis_con
         redis_con = self.env.getConnection()
         global port


### PR DESCRIPTION
Previously there were failures while running the tests, usually in cases when the `redis-server` was installed via homebrew on macOS and/or it was impossible to configure it via the config file, and which (of course) wasn't built with the debug command being enabled by default. This enables the debug command when running the `redis-server`, so the tests will pass now.