### PR TITLE
Fix shared node detection

### DIFF
--- a/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
@@ -424,11 +424,14 @@ static QGNode *_SharedNode
 	const QGEdge *e0,
 	const QGEdge *e1
 ) {
-	ASSERT(e0 && e1);
-	if(e0->dest == e1->src) return e0->dest;   // (a)-[E0]->(b)-[E1]->(c)
-	if(e0->src == e1->dest) return e0->src;    // (a)<-[E0]-(b)<-[E1]-(c)
+	ASSERT(e0 != NULL);
+	ASSERT(e1 != NULL);
+
+	if(e0->dest == e1->src)  return e0->dest;  // (a)-[E0]->(b)-[E1]->(c)
 	if(e0->dest == e1->dest) return e0->dest;  // (a)-[E0]->(b)<-[E1]-(c)
-	if(e0->src == e1->src) return e0->src;     // (a)<-[E0]-(b)-[E1]->(c)
+	if(e0->src == e1->dest)  return e0->src;   // (a)<-[E0]-(b)<-[E1]-(c)
+	if(e0->src == e1->src)   return e0->src;   // (a)<-[E0]-(b)-[E1]->(c)
+
 	return NULL;
 }
 

--- a/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
+++ b/src/arithmetic/algebraic_expression/algebraic_expression_construction.c
@@ -415,20 +415,20 @@ static AlgebraicExpression *_AlgebraicExpression_OperandFromEdge
 	return root;
 }
 
-/* In case edges `a` and `b` share a node:
+/* In case edges `e0` and `e1` share a node:
  * (a)-[E0]->(b)<-[E1]-(c)
  * than the shared entity is returned
  * if edges are disjoint, NULL is returned. */
 static QGNode *_SharedNode
 (
-	const QGEdge *a,
-	const QGEdge *b
+	const QGEdge *e0,
+	const QGEdge *e1
 ) {
-	ASSERT(a && b);
-	if(a->dest == b->src) return a->dest;   // (a)-[E0]->(b)-[E1]->(c)
-	if(a->src == b->dest) return a->src;    // (a)<-[E0]-(b)<-[E1]-(c)
-	if(a->src == b->src) return a->src;     // (a)<-[E0]-(b)-[E1]->(c)
-	if(a->dest == b->dest) return a->dest;  // (a)-[E0]->(b)<-[E1]-(c)
+	ASSERT(e0 && e1);
+	if(e0->dest == e1->src) return e0->dest;   // (a)-[E0]->(b)-[E1]->(c)
+	if(e0->src == e1->dest) return e0->src;    // (a)<-[E0]-(b)<-[E1]-(c)
+	if(e0->dest == e1->dest) return e0->dest;  // (a)-[E0]->(b)<-[E1]-(c)
+	if(e0->src == e1->src) return e0->src;     // (a)<-[E0]-(b)-[E1]->(c)
 	return NULL;
 }
 

--- a/tests/flow/test_relation_patterns.py
+++ b/tests/flow/test_relation_patterns.py
@@ -300,3 +300,19 @@ class testRelationPattern(FlowTestsBase):
             res = g.query(q.format(L0=perm[0], L1=perm[1], L2=perm[2]))
             self.env.assertEquals(res.result_set, expected_result)
 
+    def test11_shared_node_detection(self):
+        # Construct a simple graph
+        # (s)<-[:A]-(x)
+        # (x)<-[:B]-(x)
+        # (x)-[:B]->(t)
+        # (t)<-[:B]-(x)
+        g = Graph(redis_con, "shared_node")
+        q = "MERGE (s)<-[:A]-(x)<-[:B]-(x)-[:B]->(t)<-[:B]-(x)"
+        result = g.query(q)
+
+        self.env.assertEquals(result.nodes_created, 3)
+        self.env.assertEquals(result.relationships_created, 4)
+
+        result = g.query(q)
+        self.env.assertEquals(result.nodes_created, 0)
+        self.env.assertEquals(result.relationships_created, 0)


### PR DESCRIPTION
This patch is to solve #3042

In the case of patterns where both nodes are shared, like ```(a)-[E0]->(b)<-[E1]-(a)```, the current ```_SharedNode()``` returns ``a``, but it should return ``b`` because the operations are being evaluated from left to right. 