### PR TITLE
Add issue template for bug reports.

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,72 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug"]
+assignees:
+  - LiorKogan
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: minimal-steps-to-reproduce
+    attributes:
+      label: Minimal steps to reproduce
+      description: Please tell us what steps to take in order to reproduce this problem quickly.
+      placeholder: The minimal steps are...
+      value: "1. On a fresh instance of RedisGraph, perform this query X."
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behaviour
+    attributes:
+      label: What is expected behaviour?
+      description: A clear and concise description of what you expected to happen.
+      placeholder: The expected behaviour is...
+      value: "The query should have returned these results: XXX, YYY."
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      placeholder: "RedisGraph 2.8.24 with Redis 6."
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: The Code of Conduct helps create a safe space for everyone. We require
+        that everyone agrees to it.
+      options:
+        - label: I have provided the minimal reproduction path.
+          required: true
+        - label: I have provided the relevant files via attachments (logs, stack traces, crash dumps, core-dumps, etc).
+          required: true
+        - label: I confirm the problem happens on another instance with the same state.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
This greatly helps the maintainers and contributors to understand and develop a solution to the bug described faster and helps the reporter write the report faster and in a more helpful way.

[Click to preview in my fork (1st stage - choosing).](https://github.com/vityafx/RedisGraph/issues/new/choose)
[Click to preview in my fork (2nd stage - filling).](https://github.com/vityafx/RedisGraph/issues/new?assignees=LiorKogan&labels=bug&template=BUG-REPORT.yml&title=%5BBug%5D%3A+)
[Click to preview in my fork (3rd stage - filled example).](https://github.com/vityafx/RedisGraph/issues/2)

Feel free to comment and suggest changes.