### PR TITLE
Enabled Pull Request CI Performance info generation and publishing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -555,7 +555,7 @@ jobs:
           shell: /bin/bash -l -eo pipefail
           command: make NPROC=16
       - benchmark-steps:
-          module_path: "/root/project/src/$PACKAGE_NAME.so"
+          module_path: "/root/project/bin/linux-x64-release/src/$PACKAGE_NAME.so"
 
   benchmark-profiler:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -314,6 +314,16 @@ commands:
               --fail_fast \
               --push_results_redistimeseries \
               --allowed-envs << parameters.allowed_envs >>
+      - run:
+          name: Generate Pull Request Performance info
+          command: |
+            if [[ -n ${CIRCLE_PULL_REQUEST##*/} ]]; then
+                redisbench-admin compare  \
+                  --defaults_filename ./tests/benchmarks/defaults.yml \
+                  --comparison-branch $CIRCLE_BRANCH \
+                  --pull-request ${CIRCLE_PULL_REQUEST##*/}
+            fi
+
 
 #----------------------------------------------------------------------------------------------------------------------------------
 

--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -14,3 +14,8 @@ exporter:
       - "$.OverallGraphInternalLatencies.Total.q99"
       - "$.OverallGraphInternalLatencies.Total.avg"
       - "$.OverallQueryRates.Total"
+  comparison:
+    metrics:
+      - "$.OverallQueryRates.Total"
+    mode: higher-better
+    baseline-branch: master


### PR DESCRIPTION
This PR enables Automated performance analysis summaries to be generated and published to PRs that are labeled with `action:run-benchmark` label.
- Here's a sample output of a PR comment: https://github.com/RedisGraph/RedisGraph/pull/2789#issuecomment-1371139517
- Notice that multiples pushes to the PR will always update the previous comment to avoid bloating the PR. 