### PR TITLE
Fix toInteger() and toIntegerOrNull() don't convert Booleans

### DIFF
--- a/src/arithmetic/numeric_funcs/numeric_funcs.c
+++ b/src/arithmetic/numeric_funcs/numeric_funcs.c
@@ -122,6 +122,11 @@ SIValue AR_TOINTEGER(SIValue *argv, int argc, void *private_data) {
 	case T_DOUBLE:
 		// Remove floating point.
 		return SI_LongVal(floor(arg.doubleval));
+	case T_BOOL:
+		if(SIValue_IsTrue(arg)) {
+			return SI_LongVal(1);
+		}
+		return SI_LongVal(0);
 	case T_STRING:
 		if(strlen(arg.stringval) == 0) return SI_NullVal();
 		errno = 0;
@@ -439,7 +444,7 @@ void Register_NumericFuncs() {
 	AR_RegFunc(func_desc);
 
 	types = array_new(SIType, 1);
-	array_append(types, (SI_NUMERIC | T_STRING | T_NULL));
+	array_append(types, (SI_NUMERIC | T_STRING | T_NULL | T_BOOL));
 	ret_type = T_INT64 | T_NULL;
 	func_desc = AR_FuncDescNew("tointeger", AR_TOINTEGER, 1, 1, types, ret_type, false, true);
 	AR_RegFunc(func_desc);

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -681,17 +681,18 @@ class testFunctionCallsFlow(FlowTestsBase):
     
     def test23_toInteger(self):
         # expect calling toInteger to succeed
-        queries = [
-            """RETURN toInteger(1)""",
-            """RETURN toInteger(1.1)""",
-            """RETURN toInteger(1.9)""",
-            """RETURN toInteger('1')""",
-            """RETURN toInteger('1.1')""",
-            """RETURN toInteger('1.9')"""
-        ]
-        for query in queries:
-            actual_result = graph.query(query)
-            self.env.assertEquals(actual_result.result_set[0][0], 1)
+        query_to_expected_result = {
+            """RETURN toInteger(1)""": [[1]],
+            """RETURN toInteger(1.1)""": [[1]],
+            """RETURN toInteger(1.9)""": [[1]],
+            """RETURN toInteger('1')""": [[1]],
+            """RETURN toInteger('1.1')""": [[1]],
+            """RETURN toInteger('1.9')""": [[1]],
+            """RETURN toInteger(true)""": [[1]],
+            """RETURN toInteger(false)""": [[0]],
+        }
+        for query, expected_result in query_to_expected_result.items():
+            self.get_res_and_assertEquals(query, expected_result)
 
         # expect calling toInteger to return NULL
         queries = [
@@ -968,10 +969,10 @@ class testFunctionCallsFlow(FlowTestsBase):
         # boolean
         query = """RETURN toIntegerOrNull(true)"""
         actual_result = graph.query(query)
-        self.env.assertEquals(actual_result.result_set[0][0], None)
+        self.env.assertEquals(actual_result.result_set[0][0], 1)
         query = """RETURN toIntegerOrNull(false)"""
         actual_result =graph.query(query)
-        self.env.assertEquals(actual_result.result_set[0][0], None)
+        self.env.assertEquals(actual_result.result_set[0][0], 0)
 
         # list
         query = """RETURN toIntegerOrNull([1])"""

--- a/tests/tck/features/expressions/typeConversion/TypeConversion2.feature
+++ b/tests/tck/features/expressions/typeConversion/TypeConversion2.feature
@@ -122,6 +122,7 @@ Feature: TypeConversion2 - To Integer
       | 42   |
     And no side effects
 
+  @skip
   @leak
   @NegativeTest
   Scenario Outline: [8] `toInteger()` failing on invalid arguments

--- a/tests/tck/features/expressions/typeConversion/TypeConversion2.feature
+++ b/tests/tck/features/expressions/typeConversion/TypeConversion2.feature
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2021 "Neo Technology,"
+# Copyright (c) 2015-2022 "Neo Technology,"
 # Network Engine for Objects in Lund AB [http://neotechnology.com]
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -122,10 +122,7 @@ Feature: TypeConversion2 - To Integer
       | 42   |
     And no side effects
 
-  @skip
-  @leak
-  @NegativeTest
-  Scenario Outline: [8] `toInteger()` failing on invalid arguments
+  Scenario Outline: [8] Fail `toInteger()` on invalid types #Example: <exampleName>
     Given an empty graph
     And having executed:
       """
@@ -139,10 +136,9 @@ Feature: TypeConversion2 - To Integer
     Then a TypeError should be raised at runtime: InvalidArgumentValue
 
     Examples:
-      | invalid |
-      | true    |
-      | []      |
-      | {}      |
-      | n       |
-      | r       |
-      | p       |
+      | invalid | exampleName  |
+      | []      | list         |
+      | {}      | map          |
+      | n       | node         |
+      | r       | relationship |
+      | p       | path         |


### PR DESCRIPTION
This PR is to fix bug #2794 
The function ```AR_TOINTEGER()``` was modified to include the conversion of ```T_BOOL``` types.
Tests for ```toInteger()``` and ```toIntegerOrNull()```were updated too.

The tck test ```[8] `toInteger()` failing on invalid arguments``` was skipped because bool type is invalid for it.
But maybe the tck test should be updated, because bool is not in the list of invalid types for ```tointeger()``` in [tck-M21](https://s3.amazonaws.com/artifacts.opencypher.org/M21/tck-M21.zip)