### PR TITLE
Implement typeof()

### DIFF
--- a/src/arithmetic/entity_funcs/entity_funcs.c
+++ b/src/arithmetic/entity_funcs/entity_funcs.c
@@ -236,6 +236,10 @@ SIValue AR_PROPERTY(SIValue *argv, int argc, void *private_data) {
 	}
 }
 
+SIValue AR_TYPEOF(SIValue *argv, int argc, void *private_data) {
+	return SI_ConstStringVal(SIType_ToString(SI_TYPE(argv[0])));
+}
+
 void Register_EntityFuncs() {
 	SIType *types;
 	SIType ret_type;
@@ -304,6 +308,12 @@ void Register_EntityFuncs() {
 	array_append(types, T_INT64);
 	ret_type = SI_ALL;
 	func_desc = AR_FuncDescNew("property", AR_PROPERTY, 3, 3, types, ret_type, true, true);
+	AR_RegFunc(func_desc);
+
+	types = array_new(SIType, 1);
+	array_append(types, T_NULL | SI_ALL);
+	ret_type = T_STRING;
+	func_desc = AR_FuncDescNew("typeof", AR_TYPEOF, 1, 1, types, ret_type, false, true);
 	AR_RegFunc(func_desc);
 }
 

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -2195,3 +2195,16 @@ class testFunctionCallsFlow(FlowTestsBase):
             actual_result = graph.query(query)
         except redis.ResponseError as e:
             self.env.assertContains("Division by zero", str(e))
+
+    def test87_typeof(self):
+        query_to_expected_result = {
+            "RETURN typeOf(NULL)" : [['Null']],
+            "RETURN typeOf([1,2])" : [['List']],
+            "RETURN typeOf(point({latitude:1,longitude:2}))" : [['Point']],
+            "RETURN typeOf(1), typeOf('1'), typeOf(true)" : [['Integer', 'String', 'Boolean']],
+            "MATCH path=({val: 0})-[e:works_with]->({val: 1}) RETURN typeOf(path)" : [['Path']],
+            "CREATE (a)-[b:B]->(c) RETURN typeOf(a), typeOf(b), typeOf(c)" : [['Node', 'Edge', 'Node']],
+            "CREATE (a:A {x:1, y:'1', z:true}) RETURN typeOf(a.x), typeOf(a.y), typeOf(a.z)" : [['Integer', 'String', 'Boolean']],
+        }
+        for query, expected_result in query_to_expected_result.items():
+            self.get_res_and_assertEquals(query, expected_result)


### PR DESCRIPTION
This PR implements typeof(), #2729

It is a simple function which returns: ```SI_ConstStringVal(SIType_ToString(SI_TYPE(argv[0])));```

Sample output:
```
127.0.0.1:6379> GRAPH.QUERY g "CREATE (a:A {x:1, y:'1', z:true}) RETURN typeOf(a.x), typeOf(a.y), typeOf(a.z)"
1) 1) "typeOf(a.x)"
   2) "typeOf(a.y)"
   3) "typeOf(a.z)"
2) 1) 1) "Integer"
      2) "String"
      3) "Boolean"
```

```
127.0.0.1:6379> GRAPH.QUERY g "CREATE (a)-[b:B]->(c) RETURN typeOf(a), typeOf(b), typeOf(c)"
1) 1) "typeOf(a)"
   2) "typeOf(b)"
   3) "typeOf(c)"
2) 1) 1) "Node"
      2) "Edge"
      3) "Node"
```