### PR TITLE
Add a circular buffer without the read guarantee.

### DIFF
--- a/src/util/circular_buffer_nrg.c
+++ b/src/util/circular_buffer_nrg.c
@@ -1,0 +1,512 @@
+/*
+ * Copyright Redis Ltd. 2018 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+#include <RG.h>
+#include "circular_buffer_nrg.h"
+
+#include <string.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sys/param.h>
+
+typedef struct ElementDeleteInfo {
+    CircularBufferNRG_ElementFree deleter;
+    void *user_data;
+} ElementDeleteInfo;
+
+typedef struct ElementCloneInfo {
+    CircularBufferNRG_CloneItem clone;
+    void *user_data;
+} ElementCloneInfo;
+
+// A FIFO circular queue.
+struct _CircularBufferNRG {
+    uint64_t read_offset;
+    uint64_t write_offset;
+    uint64_t item_size;
+    uint64_t item_count;
+    bool is_circled;
+    ElementDeleteInfo delete_info;
+    ElementCloneInfo clone_info;
+    uint8_t *end_marker;
+    uint8_t data[];
+};
+
+static void* _CircularBufferNRG_ItemAtOffset
+(
+    CircularBufferNRG cb,
+    const uint64_t offset
+) {
+    ASSERT(cb);
+    if (!cb || offset > cb->item_count) {
+        return NULL;
+    }
+    return cb->data + offset * cb->item_size;
+}
+
+static void* _CircularBufferNRG_ItemAtReadOffset
+(
+    CircularBufferNRG cb
+) {
+    return _CircularBufferNRG_ItemAtOffset(cb, cb->read_offset);
+}
+
+static void* _CircularBufferNRG_ItemAtWriteOffset
+(
+    CircularBufferNRG cb
+) {
+    return _CircularBufferNRG_ItemAtOffset(cb, cb->write_offset);
+}
+
+static void _DeleteElement(
+    void *item,
+    ElementDeleteInfo info
+) {
+    if (!info.deleter) {
+        return;
+    }
+
+    info.deleter(info.user_data, item);
+}
+
+static void _CloneElement(
+    const void *source,
+    void *destination,
+    ElementCloneInfo info
+) {
+    if (!info.clone) {
+        return;
+    }
+
+    info.clone(source, destination, info.user_data);
+}
+
+static void _CopyRegion(
+    const void *source,
+    void *destination,
+    const uint64_t size_of_item,
+    const uint64_t element_count,
+    ElementCloneInfo info
+) {
+    if (!info.clone) {
+        memcpy(destination, source, size_of_item * element_count);
+    } else {
+        for (uint64_t i = 0; i < element_count; ++i) {
+            const void *source_pos = source + i * size_of_item;
+            void *destination_pos = destination + i * size_of_item;
+            info.clone(source_pos, destination_pos, info.user_data);
+        }
+    }
+}
+
+CircularBufferNRG CircularBufferNRG_New
+(
+    const uint64_t item_size,
+    const uint64_t capacity
+) {
+    ASSERT(item_size);
+    ASSERT(capacity);
+    if (!item_size || !capacity) {
+        return NULL;
+    }
+
+    const uint64_t size_of_data = item_size * capacity;
+    const void *allocation = malloc(sizeof(_CircularBufferNRG) + size_of_data);
+    CircularBufferNRG cb = (CircularBufferNRG)allocation;
+
+    cb->read_offset = 0;
+    cb->write_offset = 0;
+    cb->item_size = item_size;
+    cb->item_count = 0;
+    cb->is_circled = false;
+    memset(&cb->delete_info, 0, sizeof(ElementDeleteInfo));
+    memset(&cb->clone_info, 0, sizeof(ElementCloneInfo));
+    cb->end_marker = cb->data + size_of_data;
+
+    return cb;
+}
+
+void CircularBufferNRG_SetDeleter
+(
+    CircularBufferNRG cb,
+    CircularBufferNRG_ElementFree deleter,
+    void *user_data
+) {
+    ASSERT(cb);
+    cb->delete_info.deleter = deleter;
+    cb->delete_info.user_data = user_data;
+}
+
+void CircularBufferNRG_SetItemClone
+(
+    CircularBufferNRG cb,
+    CircularBufferNRG_CloneItem clone,
+    void *user_data
+) {
+    ASSERT(cb);
+    cb->clone_info.clone = clone;
+    cb->clone_info.user_data = user_data;
+}
+
+uint64_t CircularBufferNRG_GetCapacity(const CircularBufferNRG cb) {
+    ASSERT(cb);
+    if (!cb) {
+        return 0;
+    }
+
+    return (cb->end_marker - cb->data) / cb->item_size;
+}
+
+bool CircularBufferNRG_SetCapacity
+(
+    CircularBufferNRG *cb_ptr,
+    const uint64_t new_capacity
+) {
+    ASSERT(cb_ptr && *cb_ptr);
+    ASSERT(new_capacity);
+    if (!cb_ptr || !*cb_ptr || !new_capacity) {
+        return false;
+    }
+    CircularBufferNRG cb = *cb_ptr;
+    if (new_capacity == CircularBufferNRG_GetCapacity(cb)) {
+        // NOOP, the original buffer already has the same capacity.
+        return true;
+    }
+
+    CircularBufferNRG new_cb = CircularBufferNRG_New(cb->item_size, new_capacity);
+    ASSERT(new_cb);
+    if (!new_cb) {
+        return false;
+    }
+
+    /*
+    The Reallocation one-to-one would be simple:
+    We should copy from 6 till 9, then from 0 till 6.
+     __________
+    |0123456789|
+     ^^^^^^^^^^
+       W   R
+       2   6
+
+    However, here we are also taking into account the new capacity. Suppose it
+    is 5 now, instead of 10. We should allocate a new circular buffer with the
+    size of 5 and copy the last (from the end of the previous circular buffer)
+    5 unread elements: 7, 8, 9, 0, 1, leaving the first unread one (the sixth)
+    out, as we only care about the most recent elements in the circular
+    buffer, not really the old ones.
+
+    We should copy those to the beginning of the new circular buffer as it
+    doesn't make sense to do it in any other way. Hence, the first unread
+    element will be at the 0 index and the write position will be the number of
+    elements we copied. In this case it is five, so with a circle we set it to
+    0 as well. But this isn't always the case: if in the original circular
+    buffer there were less elements than the capacity, for example, just three
+    out of 10 and we reallocated with the limit of five, then the write offset
+    should point to the third (3) index, as 3 and 4 indices will be empty.
+    */
+
+    /*
+    This is the byte offset in the old circular buffer, where we should
+    start copying "capacity" elements from, if there are so many until the
+    end of the contiguous array.
+    This should be the "new capacity" elements from the end of the old circular
+    buffer, so we calculate those as:
+
+        copy_from = "old write offset" - new_capacity
+
+    If it goes below the zero, we should split the copy phase into two stages:
+        1. Copy from zero till the old write offset.
+        2. Copy from the end of the previous contiguous array - "number of
+           elements left to copy".
+    This should be done in the reverse order, obviously, so first the 2. and
+    1. after.
+    */
+    // Here we can't attempt to copy more elements than we actually have, so
+    // we need to know how many we can.
+    const uint64_t number_of_elements = MIN(new_capacity, cb->item_count);
+    const uint64_t last_written_offset = cb->write_offset;
+    // Check if we have enough elements to copy with just one attempt.
+    // If we can, this is simple:
+    if (last_written_offset >= number_of_elements) {
+        // Just copy the last "number_of_elements" elements.
+        const void *copy_from
+            = cb->data + (cb->write_offset - number_of_elements) * cb->item_size;
+        const uint64_t copy_amount
+            = number_of_elements * cb->item_size;
+        _CopyRegion(
+            copy_from,
+            new_cb->data,
+            cb->item_size,
+            number_of_elements,
+            cb->clone_info
+        );
+    } else {
+        // Else if we can't, we split into the two stages as explained above.
+        // This is going to be the number of elements we should copy from the
+        // beginning of the old buffer.
+        const uint64_t how_many_from_the_write_offset
+            = cb->write_offset;
+        const uint64_t how_many_from_the_end_of_buffer
+            = number_of_elements - how_many_from_the_write_offset;
+        // 2. Copy from the end of the buffer, "the remainder":
+        const uint64_t first_stage_bytes
+            = how_many_from_the_end_of_buffer * cb->item_size;
+        const void *first_stage_from
+            = cb->end_marker - first_stage_bytes;
+        _CopyRegion(
+            first_stage_from,
+            new_cb->data,
+            cb->item_size,
+            how_many_from_the_end_of_buffer,
+            cb->clone_info
+        );
+        // 1. Copy from the zeroth offset till the write offset.
+        const uint64_t second_stage_bytes
+            = how_many_from_the_write_offset * cb->item_size;
+        const void *second_stage_from
+            = cb->data;
+        void *second_stage_to = new_cb->data + first_stage_bytes;
+        _CopyRegion(
+            second_stage_from,
+            second_stage_to,
+            cb->item_size,
+            how_many_from_the_write_offset,
+            cb->clone_info
+        );
+    }
+
+    // The very first unread element is copied directly to the beginning.
+    new_cb->read_offset = 0;
+    // The write offset is the last pushed element to the new buffer.
+    new_cb->write_offset = number_of_elements % new_capacity;
+    new_cb->item_count = number_of_elements;
+    new_cb->is_circled = new_cb->write_offset == 0;
+    memcpy(&new_cb->delete_info, &cb->delete_info, sizeof(ElementDeleteInfo));
+    memcpy(&new_cb->clone_info, &cb->clone_info, sizeof(ElementCloneInfo));
+
+    CircularBufferNRG_Free(cb);
+    *cb_ptr = new_cb;
+
+    return true;
+}
+
+// Increments the offset with a circle back.
+// Returns true if the value has circled, false otherwise.
+static bool _IncrementOffsetCircular
+(
+    uint64_t *offset_ptr,
+    const uint64_t capacity
+) {
+    ASSERT(offset_ptr);
+    if (!offset_ptr) {
+        return false;
+    }
+
+    *offset_ptr = *offset_ptr + 1;
+    if (unlikely(*offset_ptr >= capacity)) {
+        *offset_ptr = 0;
+        return true;
+    }
+
+    return false;
+}
+
+void CircularBufferNRG_Add
+(
+    CircularBufferNRG cb,
+    const void *item
+) {
+    ASSERT(cb);
+    if (!cb) {
+        return;
+    }
+
+    void *destination = _CircularBufferNRG_ItemAtWriteOffset(cb);
+
+    // If we are overwriting, use the deleter.
+    if (cb->item_count > cb->write_offset) {
+        _DeleteElement(destination, cb->delete_info);
+    }
+    memcpy(destination, item, cb->item_size);
+
+    const uint64_t capacity = CircularBufferNRG_GetCapacity(cb);
+
+    if (cb->is_circled && unlikely(cb->write_offset == cb->read_offset)) {
+        _IncrementOffsetCircular(&cb->read_offset, capacity);
+    }
+
+    cb->item_count = MIN(cb->item_count + 1, capacity);
+
+    const bool writes_circled = _IncrementOffsetCircular(&cb->write_offset, capacity);
+
+    if (writes_circled) {
+        cb->is_circled = true;
+    }
+}
+
+void CircularBufferNRG_Read
+(
+    CircularBufferNRG cb,
+    void *item
+) {
+    const uint64_t capacity = CircularBufferNRG_GetCapacity(cb);
+
+    if (unlikely(cb->read_offset == cb->write_offset)) {
+        if (cb->is_circled) {
+            cb->is_circled = false;
+        } else {
+            return;
+        }
+    }
+
+    const void* source = _CircularBufferNRG_ItemAtReadOffset(cb);
+    memcpy(item, source, cb->item_size);
+
+    const bool reads_circled = _IncrementOffsetCircular(&cb->read_offset, capacity);
+    if (cb->is_circled && reads_circled) {
+        cb->is_circled = false;
+    }
+}
+
+void _CircularBufferNRG_ViewAllWithOffset
+(
+    CircularBufferNRG buffer,
+    CircularBufferNRG_ReadAllCallback callback,
+    void *user_data,
+    uint64_t *read_view_offset_ptr
+) {
+    ASSERT(buffer);
+    ASSERT(callback);
+    if (!buffer || !callback) {
+        return;
+    }
+
+    uint64_t read_view_offset = buffer->read_offset;
+    bool is_circled = buffer->is_circled;
+    while (true) {
+        if (read_view_offset == buffer->write_offset) {
+            if (is_circled) {
+                is_circled = false;
+            } else {
+                break;
+            }
+        }
+
+        void *item = _CircularBufferNRG_ItemAtOffset(buffer, read_view_offset);
+        const bool should_stop = callback(user_data, item);
+
+        if (buffer->data + ++read_view_offset * buffer->item_size >= buffer->end_marker) {
+            read_view_offset = 0;
+        }
+
+        if (should_stop) {
+            break;
+        }
+    }
+
+    if (read_view_offset_ptr) {
+        *read_view_offset_ptr = read_view_offset;
+    }
+}
+
+void CircularBufferNRG_ReadAll
+(
+    CircularBufferNRG buffer,
+    CircularBufferNRG_ReadAllCallback callback,
+    void *user_data
+) {
+    ASSERT(buffer);
+    ASSERT(callback);
+    if (!buffer || !callback) {
+        return;
+    }
+
+    _CircularBufferNRG_ViewAllWithOffset(buffer, callback, user_data, &buffer->read_offset);
+
+    buffer->is_circled = false;
+}
+
+void CircularBufferNRG_ViewAll
+(
+    CircularBufferNRG buffer,
+    CircularBufferNRG_ReadAllCallback callback,
+    void *user_data
+) {
+    _CircularBufferNRG_ViewAllWithOffset(buffer, callback, user_data, NULL);
+}
+
+void *CircularBufferNRG_ViewCurrent
+(
+    const CircularBufferNRG cb
+) {
+    ASSERT(cb);
+    if (!cb) {
+        return NULL;
+    }
+    if (CircularBufferNRG_ItemCount(cb) == 0) {
+        return NULL;
+    }
+    return _CircularBufferNRG_ItemAtReadOffset(cb);
+}
+
+uint64_t CircularBufferNRG_ItemCount
+(
+    const CircularBufferNRG cb
+) {
+    ASSERT(cb);
+    if (!cb) {
+        return 0;
+    }
+
+    return cb->item_count;
+}
+
+uint64_t CircularBufferNRG_ItemSize
+(
+    const CircularBufferNRG cb
+) {
+    ASSERT(cb);
+    if (!cb) {
+        return 0;
+    }
+    return cb->item_size;
+}
+
+bool CircularBufferNRG_IsEmpty
+(
+    const CircularBufferNRG cb
+) {
+    ASSERT(cb);
+    if (!cb) {
+        return false;
+    }
+    return cb->item_count == 0;
+}
+
+static void _CircularBufferNRG_DeleteAllElements(CircularBufferNRG cb) {
+    ASSERT(cb);
+    if (!cb || !cb->delete_info.deleter) {
+        return;
+    }
+
+    uint64_t read_offset = 0;
+    while (read_offset < cb->item_count) {
+        void *item = _CircularBufferNRG_ItemAtOffset(cb, read_offset);
+        _DeleteElement(item, cb->delete_info);
+        ++read_offset;
+    }
+}
+
+void CircularBufferNRG_Free
+(
+    CircularBufferNRG cb
+) {
+    ASSERT(cb);
+    if (cb) {
+        _CircularBufferNRG_DeleteAllElements(cb);
+        free(cb);
+    }
+}

