### PR TITLE
Add number utilities.

### DIFF
--- a/src/util/num.c
+++ b/src/util/num.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright Redis Ltd. 2018 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#include "num.h"
+
+#if __has_builtin(__builtin_add_overflow)
+#define CHECKED_ADD(prefix, type) \
+    bool checked_add_##prefix(const type lhs, const type rhs, type *result) { \
+return !__builtin_add_overflow(lhs, rhs, result); \
+}
+#else
+#define CHECKED_ADD(prefix, type)                   \
+bool checked_add_##prefix                           \
+(                                                   \
+    const type lhs,                                 \
+    const type rhs,                                 \
+    type *result                                    \
+) {                                                 \
+    if (!result) {                                  \
+        return false;                               \
+    }                                               \
+                                                    \
+    *result = lhs + rhs;                            \
+    if (*result < lhs || *result < rhs) {           \
+        return false;                               \
+    }                                               \
+                                                    \
+    return true;                                    \
+}
+#endif // __builtin_add_overflow
+
+CHECKED_ADD(u8, uint8_t);
+CHECKED_ADD(u16, uint16_t);
+CHECKED_ADD(u32, uint32_t);
+CHECKED_ADD(u64, uint64_t);

--- a/src/util/num.h
+++ b/src/util/num.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright Redis Ltd. 2018 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+/**
+ * This file contains helpful functions to work with numbers, like
+ * checked addition for unsigned integers, among others.
+ * To support the "overload" for a single function using different arguments
+ * (except for the out parameter), all the arguments for addition are implicitly
+ * converted to the max-width type (uint64_t) and only then, inside the body,
+ * the checks are performed.
+*/
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// Checks whether the specified flag is set within the flag variable.
+// Evaluates to true if set, to false otherwise.
+#define CHECK_FLAG(flag_var, flag_value) \
+    ((flag_var & flag_value) == flag_value)
+
+bool checked_add_u8(const uint8_t lhs, const uint8_t rhs, uint8_t *result);
+bool checked_add_u16(const uint16_t lhs, const uint16_t rhs, uint16_t *result);
+bool checked_add_u32(const uint32_t lhs, const uint32_t rhs, uint32_t *result);
+bool checked_add_u64(const uint64_t lhs, const uint64_t rhs, uint64_t *result);

--- a/tests/unit/test_num.c
+++ b/tests/unit/test_num.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright Redis Ltd. 2018 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#include "src/util/num.h"
+#include <stdint.h>
+
+#include "acutest.h"
+
+#define TYPE(width) uint##width##_t
+#define ADD(width) checked_add_u##width
+
+#define DEFINE_TEST(name, width)                      \
+void test_NumOverflow_CheckedAddU##width(void) {      \
+    TYPE(width) out = 0;                              \
+    static const TYPE(width) MAX = UINT##width##_MAX; \
+    bool is_ok = ADD(width)(MAX - 1, 1, &out);        \
+    /* The value hasn't overflown. */                 \
+    TEST_ASSERT(out == MAX);                          \
+    TEST_ASSERT(is_ok == true);                       \
+    is_ok = ADD(width)(MAX - 1, 2, &out);             \
+    /* The value has overflown. */                    \
+    TEST_ASSERT(out == 0);                            \
+    TEST_ASSERT(is_ok == false);                      \
+    is_ok = ADD(width)(MAX - 1, 100, &out);           \
+    /* The value has overflown. */                    \
+    TEST_ASSERT(out == 98);                           \
+    TEST_ASSERT(is_ok == false);                      \
+}
+
+DEFINE_TEST(test_NumOverflow_CheckedAddU8, 8);
+DEFINE_TEST(test_NumOverflow_CheckedAddU16, 16);
+DEFINE_TEST(test_NumOverflow_CheckedAddU32, 32);
+DEFINE_TEST(test_NumOverflow_CheckedAddU64, 64);
+
+
+TEST_LIST = {
+    {"NumOverflow_CheckedAddU8", test_NumOverflow_CheckedAddU8},
+    {"NumOverflow_CheckedAddU16", test_NumOverflow_CheckedAddU16},
+    {"NumOverflow_CheckedAddU32", test_NumOverflow_CheckedAddU32},
+    {"NumOverflow_CheckedAddU64", test_NumOverflow_CheckedAddU64},
+    {NULL, NULL}
+};


### PR DESCRIPTION
For the initial stage, adds the number overflow additions. This is used by GRAPH.INFO when collecting information from multiple shards, as we can't guarantee the numbers we receive and add together won't overflow in the resulting integers.