### PR TITLE
Fix match

### DIFF
--- a/src/execution_plan/execution_plan_build/build_match_op_tree.c
+++ b/src/execution_plan/execution_plan_build/build_match_op_tree.c
@@ -48,6 +48,17 @@ static void _ExecutionPlan_ProcessQueryGraph
 		OpBase *root = NULL; // the root of the traversal chain will be added to the ExecutionPlan
 		OpBase *tail = NULL;
 
+		if(edge_count == 0) {
+			// if there are no edges in the component, we only need a node scan
+			// if no labels are introduced, and the var is bound, don't build
+			// a traversal
+			QGNode *n = cc->nodes[0];
+			if(raxFind(bound_vars, (unsigned char *)n->alias, strlen(n->alias))
+					!= raxNotFound && QGNode_LabelCount(n) == 0) {
+				continue;
+			}
+		}
+
 		AlgebraicExpression **exps = AlgebraicExpression_FromQueryGraph(cc);
 		uint expCount = array_len(exps);
 

--- a/src/execution_plan/execution_plan_build/build_match_op_tree.c
+++ b/src/execution_plan/execution_plan_build/build_match_op_tree.c
@@ -48,15 +48,6 @@ static void _ExecutionPlan_ProcessQueryGraph
 		OpBase *root = NULL; // the root of the traversal chain will be added to the ExecutionPlan
 		OpBase *tail = NULL;
 
-		if(edge_count == 0) {
-			// if there are no edges in the component, we only need a node scan
-			QGNode *n = cc->nodes[0];
-			if(raxFind(bound_vars, (unsigned char *)n->alias, strlen(n->alias))
-					!= raxNotFound) {
-				continue;
-			}
-		}
-
 		AlgebraicExpression **exps = AlgebraicExpression_FromQueryGraph(cc);
 		uint expCount = array_len(exps);
 

--- a/tests/flow/test_bound_variables.py
+++ b/tests/flow/test_bound_variables.py
@@ -4,6 +4,7 @@ from index_utils import *
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 redis_graph = None
+GRAPH_ID = "G"
 
 
 class testBoundVariables(FlowTestsBase):
@@ -11,7 +12,7 @@ class testBoundVariables(FlowTestsBase):
         self.env = Env(decodeResponses=True)
         global redis_graph
         redis_con = self.env.getConnection()
-        redis_graph = Graph(redis_con, "G")
+        redis_graph = Graph(redis_con, GRAPH_ID)
         self.populate_graph()
 
     def populate_graph(self):
@@ -95,3 +96,20 @@ class testBoundVariables(FlowTestsBase):
         # Verify results.
         expected_result = [[0], [1], [2]]
         self.env.assertEquals(actual_result.result_set, expected_result)
+
+    def test06_override_bound_with_label(self):
+        """Tests that we override a bound alias with a new scan if it has a
+        label"""
+
+        # clear the db
+        self.env.flush()
+        redis_graph = Graph(self.env.getConnection(), GRAPH_ID)
+
+        # create one node with label `N`
+        res = redis_graph.query("CREATE (:N)")
+        self.env.assertEquals(res.nodes_created, 1)
+
+        res = redis_graph.query("MATCH(n:N) WITH n MATCH (n:X) RETURN n")
+
+        # make sure no nodes were returned
+        self.env.assertEquals(len(res.result_set), 0)


### PR DESCRIPTION
This PR fixes #2957.
Specifically, we construct a scan in case an override of a bound var exists (non-zero labels).