### PR TITLE
benchmark batch node deletion

### DIFF
--- a/tests/benchmarks/batch_node_delete.yml
+++ b/tests/benchmarks/batch_node_delete.yml
@@ -1,0 +1,20 @@
+name: "NODE-BATCH-DELETE"
+remote:
+  - setup: redisgraph-r5
+  - type: oss-standalone
+dbconfig:
+  - init_commands:
+    - '"GRAPH.QUERY" "g" "UNWIND range(0, 3000000) AS x CREATE (:N{v:x})"'
+clientconfig:
+  - tool: redisgraph-benchmark-go
+  - parameters:
+    - graph: "g"
+    - rps: 0
+    - clients: 1
+    - threads: 4
+    - connections: 1
+    - requests: 1000
+    - queries:
+        - { q: "MATCH (n) WITH n LIMIT 3000 DELETE n", ratio: 1 }
+kpis:
+  - le: { $.OverallGraphInternalLatencies.Total.q50: 40.0 }

--- a/tests/benchmarks/batch_node_delete.yml
+++ b/tests/benchmarks/batch_node_delete.yml
@@ -17,4 +17,4 @@ clientconfig:
     - queries:
         - { q: "MATCH (n) WITH n LIMIT 3000 DELETE n", ratio: 1 }
 kpis:
-  - le: { $.OverallGraphInternalLatencies.Total.q50: 40.0 }
+  - le: { $.OverallGraphInternalLatencies.Total.q50: 950.0 }


### PR DESCRIPTION
Benchmark batch node deletion, deleting 3,000 nodes in each batch. operating on a graph with 3M nodes.