### PR TITLE
Relationship isomorphism

### DIFF
--- a/src/algorithms/all_paths.h
+++ b/src/algorithms/all_paths.h
@@ -4,16 +4,14 @@
  * the Server Side Public License v1 (SSPLv1).
  */
 
-/*
- * Finds all paths starting at given source node
- * We're computing one path at a time, this is done
- * to take advantage of scenarios where a query specifies LIMIT.
- * To implement this kind of iterative path finding using DFS
- * we're keeping track after:
- * 1. the last path computed, which we'll try to expand
- * 2. neighboring nodes discovered, each placed within a "level"
- * array containing all nodes discovered at a specific level.
- * */
+// finds all paths starting at given source node
+// we're computing one path at a time, this is done
+// to take advantage of scenarios where a query specifies LIMIT
+// to implement this kind of iterative path finding using DFS
+// we're keeping track after:
+// 1. the last path computed, which we'll try to expand
+// 2. neighboring nodes discovered, each placed within a "level"
+// array containing all nodes discovered at a specific level
 
 #pragma once
 
@@ -28,39 +26,42 @@ typedef struct {
 } LevelConnection;
 
 typedef struct {
-	LevelConnection **levels;   // Nodes reached at depth i, and edges leading to them.
-	Path *path;                 // Current path.
-	Graph *g;                   // Graph to traverse.
-	Edge *neighbors;            // Reusable buffer of edges along the current path.
-	int *relationIDs;           // edge type(s) to traverse.
-	int relationCount;          // length of relationIDs.
-	GRAPH_EDGE_DIR dir;         // traverse direction.
-	uint minLen;                // Path minimum length.
-	uint maxLen;                // Path max length.
-	Node *dst;                  // Destination node, defaults to NULL in case of general all paths execution.
-	Record r;                   // Record the traversal is being performed upon, only used for edge filtering.
-	FT_FilterNode *ft;          // FilterTree of predicates to be applied to traversed edges.
-	uint edge_idx;              // Record index of the edge alias, only used for edge filtering.
-	bool shortest_paths;        // Only collect shortest paths.
-	GrB_Vector visited;         // Visited nodes in shortest path.
+	LevelConnection **levels;  // nodes reached at depth i, and edges leading to them
+	Path *path;                // current path
+	Graph *g;                  // graph to traverse
+	Edge *incoming;            // reusable buffer of incoming edges
+	Edge *outgoing;            // reusable buffer of outgoing edges
+	int *relationIDs;          // edge type(s) to traverse
+	int relationCount;         // length of relationIDs
+	GRAPH_EDGE_DIR dir;        // traverse direction
+	uint minLen;               // path minimum length
+	uint maxLen;               // path max length
+	Node *dst;                 // destination node, defaults to NULL in case of general all paths execution
+	Record r;                  // record the traversal is being performed upon, only used for edge filtering
+	FT_FilterNode *ft;         // filterTree of predicates to be applied to traversed edges
+	uint edge_idx;             // record index of the edge alias, only used for edge filtering
+	bool shortest_paths;       // only collect shortest paths
+	GrB_Vector visited;        // visited nodes in shortest path
 } AllPathsCtx;
 