--- a/src/util/circular_buffer_nrg.h
+++ b/src/util/circular_buffer_nrg.h
@@ -1,0 +1,134 @@
+/*
+ * Copyright Redis Ltd. 2018 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+/*
+This file contains a data structure of a circular buffer without a read
+guarantee, meaning it is possible to overwrite the elements that haven't been
+read yet. This is useful when we want to only be able to see the "last top-N"
+elements stored within the container, and we aren't interested in the ones that
+were added earlier than these "last top-N". Hence, this structure's name
+contains the "NRG" suffix - "No Read Guarantee".
+
+A few features of the data structure:
+
+1. It is possible to specify a custom deleter specified if it is required for
+certain types.
+2. It can dynamically grow in size and shrink.
+3. It allows two versions of accessing the stored elements - one that adjusts
+the read pointer and one that doesn't; both are useful.
+4. It is possible to traverse the whole collection without the overhead and
+making copies, by providing a custom callback function which will be called for
+each of the stored item, by providing a pointer to it for further
+re-interpretation by the caller. During such a traversal, the custom callback
+function may force the ongoing traversal to stop by means of the return value.
+
+This circular buffer is not thread safe and requires external synchronisation.
+*/
+
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct _CircularBufferNRG _CircularBufferNRG;
+typedef _CircularBufferNRG* CircularBufferNRG;
+
+// Should return true if the read has to be stopped right after the invocation.
+typedef bool (*CircularBufferNRG_ReadAllCallback)(void *user_data, const void *item);
+typedef void (*CircularBufferNRG_ElementFree)(void *user_data, void *item);
+typedef void (*CircularBufferNRG_CloneItem)(const void *item_to_clone, void *destination_item, void *user_data);
+
+CircularBufferNRG CircularBufferNRG_New
+(
+    const uint64_t item_size,
+    const uint64_t capacity
+);
+
+void CircularBufferNRG_SetDeleter
+(
+    CircularBufferNRG cb,
+    CircularBufferNRG_ElementFree deleter,
+    void *user_data
+);
+
+void CircularBufferNRG_SetItemClone
+(
+    CircularBufferNRG cb,
+    CircularBufferNRG_CloneItem clone,
+    void *user_data
+);
+
+uint64_t CircularBufferNRG_GetCapacity(const CircularBufferNRG circular_buffer);
+// (Re)sets the capacity of the circular buffer. If the new capacity is less
+// than what it has been, all the elements past the new capacity are gone.
+// Returns true if the capacity setting was successfull, false otherwise.
+bool CircularBufferNRG_SetCapacity(CircularBufferNRG *cb_ptr, const uint64_t new_capacity);
+
+// Adds an item to the buffer, advances the write offset, and, in case of
+// a full circle, the read offset as well.
+void CircularBufferNRG_Add
+(
+    CircularBufferNRG circular_buffer,
+    const void *item_to_add
+);
+
+// Removes the oldest item from buffer. If there was nothing to read, and so,
+// remove, the item pointer is not changed.
+void CircularBufferNRG_Read
+(
+    CircularBufferNRG cb,
+    void *output
+);
+
+// Iterates over the entire unread contents and invokes the callback.
+// Does it without making copies (memcpy) but rather passing a view pointer to
+// the callback function, suitable for a reinterpret cast.
+// This function adjusts the read offset.
+void CircularBufferNRG_ReadAll
+(
+    CircularBufferNRG buffer,
+    CircularBufferNRG_ReadAllCallback callback,
+    void *user_data
+);
+
+// Iterates over the entire unread contents and invokes the callback.
+// Does it without making copies (memcpy) but rather passing a view pointer to
+// the callback function, suitable for a reinterpret cast.
+// This doesn't adjust the read offset.
+void CircularBufferNRG_ViewAll
+(
+    CircularBufferNRG buffer,
+    CircularBufferNRG_ReadAllCallback callback,
+    void *user_data
+);
+
+// Returns a pointer to the current item without adjusting the read offset.
+void *CircularBufferNRG_ViewCurrent
+(
+    const CircularBufferNRG cb
+);
+
+// Returns number of items in buffer.
+uint64_t CircularBufferNRG_ItemCount
+(
+    const CircularBufferNRG cb
+);
+
+uint64_t CircularBufferNRG_ItemSize
+(
+    const CircularBufferNRG cb
+);
+
+// Returns true if buffer there is nothing to read.
+bool CircularBufferNRG_IsEmpty
+(
+    const CircularBufferNRG cb
+);
+
+void CircularBufferNRG_Free
+(
+    CircularBufferNRG cb
+);

