### PR TITLE
fix using timeout max as default when default not configured

### DIFF
--- a/src/commands/cmd_dispatcher.c
+++ b/src/commands/cmd_dispatcher.c
@@ -74,7 +74,7 @@ static int _read_flags
 					return REDISMODULE_ERR;
 				}
 
-				if(timeout == CONFIG_TIMEOUT_NO_TIMEOUT && timeout_rw) {
+				if(*timeout == CONFIG_TIMEOUT_NO_TIMEOUT && timeout_rw) {
 					Config_Option_get(Config_TIMEOUT_DEFAULT, timeout);
 					if(timeout == CONFIG_TIMEOUT_NO_TIMEOUT) {
 						*timeout = max_timeout;

--- a/src/commands/cmd_dispatcher.c
+++ b/src/commands/cmd_dispatcher.c
@@ -42,7 +42,7 @@ static int _read_flags
 	if(max_timeout != CONFIG_TIMEOUT_NO_TIMEOUT ||
 	   *timeout != CONFIG_TIMEOUT_NO_TIMEOUT) {
 		*timeout_rw = true;
-		if(timeout == CONFIG_TIMEOUT_NO_TIMEOUT) {
+		if(*timeout == CONFIG_TIMEOUT_NO_TIMEOUT) {
 			*timeout = max_timeout;
 		}
 	} else {


### PR DESCRIPTION
fix https://github.com/RedisGraph/RedisGraph/issues/2809