### PR TITLE
Fix the flaky cron abort later test.

### DIFF
--- a/src/util/cron.h
+++ b/src/util/cron.h
@@ -35,11 +35,10 @@ CronTaskHandle Cron_AddTask
 	void *pdata     // private data to pass to callback
 );
 
-// aborts CRON task
-// waits for task to complete in-case it is already executing
-// otherwise marks task as aborted
+// aborts the CRON task passed (if found).
+// this function doesn't wait until the task is completed if it has
+// already started at the moment of invocation.
 void Cron_AbortTask
 (
 	CronTaskHandle t
 );
-

--- a/tests/unit/test_cron.c
+++ b/tests/unit/test_cron.c
@@ -10,13 +10,21 @@
 #include <assert.h>
 #include <sys/select.h>
 #include <time.h>
+#include <stdatomic.h>
 
-void setup();
-void tearDown();
+static void setup();
+static void tearDown();
 
 #define TEST_INIT setup();
 #define TEST_FINI tearDown();
 #include "acutest.h"
+
+#define TEST_CASE_TIMEOUT_SECONDS 3
+// Just some random bytes we write/read from the pipes which signal that
+// a task has either is already running or has completed.
+#define RUNNING_SIGNAL_VALUE 105
+#define COMPLETED_SIGNAL_VALUE 123
+#define INVALID_SIGNAL_VALUE 100
 
 volatile int X = 1;
 
@@ -29,7 +37,13 @@ static int mssleep(uint ms) {
 	return nanosleep(&req, NULL);
 }
 