-// Create a new All paths context object.
-AllPathsCtx *AllPathsCtx_New(
-	Node *src,           // Source node to traverse.
-	Node *dst,           // Destination node of the paths
-	Graph *g,            // Graph to traverse.
-	int *relationIDs,    // Edge type(s) on which we'll traverse.
-	int relationCount,   // Length of relationIDs.
-	GRAPH_EDGE_DIR dir,  // Traversal direction.
-	uint minLen,         // Path length must contain be at least minLen + 1 nodes.
-	uint maxLen,         // Path length must not exceed maxLen + 1 nodes.
-	Record r,            // Record the traversal is being performed upon.
-	FT_FilterNode *ft,   // FilterTree of predicates to be applied to traversed edges.
-	uint edge_idx,       // Record index of the edge alias.
-	bool shortest_paths  // Only collect shortest paths.
+// create a new All paths context object
+AllPathsCtx *AllPathsCtx_New
+(
+	Node *src,           // source node to traverse
+	Node *dst,           // destination node of the paths
+	Graph *g,            // graph to traverse
+	int *relationIDs,    // edge type(s) on which we'll traverse
+	int relationCount,   // length of relationIDs
+	GRAPH_EDGE_DIR dir,  // traversal direction
+	uint minLen,         // path length must contain be at least minLen + 1 nodes
+	uint maxLen,         // path length must not exceed maxLen + 1 nodes
+	Record r,            // record the traversal is being performed upon
+	FT_FilterNode *ft,   // filterTree of predicates to be applied to traversed edges
+	uint edge_idx,       // record index of the edge alias
+	bool shortest_paths  // only collect shortest paths
 );
 
+// collect neighbors
 void addNeighbors
 (
 	AllPathsCtx *ctx,
@@ -69,9 +70,16 @@ void addNeighbors
 	GRAPH_EDGE_DIR dir
 );
 
-// Tries to produce a new path from given context
-// If no additional path can be computed return NULL.
-Path *AllPathsCtx_NextPath(AllPathsCtx *ctx);
+// tries to produce a new path from given context
+// if no additional path can be computed return NULL
+Path *AllPathsCtx_NextPath
+(
+	AllPathsCtx *ctx
+);
 
-// Free context object.
-void AllPathsCtx_Free(AllPathsCtx *ctx);
+// free context object
+void AllPathsCtx_Free
+(
+	AllPathsCtx *ctx
+);
+

--- a/src/datatypes/path/path.c
+++ b/src/datatypes/path/path.c
@@ -69,12 +69,45 @@ size_t Path_Len(const Path *p) {
 	return Path_EdgeCount(p);
 }
 
-bool Path_ContainsNode(const Path *p, Node *n) {
-	uint32_t pathDepth = Path_NodeCount(p);
-	EntityID nId = ENTITY_GET_ID(n);
-	for(int i = 0; i < pathDepth; i++) {
-		if(ENTITY_GET_ID(p->nodes + i) == nId) return true;
+// returns true node is on the path
+bool Path_ContainsNode
+(
+	const Path *p,  // path to search
+	const Node *n   // node to locate
+) {
+	ASSERT(p != NULL);
+	ASSERT(n != NULL);
+
+	EntityID id = ENTITY_GET_ID(n);
+	uint32_t count = Path_NodeCount(p);
+
+	for(int i = 0; i < count; i++) {
+		if(ENTITY_GET_ID(p->nodes + i) == id) {
+			return true;
+		}
 	}
+
+	return false;
+}
+
+// returns true if edge is on the path
+bool Path_ContainsEdge
+(
+	const Path *p,  // path to search
+	const Edge *e   // edge to locate
+) {
+	ASSERT(p != NULL);
+	ASSERT(e != NULL);
+
+	EntityID id = ENTITY_GET_ID(e);
+	uint32_t count = Path_EdgeCount(p);
+
+	for(int i = 0; i < count; i++) {
+		if(ENTITY_GET_ID(p->edges + i) == id) {
+			return true;
+		}
+	}
+
 	return false;
 }
 

--- a/src/datatypes/path/path.h
+++ b/src/datatypes/path/path.h
@@ -56,8 +56,19 @@ size_t Path_EdgeCount(const Path *p);
 // returns the path length - amount of edges
 size_t Path_Len(const Path *p);
 
-// returns if a path contains a node
-bool Path_ContainsNode(const Path *p, Node *n);
+// returns true node is on the path
+bool Path_ContainsNode
+(
+	const Path *p,  // path to search
+	const Node *n   // node to locate
+);
+
+// returns true if edge is on the path
+bool Path_ContainsEdge
+(
+	const Path *p,  // path to search
+	const Edge *e   // edge to locate
+);
 
 // clones a path
 Path *Path_Clone(const Path *p);


### PR DESCRIPTION
#2865
This PR changes how `variable length traversal` behaves

We've used to stop expanding a path upon detecting a cycle e.g. `a->b->a`
This PR simply ensures a path doesn't contains duplicated edges, allowing paths such as `a->b->a->c`