### PR TITLE
Fix right(), left() length validation

### DIFF
--- a/src/arithmetic/string_funcs/string_funcs.c
+++ b/src/arithmetic/string_funcs/string_funcs.c
@@ -20,12 +20,14 @@
 
 // returns a string containing the specified number of leftmost characters of the original string.
 SIValue AR_LEFT(SIValue *argv, int argc, void *private_data) {
-	if(SIValue_IsNull(argv[0]) || SIValue_IsNull(argv[1])) return SI_NullVal();
+	if(SIValue_IsNull(argv[0])) return SI_NullVal();
 
-	int64_t newlen = argv[1].longval;
-
+	int64_t newlen = -1;
+	if(SI_TYPE(argv[1]) == T_INT64) {
+		newlen = argv[1].longval;
+	} 
 	if(newlen < 0) {
-		ErrorCtx_SetError("length must be positive integer");
+		ErrorCtx_SetError("length must be a non-negative integer");
 		return SI_NullVal();
 	}
 
@@ -54,12 +56,14 @@ SIValue AR_LTRIM(SIValue *argv, int argc, void *private_data) {
 
 // returns a string containing the specified number of rightmost characters of the original string.
 SIValue AR_RIGHT(SIValue *argv, int argc, void *private_data) {
-	if(SIValue_IsNull(argv[0]) || SIValue_IsNull(argv[0])) return SI_NullVal();
+	if(SIValue_IsNull(argv[0])) return SI_NullVal();
 
-	int64_t newlen = argv[1].longval;
-
+	int64_t newlen = -1;
+	if(SI_TYPE(argv[1]) == T_INT64) {
+		newlen = argv[1].longval;
+	}
 	if(newlen < 0) {
-		ErrorCtx_SetError("length must be positive integer");
+		ErrorCtx_SetError("length must be a non-negative integer");
 		return SI_NullVal();
 	}
 
@@ -417,7 +421,7 @@ void Register_StringFuncs() {
 
 	types = array_new(SIType, 2);
 	array_append(types, (T_STRING | T_NULL));
-	array_append(types, T_INT64 | T_NULL);
+	array_append(types, T_INT64);
 	ret_type = T_STRING | T_NULL;
 	func_desc = AR_FuncDescNew("left", AR_LEFT, 2, 2, types, ret_type, false, true);
 	AR_RegFunc(func_desc);
@@ -430,7 +434,7 @@ void Register_StringFuncs() {
 
 	types = array_new(SIType, 2);
 	array_append(types, (T_STRING | T_NULL));
-	array_append(types, T_INT64 | T_NULL);
+	array_append(types, T_INT64);
 	ret_type = T_STRING | T_NULL;
 	func_desc = AR_FuncDescNew("right", AR_RIGHT, 2, 2, types, ret_type, false, true);
 	AR_RegFunc(func_desc);

--- a/src/arithmetic/string_funcs/string_funcs.c
+++ b/src/arithmetic/string_funcs/string_funcs.c
@@ -20,6 +20,8 @@
 
 // returns a string containing the specified number of leftmost characters of the original string.
 SIValue AR_LEFT(SIValue *argv, int argc, void *private_data) {
+	if(SIValue_IsNull(argv[0]) && SIValue_IsNull(argv[1])) return SI_NullVal();
+	
 	int64_t newlen = -1;
 	if(SI_TYPE(argv[1]) == T_INT64) {
 		newlen = argv[1].longval;
@@ -56,6 +58,8 @@ SIValue AR_LTRIM(SIValue *argv, int argc, void *private_data) {
 
 // returns a string containing the specified number of rightmost characters of the original string.
 SIValue AR_RIGHT(SIValue *argv, int argc, void *private_data) {
+	if(SIValue_IsNull(argv[0]) && SIValue_IsNull(argv[1])) return SI_NullVal();
+	
 	int64_t newlen = -1;
 	if(SI_TYPE(argv[1]) == T_INT64) {
 		newlen = argv[1].longval;
@@ -421,7 +425,7 @@ void Register_StringFuncs() {
 
 	types = array_new(SIType, 2);
 	array_append(types, (T_STRING | T_NULL));
-	array_append(types, T_INT64);
+	array_append(types, T_INT64 | T_NULL);
 	ret_type = T_STRING | T_NULL;
 	func_desc = AR_FuncDescNew("left", AR_LEFT, 2, 2, types, ret_type, false, true);
 	AR_RegFunc(func_desc);
@@ -434,7 +438,7 @@ void Register_StringFuncs() {
 
 	types = array_new(SIType, 2);
 	array_append(types, (T_STRING | T_NULL));
-	array_append(types, T_INT64);
+	array_append(types, T_INT64 | T_NULL);
 	ret_type = T_STRING | T_NULL;
 	func_desc = AR_FuncDescNew("right", AR_RIGHT, 2, 2, types, ret_type, false, true);
 	AR_RegFunc(func_desc);

--- a/src/arithmetic/string_funcs/string_funcs.c
+++ b/src/arithmetic/string_funcs/string_funcs.c
@@ -20,8 +20,6 @@
 
 // returns a string containing the specified number of leftmost characters of the original string.
 SIValue AR_LEFT(SIValue *argv, int argc, void *private_data) {
-	if(SIValue_IsNull(argv[0])) return SI_NullVal();
-
 	int64_t newlen = -1;
 	if(SI_TYPE(argv[1]) == T_INT64) {
 		newlen = argv[1].longval;
@@ -30,6 +28,8 @@ SIValue AR_LEFT(SIValue *argv, int argc, void *private_data) {
 		ErrorCtx_SetError("length must be a non-negative integer");
 		return SI_NullVal();
 	}
+
+	if(SIValue_IsNull(argv[0])) return SI_NullVal();
 
 	if(strlen(argv[0].stringval) <= newlen) {
 		// No need to truncate this string based on the requested length
@@ -56,8 +56,6 @@ SIValue AR_LTRIM(SIValue *argv, int argc, void *private_data) {
 
 // returns a string containing the specified number of rightmost characters of the original string.
 SIValue AR_RIGHT(SIValue *argv, int argc, void *private_data) {
-	if(SIValue_IsNull(argv[0])) return SI_NullVal();
-
 	int64_t newlen = -1;
 	if(SI_TYPE(argv[1]) == T_INT64) {
 		newlen = argv[1].longval;
@@ -66,6 +64,8 @@ SIValue AR_RIGHT(SIValue *argv, int argc, void *private_data) {
 		ErrorCtx_SetError("length must be a non-negative integer");
 		return SI_NullVal();
 	}
+
+	if(SIValue_IsNull(argv[0])) return SI_NullVal();
 
 	int64_t start = strlen(argv[0].stringval) - newlen;
 
@@ -141,7 +141,7 @@ SIValue AR_SUBSTRING(SIValue *argv, int argc, void *private_data) {
 
 	/* Make sure start doesn't overreach. */
 	if(start < 0) {
-		ErrorCtx_SetError("start must be positive integer");
+		ErrorCtx_SetError("start must be a non-negative integer");
 		return SI_NullVal();
 	}
 	if(start >= original_len) return SI_ConstStringVal("");
@@ -152,7 +152,7 @@ SIValue AR_SUBSTRING(SIValue *argv, int argc, void *private_data) {
 	} else {
 		length = argv[2].longval;
 		if(length < 0) {
-			ErrorCtx_SetError("length must be positive integer");
+			ErrorCtx_SetError("length must be a non-negative integer");
 			return SI_ConstStringVal("");
 		}
 

--- a/src/arithmetic/string_funcs/string_funcs.c
+++ b/src/arithmetic/string_funcs/string_funcs.c
@@ -20,7 +20,7 @@
 
 // returns a string containing the specified number of leftmost characters of the original string.
 SIValue AR_LEFT(SIValue *argv, int argc, void *private_data) {
-	if(SIValue_IsNull(argv[0]) && SIValue_IsNull(argv[1])) return SI_NullVal();
+	if(SIValue_IsNull(argv[0])) return SI_NullVal();
 	
 	int64_t newlen = -1;
 	if(SI_TYPE(argv[1]) == T_INT64) {
@@ -30,8 +30,6 @@ SIValue AR_LEFT(SIValue *argv, int argc, void *private_data) {
 		ErrorCtx_SetError("length must be a non-negative integer");
 		return SI_NullVal();
 	}
-
-	if(SIValue_IsNull(argv[0])) return SI_NullVal();
 
 	if(strlen(argv[0].stringval) <= newlen) {
 		// No need to truncate this string based on the requested length
@@ -58,7 +56,7 @@ SIValue AR_LTRIM(SIValue *argv, int argc, void *private_data) {
 
 // returns a string containing the specified number of rightmost characters of the original string.
 SIValue AR_RIGHT(SIValue *argv, int argc, void *private_data) {
-	if(SIValue_IsNull(argv[0]) && SIValue_IsNull(argv[1])) return SI_NullVal();
+	if(SIValue_IsNull(argv[0])) return SI_NullVal();
 	
 	int64_t newlen = -1;
 	if(SI_TYPE(argv[1]) == T_INT64) {
@@ -68,8 +66,6 @@ SIValue AR_RIGHT(SIValue *argv, int argc, void *private_data) {
 		ErrorCtx_SetError("length must be a non-negative integer");
 		return SI_NullVal();
 	}
-
-	if(SIValue_IsNull(argv[0])) return SI_NullVal();
 
 	int64_t start = strlen(argv[0].stringval) - newlen;
 

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -726,14 +726,14 @@ class testFunctionCallsFlow(FlowTestsBase):
             graph.query(query)
             self.env.assertTrue(False)
         except ResponseError as e:
-            self.env.assertEqual(str(e), "length must be positive integer")
+            self.env.assertEqual(str(e), "length must be a non-negative integer")
 
         try:
             query = """RETURN SUBSTRING("muchacho", -3, 3)"""
             graph.query(query)
             self.env.assertTrue(False)
         except ResponseError as e:
-            self.env.assertEqual(str(e), "start must be positive integer")
+            self.env.assertEqual(str(e), "start must be a non-negative integer")
 
     def test25_left(self):
         query = """RETURN LEFT('muchacho', 4)"""
@@ -753,9 +753,18 @@ class testFunctionCallsFlow(FlowTestsBase):
             graph.query(query)
             self.env.assertTrue(False)
         except ResponseError as e:
-            self.env.assertEqual(str(e), "length must be positive integer")
+            self.env.assertEqual(str(e), "length must be a non-negative integer")
 
-    def tes26_right(self):
+        # invalid input types
+        queries = [
+            """RETURN left(NULL, NULL)""",
+            """RETURN left(NULL, 'a')""",
+            """RETURN left(NULL, 1.3)""",
+        ]
+        for query in queries:
+            self.expect_type_error(query)
+
+    def test26_right(self):
         query = """RETURN RIGHT('muchacho', 4)"""
         actual_result = graph.query(query)
         self.env.assertEquals(actual_result.result_set[0][0], "acho")
@@ -773,7 +782,16 @@ class testFunctionCallsFlow(FlowTestsBase):
             graph.query(query)
             self.env.assertTrue(False)
         except ResponseError as e:
-            self.env.assertEqual(str(e), "length must be positive integer")
+            self.env.assertEqual(str(e), "length must be a non-negative integer")
+
+        # invalid input types
+        queries = [
+            """RETURN right(NULL, NULL)""",
+            """RETURN right(NULL, 'a')""",
+            """RETURN right(NULL, 1.3)""",
+        ]
+        for query in queries:
+            self.expect_type_error(query)
 
     def test27_string_concat(self):
         larg_double = 1.123456e300

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -736,17 +736,14 @@ class testFunctionCallsFlow(FlowTestsBase):
             self.env.assertEqual(str(e), "start must be a non-negative integer")
 
     def test25_left(self):
-        query = """RETURN LEFT('muchacho', 4)"""
-        actual_result = graph.query(query)
-        self.env.assertEquals(actual_result.result_set[0][0], "much")
-
-        query = """RETURN LEFT('muchacho', 100)"""
-        actual_result = graph.query(query)
-        self.env.assertEquals(actual_result.result_set[0][0], "muchacho")
-
-        query = """RETURN LEFT(NULL, 100)"""
-        actual_result = graph.query(query)
-        self.env.assertEquals(actual_result.result_set[0][0], None)
+        query_to_expected_result = {
+            "RETURN LEFT('muchacho', 4)" : [['much']],
+            "RETURN LEFT('muchacho', 100)" : [['muchacho']],
+            "RETURN LEFT(NULL, 100)" : [[None]],
+            "RETURN LEFT(NULL, NULL)" : [[None]],
+        }
+        for query, expected_result in query_to_expected_result.items():
+            self.get_res_and_assertEquals(query, expected_result)
 
         try:
             query = """RETURN LEFT('', -100)"""
@@ -757,7 +754,6 @@ class testFunctionCallsFlow(FlowTestsBase):
 
         # invalid input types
         queries = [
-            """RETURN left(NULL, NULL)""",
             """RETURN left(NULL, 'a')""",
             """RETURN left(NULL, 1.3)""",
         ]
@@ -765,17 +761,14 @@ class testFunctionCallsFlow(FlowTestsBase):
             self.expect_type_error(query)
 
     def test26_right(self):
-        query = """RETURN RIGHT('muchacho', 4)"""
-        actual_result = graph.query(query)
-        self.env.assertEquals(actual_result.result_set[0][0], "acho")
-
-        query = """RETURN RIGHT('muchacho', 100)"""
-        actual_result = graph.query(query)
-        self.env.assertEquals(actual_result.result_set[0][0], "muchacho")
-
-        query = """RETURN RIGHT(NULL, 100)"""
-        actual_result = graph.query(query)
-        self.env.assertEquals(actual_result.result_set[0][0], None)
+        query_to_expected_result = {
+            "RETURN RIGHT('muchacho', 4)" : [['acho']],
+            "RETURN RIGHT('muchacho', 100)" : [['muchacho']],
+            "RETURN RIGHT(NULL, 100)" : [[None]],
+            "RETURN RIGHT(NULL, NULL)" : [[None]],
+        }
+        for query, expected_result in query_to_expected_result.items():
+            self.get_res_and_assertEquals(query, expected_result)
 
         try:
             query = """RETURN RIGHT('', -100)"""
@@ -786,7 +779,6 @@ class testFunctionCallsFlow(FlowTestsBase):
 
         # invalid input types
         queries = [
-            """RETURN right(NULL, NULL)""",
             """RETURN right(NULL, 'a')""",
             """RETURN right(NULL, 1.3)""",
         ]

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -739,23 +739,29 @@ class testFunctionCallsFlow(FlowTestsBase):
         query_to_expected_result = {
             "RETURN LEFT('muchacho', 4)" : [['much']],
             "RETURN LEFT('muchacho', 100)" : [['muchacho']],
+            "RETURN LEFT(NULL, -1)" : [[None]],
             "RETURN LEFT(NULL, 100)" : [[None]],
             "RETURN LEFT(NULL, NULL)" : [[None]],
         }
         for query, expected_result in query_to_expected_result.items():
             self.get_res_and_assertEquals(query, expected_result)
 
-        try:
-            query = """RETURN LEFT('', -100)"""
-            graph.query(query)
-            self.env.assertTrue(False)
-        except ResponseError as e:
-            self.env.assertEqual(str(e), "length must be a non-negative integer")
+        # invalid length argument
+        queries = [
+            """RETURN LEFT('', -100)""",
+            """RETURN LEFT('a', NULL)""",
+            ]
+        for query in queries:
+            try:
+                graph.query(query)
+                self.env.assertTrue(False)
+            except ResponseError as e:
+                self.env.assertEqual(str(e), "length must be a non-negative integer")
 
         # invalid input types
         queries = [
-            """RETURN left(NULL, 'a')""",
-            """RETURN left(NULL, 1.3)""",
+            """RETURN LEFT(NULL, 'a')""",
+            """RETURN LEFT(NULL, 1.3)""",
         ]
         for query in queries:
             self.expect_type_error(query)
@@ -764,23 +770,29 @@ class testFunctionCallsFlow(FlowTestsBase):
         query_to_expected_result = {
             "RETURN RIGHT('muchacho', 4)" : [['acho']],
             "RETURN RIGHT('muchacho', 100)" : [['muchacho']],
+            "RETURN RIGHT(NULL, -1)" : [[None]],
             "RETURN RIGHT(NULL, 100)" : [[None]],
             "RETURN RIGHT(NULL, NULL)" : [[None]],
         }
         for query, expected_result in query_to_expected_result.items():
             self.get_res_and_assertEquals(query, expected_result)
 
-        try:
-            query = """RETURN RIGHT('', -100)"""
-            graph.query(query)
-            self.env.assertTrue(False)
-        except ResponseError as e:
-            self.env.assertEqual(str(e), "length must be a non-negative integer")
+        # invalid length argument
+        queries = [
+            """RETURN RIGHT('', -100)""",
+            """RETURN RIGHT('a', NULL)""",
+            ]
+        for query in queries:
+            try:
+                graph.query(query)
+                self.env.assertTrue(False)
+            except ResponseError as e:
+                self.env.assertEqual(str(e), "length must be a non-negative integer")
 
         # invalid input types
         queries = [
-            """RETURN right(NULL, 'a')""",
-            """RETURN right(NULL, 1.3)""",
+            """RETURN RIGHT(NULL, 'a')""",
+            """RETURN RIGHT(NULL, 1.3)""",
         ]
         for query in queries:
             self.expect_type_error(query)


### PR DESCRIPTION
These changes are to fix bug #2798.

Changes:
- The validations of length are done before validating if input string is null
- Error message for invalid length was changed in functions ```left()```, ```right()```, and ```substring()```

Sample output:
```
127.0.0.1:6379> GRAPH.QUERY g "RETURN right('a', null)"
(error) length must be a non-negative integer
```
```
127.0.0.1:6379> GRAPH.QUERY g "RETURN right(null, null)"
1) 1) "right(null, null)"
2) 1) 1) (nil)
```
```
127.0.0.1:6379> GRAPH.QUERY g "RETURN right(null, -1)"
1) 1) "right(null, -1)"
2) 1) 1) (nil)
```
Edit: Sample output updated with changes  [f917b06](https://github.com/RedisGraph/RedisGraph/pull/2801/commits/f917b067e6a22abac5b75eea1060792c7461e114)