### PR TITLE
Fix _AR_EXP_FromIntegerString()

### DIFF
--- a/src/arithmetic/arithmetic_expression_construct.c
+++ b/src/arithmetic/arithmetic_expression_construct.c
@@ -171,6 +171,7 @@ static AR_ExpNode *_AR_EXP_FromPropertyExpression(const cypher_astnode_t *expr) 
 
 static SIValue _AR_EXP_FromIntegerString(const char *value_str) {
 	char *endptr = NULL;
+	errno = 0;
 	int64_t l = strtol(value_str, &endptr, 0);
 	if(endptr[0] != 0) {
 		// Failed to convert integer value; set compile-time error to be raised later.


### PR DESCRIPTION
This PR is to solve #2931, where wrong overflow error message are reported when string is converted to long integer.
The change just add ``errno = 0`` before ``strtol()``. 
Tests with valid an invalid queries were added also.