### PR TITLE
fix Unwind op construction

### DIFF
--- a/src/ast/enrichment/annotate_projected_named_paths.c
+++ b/src/ast/enrichment/annotate_projected_named_paths.c
@@ -127,6 +127,11 @@ static void _annotate_relevant_projected_named_path_identifier
 				_annotate_named_paths_in_expression(ast, identifier_map,
 													named_paths_ctx, exp);
 			}
+		} else if(clause_type == CYPHER_AST_UNWIND) {
+			const cypher_astnode_t *exp =
+				cypher_ast_unwind_get_expression(clause);
+			_annotate_named_paths_in_expression(ast, identifier_map,
+												named_paths_ctx, exp);
 		}
 	}
 }

--- a/src/execution_plan/execution_plan_build/build_pattern_comprehension_ops.c
+++ b/src/execution_plan/execution_plan_build/build_pattern_comprehension_ops.c
@@ -171,7 +171,7 @@ void buildPatternPathOps
 	ASSERT(ast  != NULL);
 	ASSERT(root->type == OPType_PROJECT   ||
 	       root->type == OPType_AGGREGATE ||
-		   root->type == OPType_UNWIND);
+	       root->type == OPType_UNWIND);
 
 	// search for pattern comprehension AST nodes
 	// quickly return if none been found

--- a/src/execution_plan/execution_plan_build/build_pattern_comprehension_ops.c
+++ b/src/execution_plan/execution_plan_build/build_pattern_comprehension_ops.c
@@ -43,6 +43,9 @@ void buildPatternComprehensionOps
 	ASSERT(plan != NULL);
 	ASSERT(root != NULL);
 	ASSERT(ast  != NULL);
+	ASSERT(root->type == OPType_PROJECT   ||
+	       root->type == OPType_AGGREGATE ||
+		   root->type == OPType_UNWIND);
 
 	// search for pattern comprehension AST nodes
 	// quickly return if none been found
@@ -166,6 +169,9 @@ void buildPatternPathOps
 	ASSERT(plan != NULL);
 	ASSERT(root != NULL);
 	ASSERT(ast  != NULL);
+	ASSERT(root->type == OPType_PROJECT   ||
+	       root->type == OPType_AGGREGATE ||
+		   root->type == OPType_UNWIND);
 
 	// search for pattern comprehension AST nodes
 	// quickly return if none been found

--- a/src/execution_plan/execution_plan_build/build_pattern_comprehension_ops.c
+++ b/src/execution_plan/execution_plan_build/build_pattern_comprehension_ops.c
@@ -43,7 +43,6 @@ void buildPatternComprehensionOps
 	ASSERT(plan != NULL);
 	ASSERT(root != NULL);
 	ASSERT(ast  != NULL);
-	ASSERT(root->type == OPType_PROJECT || root->type == OPType_AGGREGATE);
 
 	// search for pattern comprehension AST nodes
 	// quickly return if none been found
@@ -167,7 +166,6 @@ void buildPatternPathOps
 	ASSERT(plan != NULL);
 	ASSERT(root != NULL);
 	ASSERT(ast  != NULL);
-	ASSERT(root->type == OPType_PROJECT || root->type == OPType_AGGREGATE);
 
 	// search for pattern comprehension AST nodes
 	// quickly return if none been found

--- a/src/execution_plan/execution_plan_build/execution_plan_construct.c
+++ b/src/execution_plan/execution_plan_build/execution_plan_construct.c
@@ -167,6 +167,13 @@ static inline void _buildCreateOp
 static inline void _buildUnwindOp(ExecutionPlan *plan, const cypher_astnode_t *clause) {
 	AST_UnwindContext unwind_ast_ctx = AST_PrepareUnwindOp(clause);
 	OpBase *op = NewUnwindOp(plan, unwind_ast_ctx.exp);
+
+	// build pattern\list comprehension related ops, and connect them to
+	// the Unwind op
+	const cypher_astnode_t *exp = cypher_ast_unwind_get_expression(clause);
+	buildPatternComprehensionOps(plan, op, exp);
+	buildPatternPathOps(plan, op, exp);
+
 	ExecutionPlan_UpdateRoot(plan, op);
 }
 

--- a/tests/flow/test_unwind_clause.py
+++ b/tests/flow/test_unwind_clause.py
@@ -127,3 +127,15 @@ class testUnwindClause():
         e = Edge(0, "E", 1, edge_id=0)
         path = Path.new_empty_path().add_node(n1).add_edge(e).add_node(n2)
         self.env.assertEquals(res.result_set[0][0], path)
+
+        # use reduce in eval expression (user failed on this)
+        res = redis_graph.query(
+            """
+            UNWIND [p=()-[]->() | reduce(a=1,b in [1] | 1)] AS n
+            RETURN n
+            """
+        )
+
+        # assert results
+        self.env.assertEquals(len(res.result_set), 1)
+        self.env.assertEquals(res.result_set[0][0], 1)

--- a/tests/flow/test_unwind_clause.py
+++ b/tests/flow/test_unwind_clause.py
@@ -128,14 +128,26 @@ class testUnwindClause():
         path = Path.new_empty_path().add_node(n1).add_edge(e).add_node(n2)
         self.env.assertEquals(res.result_set[0][0], path)
 
-        # use reduce in eval expression (user failed on this)
+        # simple reduce in eval expression
         res = redis_graph.query(
             """
-            UNWIND [p=()-[]->() | reduce(a=1,b in [1] | 1)] AS n
+            UNWIND [p=()-[]->() | reduce(a=1,b in [1] | a + b)] AS n
             RETURN n
             """
         )
 
         # assert results
         self.env.assertEquals(len(res.result_set), 1)
-        self.env.assertEquals(res.result_set[0][0], 1)
+        self.env.assertEquals(res.result_set[0][0], 2)
+
+        # reference `p` in eval expression
+        res = redis_graph.query(
+            """
+            UNWIND [p=()-[]->() | reduce(a=1,b in [1] | a + b + length(p))] AS n
+            RETURN n
+            """
+        )
+
+        # assert results
+        self.env.assertEquals(len(res.result_set), 1)
+        self.env.assertEquals(res.result_set[0][0], 3)


### PR DESCRIPTION
Fixes the construction of the Unwind operation, by building the ops corresponding to the path comprehension that may be inside it.

Fixes #3032.