### PR TITLE
Fix test_bulk_insertion

### DIFF
--- a/tests/flow/test_bulk_insertion.py
+++ b/tests/flow/test_bulk_insertion.py
@@ -391,7 +391,7 @@ class testGraphBulkInsertFlow(FlowTestsBase):
 
         thread.join()
         # Verify that at least one ping was issued
-        self.env.assertGreater(ping_count, 1)
+        self.env.assertGreaterEqual(ping_count, 1)
 
     # Verify that nodes with multiple labels are created correctly
     def test10_multiple_labels(self):

--- a/tests/flow/test_relation_patterns.py
+++ b/tests/flow/test_relation_patterns.py
@@ -325,19 +325,19 @@ class testRelationPattern(FlowTestsBase):
         self.env.assertEquals(result.relationships_created, 0)
 
     # test error reporting for invalid min, max variable length edge length
-    def test12_lt_zero_hop_traversals(self):
+    # def test12_lt_zero_hop_traversals(self):
 
-        queries = [
-            "MATCH p=()-[*..0]->() RETURN nodes(p) AS nodes",
-            "MATCH p=()-[*1..0]->() RETURN nodes(p) AS nodes",
-            "MATCH p=()-[*2..1]->() RETURN nodes(p) AS nodes",
-            "MATCH p=()-[e*2..1]->() RETURN nodes(p) AS nodes",
-            "MATCH p=()-[e:R*20..10]->() RETURN nodes(p) AS nodes",
-            "MATCH p=()-[]->()-[*1..0]->() RETURN nodes(p) AS nodes",
-        ]
-        for query in queries:
-            self._assert_exception(redis_graph, query,
-                "Variable length path, maximum number of hops must be greater or equal to minimum number of hops.")
+    #     queries = [
+    #         "MATCH p=()-[*..0]->() RETURN nodes(p) AS nodes",
+    #         "MATCH p=()-[*1..0]->() RETURN nodes(p) AS nodes",
+    #         "MATCH p=()-[*2..1]->() RETURN nodes(p) AS nodes",
+    #         "MATCH p=()-[e*2..1]->() RETURN nodes(p) AS nodes",
+    #         "MATCH p=()-[e:R*20..10]->() RETURN nodes(p) AS nodes",
+    #         "MATCH p=()-[]->()-[*1..0]->() RETURN nodes(p) AS nodes",
+    #     ]
+    #     for query in queries:
+    #         self._assert_exception(redis_graph, query,
+    #             "Variable length path, maximum number of hops must be greater or equal to minimum number of hops.")
 
     def test13_return_var_len_edge_array(self):
         # Construct a simple graph:

--- a/tests/flow/test_relation_patterns.py
+++ b/tests/flow/test_relation_patterns.py
@@ -325,19 +325,21 @@ class testRelationPattern(FlowTestsBase):
         self.env.assertEquals(result.relationships_created, 0)
 
     # test error reporting for invalid min, max variable length edge length
-    # def test12_lt_zero_hop_traversals(self):
+    def test12_lt_zero_hop_traversals(self):
+        # Construct an empty graph
+        g = Graph(redis_con, "lt_zero_hop_traversals")
 
-    #     queries = [
-    #         "MATCH p=()-[*..0]->() RETURN nodes(p) AS nodes",
-    #         "MATCH p=()-[*1..0]->() RETURN nodes(p) AS nodes",
-    #         "MATCH p=()-[*2..1]->() RETURN nodes(p) AS nodes",
-    #         "MATCH p=()-[e*2..1]->() RETURN nodes(p) AS nodes",
-    #         "MATCH p=()-[e:R*20..10]->() RETURN nodes(p) AS nodes",
-    #         "MATCH p=()-[]->()-[*1..0]->() RETURN nodes(p) AS nodes",
-    #     ]
-    #     for query in queries:
-    #         self._assert_exception(redis_graph, query,
-    #             "Variable length path, maximum number of hops must be greater or equal to minimum number of hops.")
+        queries = [
+            "MATCH p=()-[*..0]->() RETURN nodes(p) AS nodes",
+            "MATCH p=()-[*1..0]->() RETURN nodes(p) AS nodes",
+            "MATCH p=()-[*2..1]->() RETURN nodes(p) AS nodes",
+            "MATCH p=()-[e*2..1]->() RETURN nodes(p) AS nodes",
+            "MATCH p=()-[e:R*20..10]->() RETURN nodes(p) AS nodes",
+            "MATCH p=()-[]->()-[*1..0]->() RETURN nodes(p) AS nodes",
+        ]
+        for query in queries:
+            self._assert_exception(g, query,
+                "Variable length path, maximum number of hops must be greater or equal to minimum number of hops.")
 
     def test13_return_var_len_edge_array(self):
         # Construct a simple graph:


### PR DESCRIPTION
This was the error reported by CI, when the ```ping_count``` is verified:
```sh
test_bulk_insertion:testGraphBulkInsertFlow.test09_large_bulk_insert
		:x:  (FAIL):	1 > 1	test_bulk_insertion.py:394
```
The test ```test12_lt_zero_hop_traversals(self)``` was modified to use a local graph in its tests.
