### PR TITLE
Track visited nodes

### DIFF
--- a/src/algorithms/all_neighbors.c
+++ b/src/algorithms/all_neighbors.c
@@ -24,20 +24,6 @@ static void _AllNeighborsCtx_CollectNeighbors
 	}
 }
 
-static bool _AllNeighborsCtx_Visited
-(
-	AllNeighborsCtx *ctx,
-	EntityID id
-) {
-	uint count = ctx->current_level;
-
-	for(uint i = 0; i < count; i++) {
-		if(ctx->visited[i] == id) return true;
-	}
-
-	return false;
-}
-
 void AllNeighborsCtx_Reset
 (
 	AllNeighborsCtx *ctx,  // all neighbors context to reset
@@ -46,27 +32,27 @@ void AllNeighborsCtx_Reset
 	uint minLen,           // minimum traversal depth
 	uint maxLen            // maximum traversal depth
 ) {
-	ASSERT(M             != NULL);
-	ASSERT(src           != INVALID_ENTITY_ID);
-	ASSERT(ctx           != NULL);
-	ASSERT(ctx->levels   != NULL);
-	ASSERT(ctx->visited  != NULL);
+	ASSERT(M            != NULL);
+	ASSERT(src          != INVALID_ENTITY_ID);
+	ASSERT(ctx          != NULL);
+	ASSERT(ctx->levels  != NULL);
+	ASSERT(ctx->visited != NULL);
 
-	ctx->M              =  M;
-	ctx->src            =  src;
-	ctx->minLen         =  minLen;
-	ctx->maxLen         =  maxLen;
-	ctx->first_pull     =  true;
-	ctx->current_level  =  0;
+	ctx->M             = M;
+	ctx->src           = src;
+	ctx->minLen        = minLen;
+	ctx->maxLen        = maxLen;
+	ctx->first_pull    = true;
+	ctx->current_level = 0;
 
-	uint count = array_len(ctx->levels);
-	for (uint i = 0; i < count; i++) {
-		RG_MatrixTupleIter_detach(ctx->levels + i);
-	}
 	array_clear(ctx->levels);
 	array_clear(ctx->visited);
 
-	// Dummy iterator at level 0
+	// reset visited nodes
+	HashTableRelease(ctx->visited_nodes);
+	ctx->visited_nodes = HashTableCreate(&def_dt);
+
+	// dummy iterator at level 0
 	array_append(ctx->levels, (RG_MatrixTupleIter) {0});
 }
 
@@ -82,14 +68,15 @@ AllNeighborsCtx *AllNeighborsCtx_New
 
 	AllNeighborsCtx *ctx = rm_calloc(1, sizeof(AllNeighborsCtx));
 
-	ctx->M              =  M;
-	ctx->src            =  src;
-	ctx->minLen         =  minLen;
-	ctx->maxLen         =  maxLen;
-	ctx->levels         =  array_new(RG_MatrixTupleIter, 1);
-	ctx->visited        =  array_new(EntityID, 1);
-	ctx->first_pull     =  true;
-	ctx->current_level  =  0;
+	ctx->M              = M;
+	ctx->src            = src;
+	ctx->minLen         = minLen;
+	ctx->maxLen         = maxLen;
+	ctx->levels         = array_new(RG_MatrixTupleIter, 1);
+	ctx->visited        = array_new(EntityID, 1);
+	ctx->first_pull     = true;
+	ctx->current_level  = 0;
+	ctx->visited_nodes  = HashTableCreate(&def_dt);
 
 	// Dummy iterator at level 0
 	array_append(ctx->levels, (RG_MatrixTupleIter) {0});
