### PR TITLE
Exporting the latency factor between internal and external latencies. Ensuring the factor is bellow 5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -321,7 +321,8 @@ commands:
                 redisbench-admin compare  \
                   --defaults_filename ./tests/benchmarks/defaults.yml \
                   --comparison-branch $CIRCLE_BRANCH \
-                  --pull-request ${CIRCLE_PULL_REQUEST##*/}
+                  --pull-request ${CIRCLE_PULL_REQUEST##*/} \
+                  --auto-approve
             fi
 
 

--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -1,7 +1,6 @@
 version: 0.1
 kpis:
   - eq: { $.Totals.Total.Errors: 0 }
-  - le: { $.OverallRelativeInternalExternalLatencyDiff.q50: 5 }
 exporter:
   redistimeseries:
     timemetric: "$.StartTime"

--- a/tests/benchmarks/defaults.yml
+++ b/tests/benchmarks/defaults.yml
@@ -1,6 +1,7 @@
 version: 0.1
 kpis:
   - eq: { $.Totals.Total.Errors: 0 }
+  - le: { $.OverallRelativeInternalExternalLatencyDiff.q50: 5 }
 exporter:
   redistimeseries:
     timemetric: "$.StartTime"
@@ -13,6 +14,8 @@ exporter:
       - "$.OverallGraphInternalLatencies.Total.q95"
       - "$.OverallGraphInternalLatencies.Total.q99"
       - "$.OverallGraphInternalLatencies.Total.avg"
+      - "$.OverallRelativeInternalExternalLatencyDiff.avg"
+      - "$.OverallRelativeInternalExternalLatencyDiff.q50"
       - "$.OverallQueryRates.Total"
   comparison:
     metrics:


### PR DESCRIPTION
Changes:
- Include internal/external latency ratio ( added to go benchmark took in https://github.com/RedisGraph/redisgraph-benchmark-go/pull/20 )