--- a/tests/unit/test_circular_buffer_nrg.c
+++ b/tests/unit/test_circular_buffer_nrg.c
@@ -1,0 +1,459 @@
+/*
+ * Copyright Redis Ltd. 2018 - present
+ * Licensed under your choice of the Redis Source Available License 2.0 (RSALv2) or
+ * the Server Side Public License v1 (SSPLv1).
+ */
+
+
+#include <sys/param.h>
+
+#include "src/util/circular_buffer_nrg.h"
+#include "src/util/rmalloc.h"
+#include "src/util/arr.h"
+
+void setup() {
+	Alloc_Reset();
+}
+
+#define TEST_INIT setup();
+#include "acutest.h"
+
+// GTest to AcuTest redefinitions
+#define ASSERT_EQ(lhs, rhs) TEST_ASSERT(lhs == rhs)
+#define ASSERT_NE(lhs, rhs) TEST_ASSERT(lhs != rhs)
+#define ASSERT_NOT_NULL(lhs) ASSERT_NE(lhs, NULL)
+
+void test_CircularBufferNRG_TestWrapsWrites(void) {
+    CircularBufferNRG cb = CircularBufferNRG_New(sizeof(uint8_t), 2);
+    ASSERT_NOT_NULL(cb);
+    ASSERT_EQ(CircularBufferNRG_GetCapacity(cb), 2);
+    TEST_ASSERT(CircularBufferNRG_IsEmpty(cb));
+    ASSERT_EQ(CircularBufferNRG_ItemCount(cb), 0);
+    TEST_ASSERT(!CircularBufferNRG_ViewCurrent(cb));
+
+    uint8_t value = 1;
+    CircularBufferNRG_Add(cb, &value);
+    TEST_ASSERT(!CircularBufferNRG_IsEmpty(cb));
+    ASSERT_EQ(CircularBufferNRG_GetCapacity(cb), 2);
+    ASSERT_EQ(CircularBufferNRG_ItemCount(cb), 1);
+    uint8_t viewed = *(uint8_t *)CircularBufferNRG_ViewCurrent(cb);
+    ASSERT_EQ(viewed, 1);
+    ASSERT_EQ(CircularBufferNRG_ItemCount(cb), 1);
+
+    value = 2;
+    CircularBufferNRG_Add(cb, &value);
+    ASSERT_EQ(CircularBufferNRG_GetCapacity(cb), 2);
+    viewed = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+    ASSERT_EQ(viewed, 1);
+    ASSERT_EQ(CircularBufferNRG_ItemCount(cb), 2);
+
+    value = 3;
+    CircularBufferNRG_Add(cb, &value);
+    ASSERT_EQ(CircularBufferNRG_GetCapacity(cb), 2);
+    // The read pointer still points to the least recently read entry,
+    // after overwrite. Here, the "1" was overwritten by "3", while "2"
+    // was left untouched, hence the "current" points to the first unread
+    // entry, which is "2" in this case.
+    viewed = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+    ASSERT_EQ(viewed, 2);
+    ASSERT_EQ(CircularBufferNRG_ItemCount(cb), 2);
+
+    value = 4;
+    CircularBufferNRG_Add(cb, &value);
+    ASSERT_EQ(CircularBufferNRG_GetCapacity(cb), 2);
+    // The read pointer has never been advanced by reading, and so now
+    // should just point to the earliest possible entry. In this case, it
+    // is located at the zeroeth offset, with the value of "3".
+    viewed = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+    ASSERT_EQ(viewed, 3);
+
+    CircularBufferNRG_Free(cb);
+}
+
+void test_CircularBufferNRG_TestWrapsReads(void) {
+    CircularBufferNRG cb = CircularBufferNRG_New(sizeof(uint8_t), 2);
+    uint8_t value = 1;
+    CircularBufferNRG_Add(cb, &value);
+    uint8_t removed = 0;
+    CircularBufferNRG_Read(cb, &removed);
+    ASSERT_EQ(removed, 1);
+    value = 2;
+    CircularBufferNRG_Add(cb, &value);
+    CircularBufferNRG_Read(cb, &removed);
+    ASSERT_EQ(removed, 2);
+    value = 3;
+    CircularBufferNRG_Add(cb, &value);
+    CircularBufferNRG_Read(cb, &removed);
+    ASSERT_EQ(removed, 3);
+
+    value = 4;
+    CircularBufferNRG_Add(cb, &value);
+    value = 5;
+    CircularBufferNRG_Add(cb, &value);
+    CircularBufferNRG_Read(cb, &removed);
+    ASSERT_EQ(removed, 4);
+    CircularBufferNRG_Read(cb, &removed);
+    ASSERT_EQ(removed, 5);
+    value = 6;
+    CircularBufferNRG_Add(cb, &value);
+    value = 7;
+    CircularBufferNRG_Add(cb, &value);
+    value = 8;
+    CircularBufferNRG_Add(cb, &value);
+    CircularBufferNRG_Read(cb, &removed);
+    ASSERT_EQ(removed, 7);
+    CircularBufferNRG_Read(cb, &removed);
+    ASSERT_EQ(removed, 8);
+    removed = 0;
+    CircularBufferNRG_Read(cb, &removed);
+    // When nothing to remove, the pointer remains unchanged.
+    ASSERT_EQ(removed, 0);
+
+    CircularBufferNRG_Free(cb);
+}
+
+void test_CircularBufferNRG_TestResetCapacitySingleStageNoReallocation(void) {
+    CircularBufferNRG cb = CircularBufferNRG_New(sizeof(uint8_t), 5);
+    uint8_t value = 1;
+    CircularBufferNRG_Add(cb, &value);
+    value = 2;
+    CircularBufferNRG_Add(cb, &value);
+    value = 3;
+    CircularBufferNRG_Add(cb, &value);
+    value = 4;
+    CircularBufferNRG_Add(cb, &value);
+    value = 5;
+    CircularBufferNRG_Add(cb, &value);
+
+    CircularBufferNRG old_address = cb;
+    // Returns true as if the capacity setting went okay.
+    TEST_ASSERT(CircularBufferNRG_SetCapacity(&cb, 5));
+    // The address hasn't changed, meaning there has been no reallocation.
+    ASSERT_EQ(old_address, cb);
+
+    CircularBufferNRG_Free(cb);
+}
+
+bool view_element(void *user_data, const void *item) {
+    uint8_t *viewed = (uint8_t*)(user_data);
+    const uint8_t element = *(const uint8_t *)item;
+    array_append(viewed, element);
+
+    return false;
+}
+
+void test_CircularBufferNRG_TestReadAllFullCollection(void) {
+    CircularBufferNRG cb = CircularBufferNRG_New(sizeof(uint8_t), 5);
+    uint8_t value = 1;
+    CircularBufferNRG_Add(cb, &value);
+    value = 2;
+    CircularBufferNRG_Add(cb, &value);
+    value = 3;
+    CircularBufferNRG_Add(cb, &value);
+    value = 4;
+    CircularBufferNRG_Add(cb, &value);
+    value = 5;
+    CircularBufferNRG_Add(cb, &value);
+
+    const uint8_t old_current = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+    uint8_t *viewed = array_new(uint8_t, 10);
+    CircularBufferNRG_ReadAll(cb, view_element, (void*)viewed);
+    static const uint8_t EXPECTED[] = { 1, 2, 3, 4, 5 };
+    static const size_t LENGTH = sizeof(EXPECTED) / sizeof(EXPECTED[0]);
+    ASSERT_EQ(array_len(viewed), LENGTH);
+    for (size_t i = 0; i < LENGTH; ++i) {
+        ASSERT_EQ(viewed[i], EXPECTED[i]);
+    }
+    const uint8_t current = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+    ASSERT_EQ(current, old_current);
+
+    array_free(viewed);
+    CircularBufferNRG_Free(cb);
+}
+
+typedef struct ViewElementAndEndData {
+    uint8_t *viewed;
+    uint64_t max_view_count;
+} ViewElementAndEndData;
+
+bool view_element_and_end(void *user_data, const void *item) {
+    ViewElementAndEndData *data = (ViewElementAndEndData*)user_data;
+
+    const uint8_t element = *(const uint8_t *)item;
+    array_append(data->viewed, element);
+
+    if (array_len(data->viewed) >= data->max_view_count) {
+        return true;
+    }
+
+    return false;
+}
+
+void test_CircularBufferNRG_TestReadAllAndEndPrematurely(void) {
+    CircularBufferNRG cb = CircularBufferNRG_New(sizeof(uint8_t), 5);
+    uint8_t value = 1;
+    CircularBufferNRG_Add(cb, &value);
+    value = 2;
+    CircularBufferNRG_Add(cb, &value);
+    value = 3;
+    CircularBufferNRG_Add(cb, &value);
+    value = 4;
+    CircularBufferNRG_Add(cb, &value);
+    value = 5;
+    CircularBufferNRG_Add(cb, &value);
+
+    ViewElementAndEndData data = {};
+    data.viewed = array_new(uint8_t, 10);
+    data.max_view_count = 3;
+    CircularBufferNRG_ReadAll(cb, view_element_and_end, (void *)&data);
+    static const uint8_t EXPECTED[] = { 1, 2, 3 };
+    static const size_t LENGTH = sizeof(EXPECTED) / sizeof(EXPECTED[0]);
+    ASSERT_EQ(array_len(data.viewed), LENGTH);
+    for (size_t i = 0; i < LENGTH; ++i) {
+        ASSERT_EQ(data.viewed[i], EXPECTED[i]);
+    }
+    const uint8_t current = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+    // The read offset has moved because of the "read", so we should not
+    // expect to be able to read the same elements again. As we stopped
+    // reading right after the element "3", the next read or a view are
+    // supposed to look at the element after, which is "4".
+    ASSERT_EQ(current, 4);
+
+    array_free(data.viewed);
+    CircularBufferNRG_Free(cb);
+}
+
+void test_CircularBufferNRG_TestViewAll(void) {
+    CircularBufferNRG cb = CircularBufferNRG_New(sizeof(uint8_t), 5);
+    uint8_t value = 1;
+    CircularBufferNRG_Add(cb, &value);
+    value = 2;
+    CircularBufferNRG_Add(cb, &value);
+    value = 3;
+    CircularBufferNRG_Add(cb, &value);
+    value = 4;
+    CircularBufferNRG_Add(cb, &value);
+    value = 5;
+    CircularBufferNRG_Add(cb, &value);
+
+    const uint8_t old_current = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+    uint8_t *viewed = array_new(uint8_t, 10);
+    CircularBufferNRG_ViewAll(cb, view_element, (void *)viewed);
+    static const uint8_t EXPECTED[] = { 1, 2, 3, 4, 5 };
+    static const size_t LENGTH = sizeof(EXPECTED) / sizeof(EXPECTED[0]);
+    ASSERT_EQ(array_len(viewed), LENGTH);
+    for (size_t i = 0; i < LENGTH; ++i) {
+        ASSERT_EQ(viewed[i], EXPECTED[i]);
+    }
+    const uint8_t current = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+    // The read offset hasn't moved because of the "view", so we should
+    // expect to be able to read the same elements again, as there has been
+    // no read in between the calls.
+    ASSERT_EQ(current, old_current);
+
+    array_free(viewed);
+    CircularBufferNRG_Free(cb);
+}
+
+void test_CircularBufferNRG_TestViewAllWithCircle(void) {
+    CircularBufferNRG cb = CircularBufferNRG_New(sizeof(uint8_t), 3);
+    uint8_t value = 1;
+    CircularBufferNRG_Add(cb, &value);
+    value = 2;
+    CircularBufferNRG_Add(cb, &value);
+    value = 3;
+    CircularBufferNRG_Add(cb, &value);
+    value = 4;
+    CircularBufferNRG_Add(cb, &value);
+    value = 5;
+    CircularBufferNRG_Add(cb, &value);
+
+    {
+        const uint8_t old_current = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+        uint8_t *viewed = array_new(uint8_t, 10);
+        CircularBufferNRG_ViewAll(cb, view_element, (void*)viewed);
+        const uint8_t EXPECTED[] = { 3, 4, 5 };
+        const size_t LENGTH = sizeof(EXPECTED) / sizeof(EXPECTED[0]);
+        ASSERT_EQ(array_len(viewed), LENGTH);
+        for (size_t i = 0; i < LENGTH; ++i) {
+            ASSERT_EQ(viewed[i], EXPECTED[i]);
+        }
+        const uint8_t current = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+        // The read offset hasn't moved because of the "view", so we should
+        // expect to be able to read the same elements again, as there has been
+        // no read in between the calls.
+        ASSERT_EQ(current, old_current);
+        array_free(viewed);
+    }
+
+    value = 6;
+    CircularBufferNRG_Add(cb, &value);
+    value = 7;
+    CircularBufferNRG_Add(cb, &value);
+
+    {
+        const uint8_t old_current = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+        uint8_t *viewed = array_new(uint8_t, 10);
+        CircularBufferNRG_ViewAll(cb, view_element, (void *)viewed);
+        const uint8_t EXPECTED[] = { 5, 6, 7 };
+        const size_t LENGTH = sizeof(EXPECTED) / sizeof(EXPECTED[0]);
+        ASSERT_EQ(array_len(viewed), LENGTH);
+        for (size_t i = 0; i < LENGTH; ++i) {
+            ASSERT_EQ(viewed[i], EXPECTED[i]);
+        }
+        const uint8_t current = *(uint8_t*)CircularBufferNRG_ViewCurrent(cb);
+        // The read offset hasn't moved because of the "view", so we should
+        // expect to be able to read the same elements again, as there has been
+        // no read in between the calls.
+        ASSERT_EQ(current, old_current);
+        array_free(viewed);
+    }
+
+
+    CircularBufferNRG_Free(cb);
+}
+
+void delete_element(void *user_data, void *item) {
+    uint64_t *deleted_counter = (uint64_t*)user_data;
+    char** element = (char **)item;
+    free(*element);
+    ++(*deleted_counter);
+}
+
+void delete_count(void *user_data, void *item) {
+    uint64_t *deleted_counter = (uint64_t*)user_data;
+    ++(*deleted_counter);
+}
+
+void test_CircularBufferNRG_TestCustomDeleterIsUsedProperly(void) {
+    CircularBufferNRG cb = CircularBufferNRG_New(sizeof(char *), 2);
+    uint64_t deleted_counter = 0;
+    CircularBufferNRG_SetDeleter(
+        cb,
+        delete_element,
+        (void *)&deleted_counter
+    );
+    char *s = strdup("11");
+    CircularBufferNRG_Add(cb, &s);
+    s = strdup("22");
+    CircularBufferNRG_Add(cb, &s);
+    s = strdup("33");
+    CircularBufferNRG_Add(cb, &s);
+
+    // We deleted "11".
+    ASSERT_EQ(deleted_counter, 1);
+
+    // Reads don't delete.
+    char *r = NULL;
+    CircularBufferNRG_Read(cb, (void *)&r);
+    TEST_ASSERT(!strcmp(r, "22"));
+    ASSERT_EQ(deleted_counter, 1);
+
+    CircularBufferNRG_Free(cb);
+    ASSERT_EQ(deleted_counter, 3);
+}
+
+void clone_func(const void *source, void *destination, void *user_data) {
+    uint64_t *copied_counter = (uint64_t*)user_data;
+    *(uint8_t*)destination = *(uint8_t*)source;
+    ++(*copied_counter);
+}
+
+typedef struct Reallocation {
+    uint64_t initialCapacity;
+    uint8_t initial_elements_start;
+    uint8_t initial_elements_count;
+    uint64_t newCapacity;
+    bool expectedReallocation;
+    bool expectedEmpty;
+    uint8_t expected_elements_start;
+    uint8_t expected_elements_count;
+} Reallocation;
+
+void test_CircularBufferNRG_TestResetCapacitySingleStageWithReallocation(void) {
+    const Reallocation reallocations[] = {
+        {
+            // We simply reduce the capacity and reallocate.
+            6, 1, 4, 5, true, false, 1, 4
+        },
+        {
+            // We simply reduce the capacity and reallocate.
+            6, 1, 5, 5, true, false, 1, 5
+        },
+        {
+            // We reduce the capacity, reallocate and copy only the
+            // most recently added elements.
+            6, 1, 9, 5, true, false, 5, 5
+        }
+    };
+
+    const size_t reallocations_count = sizeof(reallocations) / sizeof(reallocations[0]);
+    for (size_t i = 0; i < reallocations_count; ++i) {
+        const Reallocation param = reallocations[i];
+
+        CircularBufferNRG cb = CircularBufferNRG_New(sizeof(uint8_t), param.initialCapacity);
+        for (uint8_t j = 0; j < param.initial_elements_count; ++j) {
+            const uint8_t element = param.initial_elements_start + j;
+            CircularBufferNRG_Add(cb, &element);
+        }
+        const uint64_t original_item_count = CircularBufferNRG_ItemCount(cb);
+        ASSERT_EQ(original_item_count, MIN(param.initial_elements_count, param.initialCapacity));
+
+        uint64_t deleted_counter = 0;
+        CircularBufferNRG_SetDeleter(
+            cb,
+            delete_count,
+            (void *)&deleted_counter
+        );
+        uint64_t copied_counter = 0;
+        CircularBufferNRG_SetItemClone(
+            cb,
+            clone_func,
+            (void*)&copied_counter
+        );
+        CircularBufferNRG old_address = cb;
+        TEST_ASSERT(CircularBufferNRG_SetCapacity(&cb, param.newCapacity));
+        if (param.expectedReallocation) {
+            // The address has changed, meaning there has been a reallocation.
+            ASSERT_NE(old_address, cb);
+            ASSERT_EQ(deleted_counter, original_item_count);
+            ASSERT_EQ(copied_counter, MIN(param.newCapacity, original_item_count));
+        } else {
+            // The address hasn't changed, meaning there has been no reallocation.
+            ASSERT_EQ(old_address, cb);
+        }
+
+        ASSERT_EQ(CircularBufferNRG_GetCapacity(cb), param.newCapacity);
+        ASSERT_EQ(CircularBufferNRG_IsEmpty(cb), param.expectedEmpty);
+        ASSERT_EQ(CircularBufferNRG_ItemCount(cb), param.expected_elements_count);
+
+        // Confirm the new buffer has only the elements expected.
+        for (uint8_t j = 0; j < param.expected_elements_count; ++j) {
+            const uint8_t element = param.expected_elements_start + j;
+            uint8_t removed = 0;
+            CircularBufferNRG_Read(cb, &removed);
+            ASSERT_EQ(removed, element);
+        }
+
+        // After all the expected elements have been read, we shouldn't be able
+        // to read more.
+        uint8_t removed = 127;
+        CircularBufferNRG_Read(cb, &removed);
+        ASSERT_EQ(removed, 127);
+
+        CircularBufferNRG_Free(cb);
+    }
+}
+
+TEST_LIST = {
+    { "test_CircularBufferNRG_TestResetCapacitySingleStageWithReallocation", test_CircularBufferNRG_TestResetCapacitySingleStageWithReallocation },
+    { "test_CircularBufferNRG_TestCustomDeleterIsUsedProperly", test_CircularBufferNRG_TestCustomDeleterIsUsedProperly },
+    { "test_CircularBufferNRG_TestViewAllWithCircle", test_CircularBufferNRG_TestViewAllWithCircle },
+    { "test_CircularBufferNRG_TestViewAll", test_CircularBufferNRG_TestViewAll },
+    { "test_CircularBufferNRG_TestReadAllAndEndPrematurely", test_CircularBufferNRG_TestReadAllAndEndPrematurely },
+    { "test_CircularBufferNRG_TestReadAllFullCollection", test_CircularBufferNRG_TestReadAllFullCollection },
+    { "test_CircularBufferNRG_TestResetCapacitySingleStageNoReallocation", test_CircularBufferNRG_TestResetCapacitySingleStageNoReallocation },
+    { "test_CircularBufferNRG_TestWrapsReads", test_CircularBufferNRG_TestWrapsReads },
+    { "test_CircularBufferNRG_TestWrapsWrites", test_CircularBufferNRG_TestWrapsWrites },
+    { NULL, NULL }
+};


### PR DESCRIPTION
There are mainly two types of ring buffers: one with and one without the read guarantee. The read guarantee means that the reader must be able to read the data it hasn't read yet and this data can't be overwritten by the write mechanism: in case the ring buffer has never been read and the writes are exceeding the allocated capacity of this buffer, the writes are refused. Excluding the read guarantee allows such writes to proceed and overwrite the data the reader hasn't read yet by also adjusting the read pointer to the least recently read entry if possible.

For the GRAPH.INFO we need to allocate a ring buffer of a pre-determined capacity and we don't need to guarantee the reads. This allows us to update the ring buffer as often and as much as possible without relying on the reads.

For the ring buffer with the read guarantee there is already a "circular_buffer.c", while this adds one without the read guarantee under the name of "circular_buffer_nrg.c" where the "nrg" prefix means "No Read Guarantee".