### PR TITLE
GraphEntity_GetAttributes(): Validate e->attributes != NULL

### DIFF
--- a/src/graph/entities/graph_entity.c
+++ b/src/graph/entities/graph_entity.c
@@ -227,8 +227,10 @@ inline AttributeSet GraphEntity_GetAttributes
 	const GraphEntity *e
 ) {
 	ASSERT(e != NULL);
-
-	return *e->attributes;
+	if(likely(e->attributes != NULL)) {
+		return *e->attributes;
+	}
+	return NULL;
 }
 
 inline int GraphEntity_ClearAttributes

--- a/tests/flow/test_graph_create.py
+++ b/tests/flow/test_graph_create.py
@@ -101,7 +101,10 @@ class testGraphCreationFlow(FlowTestsBase):
         queries = ["CREATE (a), (b) SET a.v = [b]",
                    "CREATE (a {v: ['str', [1, NULL]]})",
                    "CREATE (a {v: [[{k: 'v'}]]})",
-                   "CREATE (a:L)-[e:R]->(:L {v: [e]})"]
+                   "CREATE (a:L)-[e:R]->(:L {v: [e]})",
+                   "CREATE (a:L)-[e:R]->(:L {v: [e]})",
+                   "CREATE (a), (b)-[:R {k:properties(a)}]->(c)",
+                   "CREATE (a), (b)-[:R]->(c {k:properties(a)})"]
         for query in queries:
             try:
                 redis_graph.query(query)


### PR DESCRIPTION
Validation added to GraphEntity_GetAttributes() to avoid crash reported in #3050, #3054, and #3056.
This is a minimal version of the PR [ Fix Graphentity_Getattributes() #3080](https://github.com/RedisGraph/RedisGraph/pull/3080)