### PR TITLE
GRAPH.CONSTRAINT: Fix validation max limit property count

### DIFF
--- a/src/commands/cmd_constraint.c
+++ b/src/commands/cmd_constraint.c
@@ -104,7 +104,7 @@ static int Constraint_Parse
 	long long _prop_count;
 	if(strcasecmp(token, "PROPERTIES") == 0) {
 		if(RedisModule_StringToLongLong(*argv++, &_prop_count) != REDISMODULE_OK
-				|| _prop_count < 1 || _prop_count > 256) {
+				|| _prop_count < 1 || _prop_count > 255) {
 			RedisModule_ReplyWithError(ctx, "Invalid property count");
 			return REDISMODULE_ERR;
 		}


### PR DESCRIPTION
This patch is to fix the maximum limit of properties used in GRAPH.CONSTRAINT.
The variable used is of type ``uint8_t``, then its range is ``0..255``