### PR TITLE
Fix optimize label scan (2)

### DIFF
--- a/src/execution_plan/execution_plan_build/build_match_op_tree.c
+++ b/src/execution_plan/execution_plan_build/build_match_op_tree.c
@@ -82,8 +82,16 @@ static void _ExecutionPlan_ProcessQueryGraph
 			Schema *s = GraphContext_GetSchema(gc, label, SCHEMA_NODE);
 			if(s != NULL) label_id = Schema_GetID(s);
 
+			// build candidates for swap in Label-Scan optimization
+			uint *candidates = array_new(uint, 0);
+			for(uint i = 0; i < label_count; i++) {
+				uint _label_id = QGNode_GetLabelID(src, i);
+				if(_label_id != label_id) {
+					array_append(candidates, _label_id);
+				}
+			}
 			// resolve source node by performing label scan
-			NodeScanCtx ctx = NODE_CTX_NEW(alias, label, label_id);
+			NodeScanCtx ctx = NODE_CTX_NEW(alias, label, label_id, candidates);
 			root = tail = NewNodeByLabelScanOp(plan, ctx);
 
 			// first operand has been converted into a label scan op

--- a/src/execution_plan/ops/shared/scan_functions.h
+++ b/src/execution_plan/ops/shared/scan_functions.h
@@ -8,16 +8,18 @@
 
 // Storage struct for label data in node and index scans.
 typedef struct {
-	const char *alias;   // Alias of the node being traversed.
-	const char *label;   // Label of the node being traversed.
-	int label_id;        // Label ID of the node being traversed.
+	const char *alias;  // alias of the node being traversed
+	const char *label;  // label of the node being traversed
+	int label_id;       // label ID of the node being traversed
+	int *candidates;   // candidates for swapping in Label-Scan optimization
 } NodeScanCtx;
 
 // Instantiate a new labeled node context.
-#define NODE_CTX_NEW(_alias, _label, _label_id)  \
-(NodeScanCtx) {                                  \
-	.alias = (_alias),                           \
-	.label = (_label),                           \
-	.label_id = (_label_id)                      \
+#define NODE_CTX_NEW(_alias, _label, _label_id, _candidates)  \
+(NodeScanCtx) {                                               \
+	.alias = (_alias),                                        \
+	.label = (_label),                                        \
+	.label_id = (_label_id),                                  \
+	.candidates = (_candidates)                               \
 }
 


### PR DESCRIPTION
Fix Label-Scan optimization to:
1. Take into account valid swap options (for instance mandatory ones for `MATCH` clauses, see tests to further understand).
2. Work for `OPTIONAL MATCH` clauses as well as mandatory `MATCH` clauses (no mixing between the clauses!).

Solves [MOD-5093](https://redislabs.atlassian.net/browse/MOD-5093)