### PR TITLE
Add internal function inOrEqual

### DIFF
--- a/src/arithmetic/arithmetic_expression_construct.c
+++ b/src/arithmetic/arithmetic_expression_construct.c
@@ -274,12 +274,26 @@ static AR_ExpNode *_AR_EXP_FromBinaryOpExpression(const cypher_astnode_t *expr) 
 	const cypher_operator_t *operator = cypher_ast_binary_operator_get_operator(expr);
 	AST_Operator operator_enum = AST_ConvertOperatorNode(operator);
 	// Arguments are of type CYPHER_AST_EXPRESSION
-	AR_ExpNode *op = AR_EXP_NewOpNodeFromAST(operator_enum, 2);
 	const cypher_astnode_t *lhs_node = cypher_ast_binary_operator_get_argument1(expr);
-	op->op.children[0] = _AR_EXP_FromASTNode(lhs_node);
 	const cypher_astnode_t *rhs_node = cypher_ast_binary_operator_get_argument2(expr);
-	op->op.children[1] = _AR_EXP_FromASTNode(rhs_node);
-	return op;
+	const cypher_astnode_type_t t = cypher_astnode_type(rhs_node);
+
+	if ((strcasecmp(_ASTOpToString(operator_enum), "in") == 0) && (t == CYPHER_AST_PROPERTY_OPERATOR)) {
+		// in case of function "in" with propery operator arguments, use the function "inorEqual"
+		// to support case like:
+		// CREATE (a{z:1}), (b{z:'a'}), (c{z:[1,2]}), (d)
+		// MATCH (a) WHERE (1 in a.z) RETURN a
+		// MATCH (a) RETURN a, 1 IN a.z
+		AR_ExpNode *opIrOrEqual = AR_EXP_NewOpNode("inOrEqual", true, 2);
+		opIrOrEqual->op.children[0] = _AR_EXP_FromASTNode(lhs_node);
+		opIrOrEqual->op.children[1] = _AR_EXP_FromASTNode(rhs_node);
+		return opIrOrEqual;
+	} else {
+		AR_ExpNode *op = AR_EXP_NewOpNodeFromAST(operator_enum, 2);
+		op->op.children[0] = _AR_EXP_FromASTNode(lhs_node);
+		op->op.children[1] = _AR_EXP_FromASTNode(rhs_node);
+		return op;
+	}
 }
 
 static AR_ExpNode *_AR_EXP_FromComparisonExpression(const cypher_astnode_t *expr) {

--- a/src/arithmetic/list_funcs/list_funcs.c
+++ b/src/arithmetic/list_funcs/list_funcs.c
@@ -324,8 +324,35 @@ SIValue AR_IN(SIValue *argv, int argc, void *private_data) {
 	// indicate if there was a null comparison during the array scan
 	bool comparedNull = false;
 	if(SIArray_ContainsValue(lookupList, lookupValue, &comparedNull)) {
+		//printf("Nafraf: SIArray_ContainsValue inside AR_IN\n");
 		return SI_BoolVal(true);
 	}
+	// if there was a null comparison return null, other wise return false as the lookup item did not found
+	return comparedNull ? SI_NullVal() : SI_BoolVal(false);
+}
+
+// Receives two arguments and check if arg1 is in arg2 (if it is a list) or is equal to arg2.
+SIValue AR_INOREQUAL(SIValue *argv, int argc, void *private_data) {
+	//printf("Nafraf: AR_INPROPERTIES\n");
+	ASSERT(argc == 2);
+	if(SI_TYPE(argv[1]) == T_NULL) return SI_NullVal();
+	SIValue lookupValue = argv[0];
+	SIValue containingValue = argv[1];
+
+	// indicate if there was a null comparison
+	bool comparedNull = false;
+
+	if(SI_TYPE(containingValue) == T_ARRAY) {
+		if(SIArray_ContainsValue(argv[1], lookupValue, &comparedNull)) {
+			return SI_BoolVal(true);
+		}
+	}
+	int disjointOrNull = 0;
+	int compareValue = SIValue_Compare(containingValue, lookupValue, &disjointOrNull);
+	if(disjointOrNull == COMPARED_NULL) {
+		comparedNull = true;
+	}
+	if(compareValue == 0) return SI_BoolVal(true);
 	// if there was a null comparison return null, other wise return false as the lookup item did not found
 	return comparedNull ? SI_NullVal() : SI_BoolVal(false);
 }
@@ -511,6 +538,13 @@ void Register_ListFuncs() {
 	array_append(types, T_ARRAY | T_NULL);
 	ret_type = T_NULL | T_BOOL;
 	func_desc = AR_FuncDescNew("in", AR_IN, 2, 2, types, ret_type, true, true);
+	AR_RegFunc(func_desc);
+
+	types = array_new(SIType, 2);
+	array_append(types, SI_ALL);
+	array_append(types, SI_ALL | T_NULL);
+	ret_type = T_NULL | T_BOOL;
+	func_desc = AR_FuncDescNew("inOrEqual", AR_INOREQUAL, 2, 2, types, ret_type, true, true);
 	AR_RegFunc(func_desc);
 
 	types = array_new(SIType, 1);

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -2061,6 +2061,18 @@ class testFunctionCallsFlow(FlowTestsBase):
         for query, expected_result in query_to_expected_result.items():
             self.get_res_and_assertEquals(query, expected_result)
 
+        query = "CREATE (a:testIN {z:1}), (b:testIN {z:'a'}), (c:testIN {z:[1, 2]}), (d:testIN), (e:testIN {z:[3, [1, 2]]})"
+        actual_result = graph.query(query)
+        query_to_expected_result = {
+            "MATCH (a:testIN) RETURN 1 IN a.z": [[True], [False], [True], [None], [False]],
+            "MATCH (a:testIN) RETURN 'a' IN a.z": [[False], [True], [False], [None], [False]],
+            "MATCH (a:testIN) RETURN 1 IN [a.z]": [[True], [False], [False], [None], [False]],
+            "MATCH (a:testIN) RETURN [1, 2] IN a.z": [[False], [False], [True], [None], [True]],
+            "MATCH (a:testIN) RETURN [1, 2] IN [a.z]": [[False], [False], [True], [None], [False]],
+        }
+        for query, expected_result in query_to_expected_result.items():
+            self.get_res_and_assertEquals(query, expected_result)
+
     def test81_ISNULL(self):
         arr = ["NULL", "1", "1.2", "TRUE", "FALSE", "'string'", "[1,2,3]"]
         for ind, s in enumerate(arr):


### PR DESCRIPTION
This PR is to solve #2854: "WHERE element IN list - should cast runtime non-list to a single-element list"

The proposed change is to create a new internal function ``inOrEqual`` that is called in case of ``in`` operator when the second argument is of type property operator.

The function ``inOrEqual`` receives two arguments and returns true in the following cases:
1.  ``arg2`` is list and ``arg1`` is in ``arg2``
2.  ``arg1`` is equal to ``arg2``

