### PR TITLE
Updated circleci config to only trigger benchmark by label action:run-benchmark and to run performance nightly only once a week

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,14 @@
 version: 2.1
 
+parameters:
+  run_default_flow:
+    default: true
+    type: boolean
+
+  run_benchmark_flow_label:
+    default: false
+    type: boolean
+
 commands:
   early-returns:
     steps:
@@ -572,21 +581,13 @@ on-integ-and-version-tags: &on-integ-and-version-tags
     tags:
       only: /^v[0-9].*/
 
-on-perf-tags: &on-perf-tags
-  filters:
-    branches:
-      only:
-        - master
-        - /^\d+\.\d+.*$/
-        - /^perf-.*$/
-    tags:
-      only: /^v[0-9].*/
-
 #----------------------------------------------------------------------------------------------------------------------------------
 
 workflows:
   version: 2
   build_and_package:
+    when:
+      << pipeline.parameters.run_default_flow >>
     jobs:
       - build-linux-debian:
           name: build
@@ -633,16 +634,16 @@ workflows:
           requires:
             - upload-release-artifacts
       - benchmark:
-          <<: *on-perf-tags
+          <<: *on-integ-and-version-tags
           context: common
-      # disable temporarily due to huge profile overhead in RG
-      # - benchmark-profiler:
-      #     <<: *on-perf-tags
-      #     context: common
-      # enable temporarily to understand overhead of GB
-      - benchmark-profiler:
-          <<: *on-perf-tags
+
+  benchmark_flow_label:
+    when:
+      << pipeline.parameters.run_benchmark_flow_label >>
+    jobs:
+      - benchmark:
           context: common
+          <<: *on-any-branch
 
   nightly:
     triggers:
@@ -657,10 +658,17 @@ workflows:
           matrix:
             parameters:
               redis_version: ["6.0", "7", "unstable"]
-      - benchmark:
-          context: common
       - fuzzer:
           name: nightly-fuzzer
-      # disable temporarily due to huge profile overhead in RG
-      # - benchmark-profiler:
-      #     context: common
+
+  nightly-perf-once-a-week:
+    triggers:
+      - schedule:
+          #  “At 07:00 on Mondays.”
+          cron: "00 07 * * 1"
+          filters:
+            branches:
+              only: master
+    jobs:
+      - benchmark:
+          context: common

--- a/.github/workflows/trigger-benchmark.yml
+++ b/.github/workflows/trigger-benchmark.yml
@@ -1,0 +1,34 @@
+name: Check if needs trigger CircleCI benchmark
+
+on:
+  pull_request:
+   types: [opened, labeled, unlabeled, synchronize]
+
+jobs:
+  haslabel:
+    name: analyse labels
+    runs-on: ubuntu-latest
+    outputs:
+      benchmark: ${{ steps.haslabel.outputs.labeled-run-benchmark }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Labeled with run-benchmark
+        id: haslabel
+        uses: DanielTamkin/HasLabel@v1.0.4
+        with:
+          contains: 'run-benchmark'
+  perf-ci:
+    name: Trigger CI benchmarks
+    needs: haslabel
+    if: needs.haslabel.outputs.benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: curl-circle-ci
+        run: |
+          curl --request POST \
+          --url https://circleci.com/api/v2/project/gh/${{ github.repository }}/pipeline \
+          --header 'Circle-Token: ${{ secrets.CIRCLE_CI_SECRET }}' \
+          --header 'content-type: application/json' \
+          --data '{"branch": "${{ github.event.pull_request.head.ref }}",
+          "parameters": {"run_default_flow":false, "run_benchmark_flow_label":true}}'

--- a/.github/workflows/trigger-benchmark.yml
+++ b/.github/workflows/trigger-benchmark.yml
@@ -23,10 +23,12 @@ jobs:
     if: needs.haslabel.outputs.benchmark
     runs-on: ubuntu-latest
     steps:
-      - name: trigger-circle-ci
-      - uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
-        env:
-          CCI_TOKEN: ${{ secrets.CIRCLE_CI_SECRET }}
-        with:
-          run_default_flow: false
-          run_benchmark_flow_label: true
+      - uses: actions/checkout@v2
+      - name: curl-circle-ci
+        run: |
+          curl --request POST \
+          --url https://circleci.com/api/v2/project/gh/${{ github.repository }}/pipeline \
+          --header 'Circle-Token: ${{ secrets.CIRCLE_CI_SECRET }}' \
+          --header 'content-type: application/json' \
+          --data '{"branch": "${{ github.event.pull_request.head.ref }}",
+          "parameters": {"run_default_flow":false, "run_benchmark_flow_label":true}}'

--- a/.github/workflows/trigger-benchmark.yml
+++ b/.github/workflows/trigger-benchmark.yml
@@ -23,12 +23,10 @@ jobs:
     if: needs.haslabel.outputs.benchmark
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: curl-circle-ci
-        run: |
-          curl --request POST \
-          --url https://circleci.com/api/v2/project/gh/${{ github.repository }}/pipeline \
-          --header 'Circle-Token: ${{ secrets.CIRCLE_CI_SECRET }}' \
-          --header 'content-type: application/json' \
-          --data '{"branch": "${{ github.event.pull_request.head.ref }}",
-          "parameters": {"run_default_flow":false, "run_benchmark_flow_label":true}}'
+      - name: trigger-circle-ci
+      - uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        env:
+          CCI_TOKEN: ${{ secrets.CIRCLE_CI_SECRET }}
+        with:
+          run_default_flow: false
+          run_benchmark_flow_label: true

--- a/.github/workflows/trigger-benchmark.yml
+++ b/.github/workflows/trigger-benchmark.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: trigger-circle-ci
-      - uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
         env:
           CCI_TOKEN: ${{ secrets.CIRCLE_CI_SECRET }}
         with:

--- a/.github/workflows/trigger-benchmark.yml
+++ b/.github/workflows/trigger-benchmark.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: trigger-circle-ci
-        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+      - uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
         env:
           CCI_TOKEN: ${{ secrets.CIRCLE_CI_SECRET }}
         with:


### PR DESCRIPTION
- @rafie before merging we need to ensure `CIRCLE_CI_SECRET` is present on repo
- @gkorland as discussed moving nightly of performance to once a week