@@ -101,14 +88,15 @@ EntityID AllNeighborsCtx_NextNeighbor
 (
 	AllNeighborsCtx *ctx
 ) {
-	if(!ctx) return INVALID_ENTITY_ID;
+	if(unlikely(ctx == NULL)) return INVALID_ENTITY_ID;
 
-	if(ctx->first_pull) {
+	if(unlikely(ctx->first_pull)) {
 		ASSERT(ctx->current_level == 0);
 		ctx->first_pull = false;
 
 		// update visited path, replace frontier with current node
 		array_append(ctx->visited, ctx->src);
+		HashTableAdd(ctx->visited_nodes, (void*)(ctx->src), NULL);
 
 		// current_level >= ctx->minLen
 		// see if we should expand further?
@@ -132,14 +120,18 @@ EntityID AllNeighborsCtx_NextNeighbor
 		if(info == GxB_EXHAUSTED) {
 			// backtrack
 			ctx->current_level--;
-			array_pop(ctx->visited);
+			dest_id = array_pop(ctx->visited);
+			int res = HashTableDelete(ctx->visited_nodes, (void*)(dest_id));
+			ASSERT(res == DICT_OK);
 			continue;
 		}
 
 		// update visited path, replace frontier with current node
-		array_append(ctx->visited, dest_id);
+		bool visited =
+			HashTableAdd(ctx->visited_nodes, (void*)(dest_id), NULL) != DICT_OK;
 
-		if(ctx->current_level < ctx->minLen) {
+		if(ctx->current_level < ctx->minLen && !visited) {
+			array_append(ctx->visited, dest_id);
 			// continue traversing
 			_AllNeighborsCtx_CollectNeighbors(ctx, dest_id);
 			continue;
@@ -147,8 +139,8 @@ EntityID AllNeighborsCtx_NextNeighbor
 
 		// current_level >= ctx->minLen
 		// see if we should expand further?
-		if(ctx->current_level < ctx->maxLen &&
-		   !_AllNeighborsCtx_Visited(ctx, dest_id)) {
+		if(ctx->current_level < ctx->maxLen && !visited) {
+			array_append(ctx->visited, dest_id);
 			// we can expand further
 			_AllNeighborsCtx_CollectNeighbors(ctx, dest_id);
 		}
@@ -172,6 +164,8 @@ void AllNeighborsCtx_Free
 	}
 	array_free(ctx->levels);
 	array_free(ctx->visited);
+
+	HashTableRelease(ctx->visited_nodes);
 
 	rm_free(ctx);
 }

--- a/src/algorithms/all_neighbors.h
+++ b/src/algorithms/all_neighbors.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "../../deps/GraphBLAS/Include/GraphBLAS.h"
+#include "../util/dict.h"
 #include "../graph/rg_matrix/rg_matrix.h"
 #include "../graph/rg_matrix/rg_matrix_iter.h"
 #include "../graph/entities/node.h"
@@ -29,6 +30,7 @@ typedef struct {
 	bool first_pull;               // first call to Next
 	EntityID *visited;             // visited nodes
 	RG_MatrixTupleIter *levels;    // array of neighbors iterator
+	dict *visited_nodes;           // visited nodes
 } AllNeighborsCtx;
 
 void AllNeighborsCtx_Reset

--- a/src/graph/rg_matrix/rg_matrix_iter.c
+++ b/src/graph/rg_matrix/rg_matrix_iter.c
@@ -55,9 +55,9 @@ static inline void _init_iter
 	GrB_Index max_row,
 	bool *depleted
 ) {
-	ASSERT(it != NULL) ;
-	ASSERT(m != NULL) ;
-	ASSERT(min_row <= max_row) ;
+	ASSERT(it       != NULL) ;
+	ASSERT(m        != NULL) ;
+	ASSERT(min_row  <= max_row) ;
 	ASSERT(depleted != NULL) ;
 
 	*depleted = true ; // default

--- a/tests/flow/random_graph.py
+++ b/tests/flow/random_graph.py
@@ -216,8 +216,6 @@ def run_random_graph_ops(g, nodes, edges, ops):
         params, query = ops[op](nodes, edges)
         # print(query)
         res = g.query(query, params)
-        res.nodes_created
-        res.nodes_created
         result.append(res)
 
     return total, result

--- a/tests/flow/test_function_calls.py
+++ b/tests/flow/test_function_calls.py
@@ -2489,11 +2489,11 @@ class testFunctionCallsFlow(FlowTestsBase):
         actual_result = graph.query(query)
         self.env.assertEquals(actual_result.result_set[0], expected_result)
 
-         # join overflow
-         q = """UNWIND RANGE(0, 10000000) as x
-                WITH collect('looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string') as list
-                RETURN string.join(list, 'loooooooooooooooooooooooooooooooooooooooooonggggggggggggggggggggggggggggggggggggggggggggggggggggg delimiterrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr')
-                """
+        # join overflow
+        q = """UNWIND RANGE(0, 10000000) as x
+               WITH collect('looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong string') as list
+               RETURN string.join(list, 'loooooooooooooooooooooooooooooooooooooooooonggggggggggggggggggggggggggggggggggggggggggggggggggggg delimiterrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr')
+           """
         try:
             result = graph.query(q)
             self.env.assertFalse(True)

--- a/tests/flow/test_variable_length_traversals.py
+++ b/tests/flow/test_variable_length_traversals.py
@@ -37,7 +37,9 @@ class testVariableLengthTraversals(FlowTestsBase):
 
     # Sanity check against single-hop traversal
     def test01_conditional_traverse(self):
-        query = """MATCH (a)-[e]->(b) RETURN a.name, e.connects, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a)-[e]->(b)
+                   RETURN a.name, e.connects, b.name
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         expected_result = [['A', 'AB', 'B'],
                            ['B', 'BC', 'C'],
@@ -46,31 +48,43 @@ class testVariableLengthTraversals(FlowTestsBase):
 
     # Traversal with no labels
     def test02_unlabeled_traverse(self):
-        query = """MATCH (a)-[*]->(b) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a)-[*]->(b)
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         self.env.assertEquals(len(actual_result.result_set), max_results)
 
-        query = """MATCH (a)<-[*]-(b) RETURN a, b ORDER BY a.name, b.name"""
+        query = """MATCH (a)<-[*]-(b)
+                   RETURN a, b
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         self.env.assertEquals(len(actual_result.result_set), max_results)
 
     # Traversal with labeled source
     def test03_source_labeled(self):
-        query = """MATCH (a:node)-[*]->(b) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a:node)-[*]->(b)
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         self.env.assertEquals(len(actual_result.result_set), max_results)
 
-        query = """MATCH (a:node)<-[*]-(b) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a:node)<-[*]-(b)
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         self.env.assertEquals(len(actual_result.result_set), max_results)
 
     # Traversal with labeled dest
     def test04_dest_labeled(self):
-        query = """MATCH (a)-[*]->(b:node) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a)-[*]->(b:node)
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         self.env.assertEquals(len(actual_result.result_set), max_results)
 
-        query = """MATCH (a)<-[*]-(b:node) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a)<-[*]-(b:node)
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         self.env.assertEquals(len(actual_result.result_set), max_results)
 
@@ -82,25 +96,34 @@ class testVariableLengthTraversals(FlowTestsBase):
 
     # Test bidirectional traversal
     def test06_bidirectional_traversal(self):
-        query = """MATCH (a)-[*]-(b) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a)-[*]-(b)
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         # The undirected traversal should represent every combination twice.
         self.env.assertEquals(len(actual_result.result_set), max_results * 2)
 
     def test07_non_existing_edge_traversal_with_zero_length(self):
         # Verify that zero length traversals always return source, even for non existing edges.