-static void TearDownTestCase() {
+static struct timeval _get_test_timeout_value() {
+	struct timeval timeout = {};
+
+	timeout.tv_sec = TEST_CASE_TIMEOUT_SECONDS;
+	timeout.tv_usec = 0;
+
+	return timeout;
 }
 
 void add_task(void *pdata) {
@@ -37,39 +51,180 @@ void add_task(void *pdata) {
 	X += *Y;
 }
 
+typedef void* TaskData;
+typedef void (*TaskFunction)(TaskData);
+
 typedef struct AddTaskData {
-	int value;
+	TaskFunction task_function;
+	TaskData task_data;
+	int pipe_read_fd;
 	int pipe_write_fd;
+	atomic_bool has_started;
+	atomic_bool has_completed;
 } AddTaskData;
 
-void add_task_and_notify(void *pdata) {
-	AddTaskData *data = (AddTaskData*)pdata;
-	X += data->value;
-	assert(write(data->pipe_write_fd, (const void *)pdata, 1) == 1);
+static AddTaskData _AddTaskData_New
+(
+	TaskFunction task_function,
+	TaskData task_data
+) {
+	int pipe_fds[2] = {0, 0};
+
+	TEST_ASSERT(pipe(pipe_fds) == 0);
+
+	AddTaskData data = {
+		.task_function = task_function,
+		.task_data = task_data,
+		.pipe_read_fd = pipe_fds[0],
+		.pipe_write_fd = pipe_fds[1],
+		.has_started = false,
+		.has_completed = false
+	};
+
+	return data;
 }
 
-void mul_task(void *pdata) {
+static inline bool _AddTaskData_HasStarted
+(
+	const AddTaskData data
+) {
+	return data.has_started;
+}
+
+static inline bool _AddTaskData_HasCompleted
+(
+	const AddTaskData data
+) {
+	return data.has_completed;
+}
+
+static void _AddTaskData_SignaliseValue
+(
+	AddTaskData data,
+	const unsigned char signal_value
+) {
+	static const size_t SIGNAL_SIZE = sizeof(signal_value);
+	const int written = write(
+		data.pipe_write_fd,
+		(const void *)&signal_value,
+		SIGNAL_SIZE
+	);
+	assert(written == SIGNAL_SIZE);
+}
+
+static void _AddTaskData_SignalRunning
+(
+	AddTaskData data
+) {
+	_AddTaskData_SignaliseValue(data, RUNNING_SIGNAL_VALUE);
+}
+
+static void _AddTaskData_SignalCompleted
+(
+	AddTaskData data
+) {
+	_AddTaskData_SignaliseValue(data, COMPLETED_SIGNAL_VALUE);
+}
+
+static void _AddTaskData_Execute
+(
+	void *userdata
+) {
+	AddTaskData *data = (AddTaskData*) userdata;
+
+	data->has_started = true;
+	_AddTaskData_SignalRunning(*data);
+	data->task_function(data->task_data);
+	data->has_completed = true;
+	_AddTaskData_SignalCompleted(*data);
+}
+
+static void _AddTaskData_WaitUntilSignalisedValue
+(
+	const AddTaskData data,
+	const unsigned char signalised_value
+) {
+	struct timeval timeout = _get_test_timeout_value();
+	unsigned char read_signal_data = INVALID_SIGNAL_VALUE;
+
+	// Prepare the read file descriptors by including our signal pipe.
+	fd_set read_fds;
+	FD_ZERO(&read_fds);
+	FD_SET(data.pipe_read_fd, &read_fds);
+
+	while (read_signal_data != signalised_value) {
+		const int result = select(FD_SETSIZE, &read_fds, NULL, NULL, &timeout);
+		// Check that there wasn't an error of "select".
+		TEST_ASSERT(result != -1);
+		// Check that we didn't encounter the timeout scenario and
+		// there is data available for reading, meaning the AddTask task
+		// has successfully completed.
+		TEST_ASSERT(result > 0);
+		// Check that the read channel is available for reading and has unread
+		// data.
+		TEST_ASSERT(FD_ISSET(data.pipe_read_fd, &read_fds));
+		// Wait until the signal expected is received.
+		assert(read(data.pipe_read_fd, (void *)&read_signal_data, 1) == 1);
+	}
+}
+
+static void _AddTaskData_WaitForRunning
+(
+	const AddTaskData data
+) {
+	if (data.has_started) {
+		return;
+	}
+
+	_AddTaskData_WaitUntilSignalisedValue(data, RUNNING_SIGNAL_VALUE);
+}
+
+static void _AddTaskData_WaitForCompletion
+(
+	const AddTaskData data
+) {
+	if (data.has_completed) {
+		return;
+	}
+
+	_AddTaskData_WaitUntilSignalisedValue(data, COMPLETED_SIGNAL_VALUE);
+}
+
+static void _AddTaskData_Wait
+(
+	const AddTaskData data
+) {
+	_AddTaskData_WaitForRunning(data);
+	_AddTaskData_WaitForCompletion(data);
+}
+
+static void _AddTaskData_Free(const AddTaskData data) {
+	close(data.pipe_read_fd);
+	close(data.pipe_write_fd);
+}
+
+static void mul_task(void *pdata) {
 	int *Y = (int*)pdata;
 	X *= *Y;
 }
 
-void long_running_task(void *pdata) {
+static void long_running_task(void *pdata) {
 	// sleep for 'n' milliseconds
 	int *ms = (int*)pdata;
 	mssleep(*ms);
 }
 
-void setup() {
+static void setup() {
 	// Use the malloc family for allocations
 	Alloc_Reset();
 	Cron_Start();
 }
 
-void tearDown() {
+static void tearDown() {
 	Cron_Stop();
 }
 
-void test_cronExec() {
+static void test_cronExec() {
 	// Add two tasks to CRON
 	// one adds 2 to X
 	// second multiply X by 2
@@ -85,17 +240,23 @@ void test_cronExec() {
 	// if CRON executes the tasks in the wrong order
 	// X += Z, X = 3
 	// X *= Y, X = 6
+	AddTaskData add_task_data = _AddTaskData_New(add_task, (void *)&Z);
+	AddTaskData mul_task_data = _AddTaskData_New(mul_task, (void *)&Y);
 
-	Cron_AddTask(15, add_task, &Z);
-	Cron_AddTask(5, mul_task, &Y);
+	Cron_AddTask(15, _AddTaskData_Execute, &add_task_data);
+	Cron_AddTask(5, _AddTaskData_Execute, &mul_task_data);
 
-	mssleep(100); // sleep for 100 ms
+	_AddTaskData_Wait(add_task_data);
+	_AddTaskData_Wait(mul_task_data);
+
+	_AddTaskData_Free(add_task_data);
+	_AddTaskData_Free(mul_task_data);
 
 	// verify X = (X * 2) + 2
 	TEST_ASSERT(X == 4);
 }
 
-void test_cronAbort() {
+static void test_cronAbort() {
 	// reset X = 1
 	// issue a task X += 2
 	// abort task
@@ -103,50 +264,40 @@ void test_cronAbort() {
 
 	X = 1;
 	int Y = 2;
+	AddTaskData data = _AddTaskData_New(add_task, (void *)&Y);
 
 	// issue task X += 2
-	CronTaskHandle task_handle = Cron_AddTask(15, add_task, &Y);
+	CronTaskHandle task_handle = Cron_AddTask(15, _AddTaskData_Execute, &data);
 
 	// abort task
 	Cron_AbortTask(task_handle);
 
-	mssleep(100); // sleep for 100 ms
+	// If we get here within the 0-15+ms interval, the cron thread
+	// shouldn't have yet begun the task execution.
+	TEST_ASSERT(!_AddTaskData_HasStarted(data));
+
+	_AddTaskData_Free(data);
 
 	// task should have been aborted prior to its execution
 	// expecting X = 1
 	TEST_ASSERT(X == 1);
 }
 
-void test_cronLateAbort() {
+static void test_cronLateAbort() {
 	// reset X = 1
 	// issue a task X += 2
 	// abort task AFTER task been performed
 	// validate X = 3
 
 	X = 1;
-	int pipe_fds[2] = {0, 0};
-	TEST_ASSERT(pipe(pipe_fds) == 0);
-	AddTaskData data = {
-		.value = 2,
-		.pipe_write_fd = pipe_fds[1]
-	};
-
-	struct timeval timeout = {};
-	timeout.tv_sec = 3;
-	timeout.tv_usec = 0;
-
-	fd_set read_fds;
-	FD_ZERO(&read_fds);
-	FD_SET(pipe_fds[0], &read_fds);
+	int Y = 2;
+	AddTaskData data = _AddTaskData_New(add_task, (void *)&Y);
 
 	// issue task X += 2
-	CronTaskHandle task_handle = Cron_AddTask(15, add_task_and_notify, &data);
+	CronTaskHandle task_handle = Cron_AddTask(15, _AddTaskData_Execute, &data);
 
-	const int result = select(FD_SETSIZE, &read_fds, NULL, NULL, &timeout);
-	TEST_ASSERT(result > 0);
-	TEST_ASSERT(FD_ISSET(pipe_fds[0], &read_fds));
-	close(pipe_fds[0]);
-	close(pipe_fds[1]);
+	_AddTaskData_Wait(data);
+	_AddTaskData_Free(data);
 
 	// task should have been executed, expecting X = 1
 	TEST_ASSERT(X == 3);
@@ -155,7 +306,7 @@ void test_cronLateAbort() {
 	Cron_AbortTask(task_handle);
 }
 
-void test_MultiAbort() {
+static void test_MultiAbort() {
 	// reset X = 1
 	// issue a task X += 2
 	// abort task multiple times
@@ -163,23 +314,28 @@ void test_MultiAbort() {
 
 	X = 1;
 	int Y = 2;
+	AddTaskData data = _AddTaskData_New(add_task, (void *)&Y);
 
 	// issue task X += 2
-	CronTaskHandle task_handle = Cron_AddTask(15, add_task, &Y);
+	CronTaskHandle task_handle = Cron_AddTask(15, _AddTaskData_Execute, &data);
 
-	// abort task multiple times, should not crash hang
+	// abort task multiple times, should not crash or hang
 	for(int i = 0; i < 20; i++) {
 		Cron_AbortTask(task_handle);
 	}
 
-	mssleep(100); // sleep for 100 ms
+	if (_AddTaskData_HasStarted(data)) {
+		_AddTaskData_WaitForCompletion(data);
+	}
+
+	_AddTaskData_Free(data);
 
 	// task should have been aborted prior to its execution
 	// expecting X = 1
 	TEST_ASSERT(X == 1);
 }
 
-void test_abortNoneExistingTask() {
+static void test_abortNoneExistingTask() {
 	// reset X = 1
 	// issue a task X += 2
 	// abort none existing task
@@ -187,43 +343,53 @@ void test_abortNoneExistingTask() {
 
 	X = 1;
 	int Y = 2;
+	AddTaskData data = _AddTaskData_New(add_task, (void*)&Y);
 
 	// issue task X += 2
-	CronTaskHandle task_handle = Cron_AddTask(15, add_task, &Y);
+	CronTaskHandle task_handle = Cron_AddTask(15, _AddTaskData_Execute, &data);
 	CronTaskHandle none_existing_task_handle = task_handle + 1;
 
 	// abort task, should not crash hang
 	Cron_AbortTask(none_existing_task_handle);
 
-	mssleep(100); // sleep for 100 ms
+	_AddTaskData_Wait(data);
+	_AddTaskData_Free(data);
 
 	// task should have been executed
 	// expecting X = 3
 	TEST_ASSERT(X == 3);
 }
 
-void test_AbortRunningTask() {
+static void test_AbortRunningTask() {
 	// issue a long running task ~100ms
 	// issue abort 20ms into execution
 	// validate call to Cron_AbortTask returns in less than ~10 ms
 
-	// issue a long running task, task will sleep for 100 'ms'
 	int ms = 100;
-	CronTaskHandle task_handle = Cron_AddTask(0, long_running_task, &ms);
+	AddTaskData data = _AddTaskData_New(long_running_task, (void*)&ms);
+	// issue a long running task, task will sleep for 100 'ms'
+	CronTaskHandle task_handle = Cron_AddTask(0, _AddTaskData_Execute, &data);
 
-	mssleep(20); // sleep for 20 ms
+	_AddTaskData_WaitForRunning(data);
 
 	clock_t t = clock(); // start timer
 
-	// task should be running
-	// abort task, call should return only after task is completed
+	// the task should be already running
+	// abort the task, call should return immediately without waiting
+	// until the task completed.
 	Cron_AbortTask(task_handle);
+	// As the function call should've been as fast as possible, the
+	// task is expected to not have yet been completed.
+	TEST_ASSERT(!_AddTaskData_HasCompleted(data));
 
 	t = clock() - t; // stop timer
 	double time_taken_sec = ((double)t)/CLOCKS_PER_SEC;
 
 	// expecting Cron_AbortTask to return before at-most 10 ms
 	TEST_ASSERT(time_taken_sec < 0.01);
+
+	_AddTaskData_WaitForCompletion(data);
+	_AddTaskData_Free(data);
 }
 
 TEST_LIST = {


### PR DESCRIPTION
The test should have been flaky due to the time limit imposed with no control over the clock used as well as the scheduling.

This rewrites the test so that we don't rely on any clock rather than the real clock and for just the time out, not for "letting something happen". The test only proceeds when the cron thread has performed the job and notifies the main thread about its completion. This is made possible by using the file descriptors and the select system call.

The select also makes use of the time out facility and uses a three second time interval for the test timeout.