### PR TITLE
Fix reorder expression

### DIFF
--- a/src/execution_plan/optimizations/traverse_order_utils.c
+++ b/src/execution_plan/optimizations/traverse_order_utils.c
@@ -24,7 +24,7 @@ static bool _AlgebraicExpression_IsVarLen
 	QGEdge *e = QueryGraph_GetEdgeByAlias(qg, edge_alias);
 	ASSERT(e != NULL);
 
-	return QGEdge_VariableLength(e);
+	return (QGEdge_VariableLength(e) || QGEdge_GhostEdge(e));
 }
 
 //------------------------------------------------------------------------------
@@ -92,7 +92,7 @@ int TraverseOrder_FilterExistenceScore
 	const  char  *edge          =  AlgebraicExpression_Edge(exp);
 
 	// varible length expression shouldn't be scored on its source or destination
-	// as these are usually (if labeled) represented via seperated expressions
+	// as these are usually (if labeled) represented via separated expressions
 	if(!_AlgebraicExpression_IsVarLen(exp, qg)) {
 		frequency = raxFind(filtered_entities, (unsigned char *)src, strlen(src));
 		if(frequency != raxNotFound) {

--- a/tests/flow/reversepattern/__init__.py
+++ b/tests/flow/reversepattern/__init__.py
@@ -60,8 +60,9 @@ class ReversePattern(object):
 
         # Find the leftmost node.
         start = q.find("(")
+        prefix = start
 
-        stop_words = ["WHERE", "RETURN", "SET", "DELETE"]
+        stop_words = ["WITH", "WHERE", "RETURN", "SET", "DELETE"]
         for stop in stop_words:
             end = q.find(stop)
             if end != -1:
@@ -96,5 +97,5 @@ class ReversePattern(object):
             if entity == None:
                 break
 
-        reversed_query = "MATCH" + reversed_query + q[end:]
+        reversed_query = q[:prefix-1] + reversed_query + q[end:]
         return reversed_query

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -1,4 +1,5 @@
 from common import *
+from reversepattern import ReversePattern
 
 dis_redis = None
 redis_graph = None
@@ -214,6 +215,10 @@ class testVariableLengthTraversals(FlowTestsBase):
         for query, expected_result in query_to_expected_result.items():
             actual_result = redis_graph.query(query)
             self.env.assertEquals(actual_result.result_set, expected_result)
+            # Test reversed pattern query.
+            reversed_query = ReversePattern().reverse_query_pattern(query)
+            actual_result = redis_graph.query(reversed_query)
+            self.env.assertEquals(actual_result.result_set, expected_result)
 
     # Test path with ghost edges
     def test12_ghost_edge(self):
@@ -230,11 +235,16 @@ class testVariableLengthTraversals(FlowTestsBase):
 
         # validation queries
         query_to_expected_result = {
-            "MATCH p = ()--(:A)<-[*0]-() RETURN length(p)": [[1], [1]],
+            "MATCH p = ()-[*0]->(:A) RETURN length(p)": [[0]],
             "MATCH p = ()-[*0]->(:A)--() RETURN length(p)": [[1], [1]],
         }
 
         # validate query results
         for query, expected_result in query_to_expected_result.items():
+            # Test pattern query
             actual_result = redis_graph.query(query)
+            self.env.assertEquals(actual_result.result_set, expected_result)
+            # Test reversed pattern query.
+            reversed_query = ReversePattern().reverse_query_pattern(query)
+            actual_result = redis_graph.query(reversed_query)
             self.env.assertEquals(actual_result.result_set, expected_result)

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -214,3 +214,27 @@ class testVariableLengthTraversals(FlowTestsBase):
         for query, expected_result in query_to_expected_result.items():
             actual_result = redis_graph.query(query)
             self.env.assertEquals(actual_result.result_set, expected_result)
+
+    # Test path with ghost edges
+    def test12_ghost_edge(self):
+        # clear previous data
+        conn = self.env.getConnection()
+        conn.flushall()
+
+        # populate graph
+        # create a graph with 2 nodes, 2 edges
+        # a->a
+        # b->a
+        query = "CREATE (a:A)-[:R1]->(a)<-[:R2]-(b)"
+        actual_result = redis_graph.query(query)
+
+        # validation queries
+        query_to_expected_result = {
+            "MATCH p = ()--(:A)<-[*0]-() RETURN length(p)": [[1], [1]],
+            "MATCH p = ()-[*0]->(:A)--() RETURN length(p)": [[1], [1]],
+        }
+
+        # validate query results
+        for query, expected_result in query_to_expected_result.items():
+            actual_result = redis_graph.query(query)
+            self.env.assertEquals(actual_result.result_set, expected_result)


### PR DESCRIPTION
Hi, this patch is to fix #3058.
The idea is to don't score expressions with GhostEdge, because the reorder expression function was removing conditional variable length traverse operations.

Before applying the patch, the reordering of the expression removed the ```Conditional Variable Length Traverse``` operation and the module crashes:
```sh
127.0.0.1:6379> GRAPH.explain g "MATCH ()-[*0]->(:A)--() RETURN 0"
1) "Results"
2) "    Project"
3) "        Conditional Traverse | (@anon_1:A)->(@anon_2)"
4) "            Node By Label Scan | (@anon_0)"
```

But for the same pattern written backwards, there was not problem:
```sh
127.0.0.1:6379> GRAPH.explain g "MATCH ()--(:A)<-[*0]-() RETURN 0"
1) "Results"
2) "    Project"
3) "        Conditional Variable Length Traverse | (@anon_1)-[@anon_4*0..0]->(@anon_2)"
4) "            Conditional Traverse | (@anon_1)->(@anon_0)"
5) "                Node By Label Scan | (@anon_1:A)"
```