-        query = """MATCH (a)-[:not_knows*0..1]->(b) RETURN a"""
+        query = """MATCH (a)-[:not_knows*0..1]->(b)
+                   RETURN a"""
         actual_result = redis_graph.query(query)
         self.env.assertEquals(len(actual_result.result_set), 4)
 
     # Test traversal with a possibly-null source.
     def test08_optional_source(self):
-        query = """OPTIONAL MATCH (a:fake) OPTIONAL MATCH (a)-[*]->(b) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """OPTIONAL MATCH (a:fake)
+                   OPTIONAL MATCH (a)-[*]->(b)
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         expected_result = [[None, None]]
         self.env.assertEquals(actual_result.result_set, expected_result)
 
-        query = """OPTIONAL MATCH (a:node {name: 'A'}) OPTIONAL MATCH (a)-[*]->(b {name: 'B'}) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """OPTIONAL MATCH (a:node {name: 'A'})
+                   OPTIONAL MATCH (a)-[*]->(b {name: 'B'})
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         expected_result = [['A', 'B']]
         self.env.assertEquals(actual_result.result_set, expected_result)
@@ -108,7 +131,9 @@ class testVariableLengthTraversals(FlowTestsBase):
     # Test traversals with filters on variable-length edges
     def test09_filtered_edges(self):
         # Test an inline equality predicate
