### PR TITLE
fix propagate reset

### DIFF
--- a/src/execution_plan/ops/op.c
+++ b/src/execution_plan/ops/op.c
@@ -173,8 +173,10 @@ void OpBase_PropagateReset
 	uint write_op_count = array_len(write_ops);
 	for(uint i = 0; i < write_op_count; i++) {
 		OpBase *write_op = write_ops[i];
-		OpResult res = write_op->reset(write_op);
-		ASSERT(res == OP_OK);
+		if(write_op->reset) {
+			OpResult res = op->reset(op);
+			ASSERT(res == OP_OK);
+		}
 	}
 
 	array_free(write_ops);

--- a/src/execution_plan/ops/op.c
+++ b/src/execution_plan/ops/op.c
@@ -141,15 +141,43 @@ bool OpBase_Aware
 	return (rec_idx != raxNotFound);
 }
 
+static void _OpBase_PropagateReset
+(
+	OpBase *op,
+	OpBase ***write_ops
+) {
+	if(OpBase_IsWriter(op)) {
+		array_append(*write_ops, op);
+	} else if(op->reset) {
+		OpResult res = op->reset(op);
+		ASSERT(res == OP_OK);
+	}
+
+	// recursively reset children
+	for(int i = 0; i < op->childCount; i++) {
+		_OpBase_PropagateReset(op->children[i], write_ops);
+	}
+}
+
 void OpBase_PropagateReset
 (
 	OpBase *op
 ) {
-	if(op->reset) {
-		OpResult res = op->reset(op);
+	// hold write operations until the read operations have been reset
+	OpBase **write_ops = array_new(OpBase *, 0);
+
+	// reset read operations
+	_OpBase_PropagateReset(op, &write_ops);
+
+	// reset write operations
+	uint write_op_count = array_len(write_ops);
+	for(uint i = 0; i < write_op_count; i++) {
+		OpBase *write_op = write_ops[i];
+		OpResult res = write_op->reset(write_op);
 		ASSERT(res == OP_OK);
 	}
-	for(int i = 0; i < op->childCount; i++) OpBase_PropagateReset(op->children[i]);
+
+	array_free(write_ops);
 }
 
 static void _OpBase_StatsToString

--- a/tests/flow/test_index_delete.py
+++ b/tests/flow/test_index_delete.py
@@ -126,10 +126,12 @@ class testIndexDeletionFlow():
         g = Graph(self.env.getConnection(), GRAPH_ID)
 
         # create data
-        """
-        UNWIND range(1, 1000) AS x
-        CREATE (:X {uid: toString(x)})-[:R]->(y:Y {v: x})
-        """
+        g.query(
+            """
+            UNWIND range(1, 1000) AS x
+            CREATE (:X {uid: toString(x)})-[:R]->(y:Y {v: x})
+            """
+        )
 
         # create an index
         create_node_exact_match_index(g, 'X', 'uid', sync=True)

--- a/tests/flow/test_index_delete.py
+++ b/tests/flow/test_index_delete.py
@@ -119,7 +119,7 @@ class testIndexDeletionFlow():
     def test06_reset_order(self):
         """Tests that the reset order is correct, i.e., that the reading ops are
         reset before the writing ops (otherwise we write while a read-lock is
-        held --> deadlock)."""
+        held)."""
 
         # clear the db
         self.env.flush()
@@ -128,7 +128,7 @@ class testIndexDeletionFlow():
         # create data
         g.query(
             """
-            UNWIND range(1, 1000) AS x
+            WITH 1 AS x
             CREATE (:X {uid: toString(x)})-[:R]->(y:Y {v: x})
             """
         )
@@ -141,14 +141,16 @@ class testIndexDeletionFlow():
         # entity and setting of a property on the other entity
         res = g.query(
             """
-            MATCH (x:X {uid: '55'})-[:R]->(y:Y)
+            MATCH (x:X {uid: '1'})-[:R]->(y:Y)
             DELETE y
-            SET x.uid = '1'
+            SET x.uid = '10'
             RETURN x
             """
         )
 
         # validate results
+        self.env.assertEquals(res.nodes_deleted, 1)
+        self.env.assertEquals(res.relationships_deleted, 1)
         self.env.assertEquals(len(res.result_set), 1)
         self.env.assertEquals(res.result_set[0][0],
-            Node(label='X', properties={'uid': '1'}))
+            Node(label='X', properties={'uid': '10'}))

--- a/tests/flow/test_index_delete.py
+++ b/tests/flow/test_index_delete.py
@@ -116,3 +116,34 @@ class testIndexDeletionFlow():
                 indicies = list_indicies(g).result_set
                 self.env.assertEquals(len(indicies), 0)
 
+    def test06_reset_order(self):
+        """Tests that the reset order is correct, i.e., that the reading ops are
+        reset before the writing ops (otherwise we write while a read-lock is
+        held --> deadlock)."""
+
+        # clear the db
+        self.env.flush()
+        g = Graph(self.env.getConnection(), GRAPH_ID)
+
+        # create data
+        """
+        UNWIND range(1, 1000) AS Uid
+        CREATE (x:X {uid: toString(Uid)})-[:R]->(y:Y {v: Uid})
+        """
+
+        # create an index
+        create_node_exact_match_index(g, 'X', 'Uid', sync=True)
+        create_node_exact_match_index(g, 'Y', 'v', sync=True)
+
+        # utilize the index for a scan, followed by a deletion of the indexed
+        # entity and setting of a property on the other entity
+        res = g.query(
+            """
+            MATCH (x:X {Uid: 55})-[:R]->(y:Y)
+            DELETE y
+            SET x.v = 1
+            """
+        )
+
+        # validate results
+        self.env.assertEquals(len(res.result_set), 0)


### PR DESCRIPTION
Fixes the `propagate_reset` mechanism to reset read operations before reseting write operations, in order to avoid writing on an indexed entity which is being read.