### PR TITLE
left(), right(): Remove NULL from valid 2nd arg types

### DIFF
--- a/src/arithmetic/string_funcs/string_funcs.c
+++ b/src/arithmetic/string_funcs/string_funcs.c
@@ -702,7 +702,7 @@ void Register_StringFuncs() {
 
 	types = array_new(SIType, 2);
 	array_append(types, (T_STRING | T_NULL));
-	array_append(types, T_INT64 | T_NULL);
+	array_append(types, T_INT64);
 	ret_type = T_STRING | T_NULL;
 	func_desc = AR_FuncDescNew("left", AR_LEFT, 2, 2, types, ret_type, false, true);
 	AR_RegFunc(func_desc);
@@ -715,7 +715,7 @@ void Register_StringFuncs() {
 
 	types = array_new(SIType, 2);
 	array_append(types, (T_STRING | T_NULL));
-	array_append(types, T_INT64 | T_NULL);
+	array_append(types, T_INT64);
 	ret_type = T_STRING | T_NULL;
 	func_desc = AR_FuncDescNew("right", AR_RIGHT, 2, 2, types, ret_type, false, true);
 	AR_RegFunc(func_desc);

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -727,7 +727,6 @@ class testFunctionCallsFlow(FlowTestsBase):
             "RETURN LEFT('muchacho', 100)" : [['muchacho']],
             "RETURN LEFT(NULL, -1)" : [[None]],
             "RETURN LEFT(NULL, 100)" : [[None]],
-            "RETURN LEFT(NULL, NULL)" : [[None]],
             # test unicode charecters
             "RETURN LEFT('丁丂七丄丅丆万丈三上', 4)" : [['丁丂七丄']],
             "RETURN LEFT('丁丂七丄丅丆万丈三上', 100)" : [['丁丂七丄丅丆万丈三上']],
@@ -738,7 +737,6 @@ class testFunctionCallsFlow(FlowTestsBase):
         # invalid length argument
         queries = [
             """RETURN LEFT('', -100)""",
-            """RETURN LEFT('a', NULL)""",
             ]
         for query in queries:
             try:
@@ -751,6 +749,7 @@ class testFunctionCallsFlow(FlowTestsBase):
         queries = [
             """RETURN LEFT(NULL, 'a')""",
             """RETURN LEFT(NULL, 1.3)""",
+            """RETURN LEFT('a', NULL)""",
         ]
         for query in queries:
             self.expect_type_error(query)
@@ -761,7 +760,6 @@ class testFunctionCallsFlow(FlowTestsBase):
             "RETURN RIGHT('muchacho', 100)" : [['muchacho']],
             "RETURN RIGHT(NULL, -1)" : [[None]],
             "RETURN RIGHT(NULL, 100)" : [[None]],
-            "RETURN RIGHT(NULL, NULL)" : [[None]],
             # test unicode charecters
             "RETURN RIGHT('丁丂七丄丅丆万丈三上', 4)" : [['万丈三上']],
             "RETURN RIGHT('丁丂七丄丅丆万丈三上', 100)" : [['丁丂七丄丅丆万丈三上']],
@@ -772,7 +770,6 @@ class testFunctionCallsFlow(FlowTestsBase):
         # invalid length argument
         queries = [
             """RETURN RIGHT('', -100)""",
-            """RETURN RIGHT('a', NULL)""",
             ]
         for query in queries:
             try:
@@ -785,6 +782,7 @@ class testFunctionCallsFlow(FlowTestsBase):
         queries = [
             """RETURN RIGHT(NULL, 'a')""",
             """RETURN RIGHT(NULL, 1.3)""",
+            """RETURN RIGHT('a', NULL)""",
         ]
         for query in queries:
             self.expect_type_error(query)


### PR DESCRIPTION
This patch is to solve this small bug:

```sh
GRAPH.QUERY g "RETURN left('abc', 0.5)"
(error) Type mismatch: expected Integer or Null but was Float
GRAPH.QUERY g "RETURN left('abc', null)"
(error) length must be a non-negative integer
```
The reply to the first call states that Null is a valid type for the second parameter, while actually it is not.
Same for ``right()``.
When passing Null we should receive ``Type mismatch: expected Integer``.

After apply the patch:
```sh
GRAPH.QUERY g "RETURN left('abc', 0.5)"
(error) Type mismatch: expected Integer but was Float
GRAPH.QUERY g "RETURN left('abc', null)"
(error) Type mismatch: expected Integer but was Null
```