-        query = """MATCH (a)-[* {connects: 'BC'}]->(b) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a)-[* {connects: 'BC'}]->(b)
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         # The filter op should have been optimized out
         plan = redis_graph.execution_plan(query)
         self.env.assertNotIn("Filter", plan)
@@ -117,7 +142,10 @@ class testVariableLengthTraversals(FlowTestsBase):
         self.env.assertEquals(actual_result.result_set, expected_result)
 
         # Test a WHERE clause predicate
-        query = """MATCH (a)-[e*]->(b) WHERE e.connects IN ['BC', 'CD'] RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a)-[e*]->(b)
+                   WHERE e.connects IN ['BC', 'CD']
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         # The filter op should have been optimized out
         plan = redis_graph.execution_plan(query)
         self.env.assertNotIn("Filter", plan)
@@ -128,7 +156,10 @@ class testVariableLengthTraversals(FlowTestsBase):
         self.env.assertEquals(actual_result.result_set, expected_result)
 
         # Test a WHERE clause predicate with an OR condition
-        query = """MATCH (a)-[e*]->(b) WHERE e.connects = 'BC' OR e.connects = 'CD' RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a)-[e*]->(b)
+                   WHERE e.connects = 'BC' OR e.connects = 'CD'
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         # The filter op should have been optimized out
         plan = redis_graph.execution_plan(query)
         self.env.assertNotIn("Filter", plan)
@@ -137,7 +168,10 @@ class testVariableLengthTraversals(FlowTestsBase):
         self.env.assertEquals(actual_result.result_set, expected_result)
 
         # Test the concatenation of multiple predicates
-        query = """MATCH (a)-[e*]->(b) WHERE e.connects IN ['AB', 'BC', 'CD'] AND e.connects <> 'CD' RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a)-[e*]->(b)
+                   WHERE e.connects IN ['AB', 'BC', 'CD'] AND e.connects <> 'CD'
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         # The filter op should have been optimized out
         plan = redis_graph.execution_plan(query)
         self.env.assertNotIn("Filter", plan)
@@ -148,7 +182,10 @@ class testVariableLengthTraversals(FlowTestsBase):
         self.env.assertEquals(actual_result.result_set, expected_result)
 
         # Test the concatenation of AND and OR conditions
-        query = """MATCH (a)-[e*]->(b) WHERE e.connects IN ['AB', 'BC', 'CD'] AND (e.connects = 'AB' OR e.connects = 'BC')  AND e.connects <> 'CD' RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a)-[e*]->(b)
+                   WHERE e.connects IN ['AB', 'BC', 'CD'] AND (e.connects = 'AB' OR e.connects = 'BC')  AND e.connects <> 'CD'
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         # The filter op should have been optimized out
         plan = redis_graph.execution_plan(query)
         self.env.assertNotIn("Filter", plan)
@@ -159,7 +196,10 @@ class testVariableLengthTraversals(FlowTestsBase):
         self.env.assertEquals(actual_result.result_set, expected_result)
 
         # Validate that WHERE clause predicates are applied to edges lower than the minHops value
-        query = """MATCH (a)-[e*2..]->(b) WHERE e.connects <> 'AB' RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a)-[e*2..]->(b)
+                   WHERE e.connects <> 'AB'
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         expected_result = [['B', 'D']]
         self.env.assertEquals(actual_result.result_set, expected_result)
@@ -178,7 +218,11 @@ class testVariableLengthTraversals(FlowTestsBase):
         # built in different ExecutionPlan segments. The segments must be
         # updated before cloning the Optional subtree,
         # or else the variable-length edge reference will be lost.
