### PR TITLE
Foreach fix

### DIFF
--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1383,6 +1383,16 @@ static VISITOR_STRATEGY _Validate_FOREACH_Clause
 		// set the clause of the context
 		vctx->clause = CYPHER_AST_FOREACH;
 
+		// make sure that the list variable is bound, if it is an alias
+		const cypher_astnode_t *list_node =
+			cypher_ast_foreach_get_expression(n);
+		if(cypher_astnode_type(list_node) == CYPHER_AST_IDENTIFIER) {
+			const char *list_var_name =
+				cypher_ast_identifier_get_name(list_node);
+			_Validate_referred_identifier(vctx->defined_identifiers,
+										  list_var_name);
+		}
+
 		// introduce loop variable to bound vars
 		const cypher_astnode_t *identifier_node =
 			cypher_ast_foreach_get_identifier(n);

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1383,15 +1383,10 @@ static VISITOR_STRATEGY _Validate_FOREACH_Clause
 		// set the clause of the context
 		vctx->clause = CYPHER_AST_FOREACH;
 
-		// make sure that the list variable is bound, if it is an alias
+		// visit FOREACH array expression
 		const cypher_astnode_t *list_node =
 			cypher_ast_foreach_get_expression(n);
-		if(cypher_astnode_type(list_node) == CYPHER_AST_IDENTIFIER) {
-			const char *list_var_name =
-				cypher_ast_identifier_get_name(list_node);
-			_Validate_referred_identifier(vctx->defined_identifiers,
-										  list_var_name);
-		}
+		AST_Visitor_visit(list_node, visitor);
 
 		// introduce loop variable to bound vars
 		const cypher_astnode_t *identifier_node =
@@ -1402,9 +1397,6 @@ static VISITOR_STRATEGY _Validate_FOREACH_Clause
 
 		raxInsert(vctx->defined_identifiers, (unsigned char *) identifier,
 				  strlen(identifier), NULL, NULL);
-
-		// visit FOREACH array expression
-		AST_Visitor_visit(list_node, visitor);
 
 		// visit FOREACH loop body clauses
 		uint nclauses = cypher_ast_foreach_nclauses(n);

--- a/src/ast/ast_validations.c
+++ b/src/ast/ast_validations.c
@@ -1404,8 +1404,7 @@ static VISITOR_STRATEGY _Validate_FOREACH_Clause
 				  strlen(identifier), NULL, NULL);
 
 		// visit FOREACH array expression
-		const cypher_astnode_t *exp = cypher_ast_foreach_get_expression(n);
-		AST_Visitor_visit(exp, visitor);
+		AST_Visitor_visit(list_node, visitor);
 
 		// visit FOREACH loop body clauses
 		uint nclauses = cypher_ast_foreach_nclauses(n);

--- a/tests/flow/test_foreach.py
+++ b/tests/flow/test_foreach.py
@@ -640,3 +640,19 @@ class testForeachFlow():
 
         # no nodes should have been created
         self.env.assertEquals(res.nodes_created, 0)
+
+    def test14_unbound_list_var(self):
+        """Tests that given an unbound list-var, an error is raised"""
+
+        try:
+            graph.query("FOREACH(n in li | CREATE (:N))")
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError as e:
+            self.env.assertIn("li not defined", str(e))
+
+        # same check, when the list-var is the same as the list expression
+        try:
+            graph.query("FOREACH(n in n | CREATE (:N))")
+            self.env.assertTrue(False)
+        except redis.exceptions.ResponseError as e:
+            self.env.assertIn("n not defined", str(e))


### PR DESCRIPTION
This PR handles the case `FOREACH(n in n | ...)`, which did not raise an error stating that `n` is undefined.