-        query = """MATCH (a {name: 'A'}) WITH a OPTIONAL MATCH (a)-[* {connects: 'AB'}]->(b) RETURN a.name, b.name ORDER BY a.name, b.name"""
+        query = """MATCH (a {name: 'A'})
+                   WITH a
+                   OPTIONAL MATCH (a)-[* {connects: 'AB'}]->(b)
+                   RETURN a.name, b.name
+                   ORDER BY a.name, b.name"""
         actual_result = redis_graph.query(query)
         expected_result = [['A', 'B']]
         self.env.assertEquals(actual_result.result_set, expected_result)
@@ -214,3 +258,89 @@ class testVariableLengthTraversals(FlowTestsBase):
         for query, expected_result in query_to_expected_result.items():
             actual_result = redis_graph.query(query)
             self.env.assertEquals(actual_result.result_set, expected_result)
+
+    def test12_close_cycle(self):
+        # create a graph with a cycle in it
+        # a->d
+        # a->b->c->a
+        #
+        # variable length traversal should not get stuck in a cycle
+        # in addition, the traversal mustn't continue traversing once a cycle
+        # is detected, for the test graph that means that the path: a->b->c->a->d/b
+        # can't be matched
+
+        # clear previous data
+        conn = self.env.getConnection()
+        conn.flushall()
+
+        # create graph
+        query = """CREATE (a:A {v:'a'}), (b:B {v:'b'}), (c:C {v:'c'}), (d:D {v:'d'}),
+                          (a)-[:R]->(b)-[:R]->(c)-[:R]->(a),
+                          (a)-[:R]->(d)"""
+
+        result = redis_graph.query(query)
+        self.env.assertEquals(result.nodes_created, 4)
+        self.env.assertEquals(result.relationships_created, 4)
+
+        # perform variable length traverse from 'a'
+        query = """MATCH (a:A)-[*2..]->(z)
+                   RETURN z.v
+                   ORDER BY z.v"""
+
+        result = redis_graph.query(query).result_set
+        self.env.assertEquals(len(result), 2)
+        self.env.assertEquals(result[0][0], 'a')
+        self.env.assertEquals(result[1][0], 'c')
+
+    def test13_fanout(self):
+        # create a tree structure graph with a fanout of 3
+        # root->a1
+        # root->a2
+        # root->a3
+        # a1->b1
+        # a1->b2
+        # a1->b3
+        # ...
+        # a3->d3
+
+        conn = self.env.getConnection()
+        conn.flushall()
+
+        # create a tree structure with a fanout of 3
+        q = """CREATE (root {l:0, id:0})
+               WITH root
+               UNWIND range(0, 2) AS i
+               CREATE (root)-[:R]->(a{l:1, id:i})
+               WITH collect(a) as nodes
+               UNWIND nodes AS n
+               UNWIND range(0, 2) AS i
+               CREATE (n)-[:R]->(a{l:2, id:n.id*3+i})"""
+
+        res = redis_graph.query(q)
+        self.env.assertEquals(res.nodes_created, 13)
+
+        # get all reachable nodes from root
+        q = """MATCH (root {l:0})-[*0..]->(n)
+               RETURN n.l, n.id
+               ORDER BY n.l, n.id"""
+        res = redis_graph.query(q).result_set
+        self.env.assertEquals(len(res), 13)
+
+        # root
+        self.env.assertEquals(res[0][0], 0)
+        self.env.assertEquals(res[0][1], 0)
+
+        # children of root
+        for i in range(3):
+            l = res[i+1][0]
+            identity = res[i+1][1]
+            self.env.assertEquals(l, 1)
+            self.env.assertEquals(identity, i)
+
+        # grandchildren of root
+        for i in range(9):
+            l = res[i+4][0]
+            identity = res[i+4][1]
+            self.env.assertEquals(l, 2)
+            self.env.assertEquals(identity, i)
+


### PR DESCRIPTION
Deep DFS traversals performed a naive test to see if the current nodes is on the path, switch to hash table to track nodes on path